### PR TITLE
Add PreMailer xUnit tests and pipeline updates

### DIFF
--- a/PSParseHTML.AzurePipelines.yml
+++ b/PSParseHTML.AzurePipelines.yml
@@ -7,6 +7,8 @@ jobs:
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck
           .\PSParseHTML.Tests.ps1
         displayName: "Run Pester Tests - PowerShell 5"
+      - script: dotnet test Sources/PSParseHTML.sln --no-build --verbosity normal
+        displayName: "Run .NET Tests"
       #  - script: |
       #        pwsh -c '.\PSWriteHTML.Tests.ps1'
       #    displayName: "Run Pester Tests - PowerShell 6+"
@@ -24,6 +26,8 @@ jobs:
       - script: |
           pwsh -c '.\PSParseHTML.Tests.ps1'
         displayName: "Run Pester Tests"
+      - script: dotnet test Sources/PSParseHTML.sln --no-build --verbosity normal
+        displayName: "Run .NET Tests"
 
   - job: Build_PSCore_MacOS1013
     pool:
@@ -38,3 +42,5 @@ jobs:
       - script: |
           pwsh -c '.\PSParseHTML.Tests.ps1'
         displayName: "Run Pester Tests"
+      - script: dotnet test Sources/PSParseHTML.sln --no-build --verbosity normal
+        displayName: "Run .NET Tests"

--- a/Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj
+++ b/Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PSParseHTML\PSParseHTML.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
@@ -1,0 +1,38 @@
+using PSParseHTML;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class PreMailerClientTests
+{
+    private const string HtmlWithMediaQuery = "<html><head><style>h1{color:red;}@media(max-width:600px){h1{font-size:14px;}}</style></head><body><h1>Hello</h1></body></html>";
+
+    [Fact]
+    public void MoveCssInline_RemovesStyleElements_WhenEnabled()
+    {
+        var options = new PreMailerOptions { RemoveStyleElements = true };
+        PreMailerResult result = PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        Assert.DoesNotContain("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MoveCssInline_PreservesStyleElements_WhenDisabled()
+    {
+        var options = new PreMailerOptions { RemoveStyleElements = false };
+        PreMailerResult result = PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MoveCssInline_PreservesMediaQueries_WhenRequested()
+    {
+        var options = new PreMailerOptions
+        {
+            RemoveStyleElements = true,
+            PreserveMediaQueries = true
+        };
+        PreMailerResult result = PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        Assert.Contains("@media", result.Html, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Sources/PSParseHTML.sln
+++ b/Sources/PSParseHTML.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PSParseHTML.Examples", "PSP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PSParseHTML.PowerShell", "PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj", "{6F061A54-EB45-4032-A0CE-48BE6C3FE2C5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PSParseHTML.Tests", "PSParseHTML.Tests\PSParseHTML.Tests.csproj", "{D557C908-54E5-4DE0-AF64-96271B4C5666}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{6F061A54-EB45-4032-A0CE-48BE6C3FE2C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F061A54-EB45-4032-A0CE-48BE6C3FE2C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F061A54-EB45-4032-A0CE-48BE6C3FE2C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D557C908-54E5-4DE0-AF64-96271B4C5666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D557C908-54E5-4DE0-AF64-96271B4C5666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D557C908-54E5-4DE0-AF64-96271B4C5666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D557C908-54E5-4DE0-AF64-96271B4C5666}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/PSParseHTML/PSParseHTML.csproj
+++ b/Sources/PSParseHTML/PSParseHTML.csproj
@@ -25,9 +25,6 @@
 		<!-- <PackageReference Include="Selenium.WebDriver" Version="4.16.2" /> -->
         </ItemGroup>
 
-        <ItemGroup>
-                <Compile Include="PreMailer\*.cs" />
-        </ItemGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
 		<DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -68,8 +68,7 @@ public class PreMailerClient {
                 Options.StripIdAndClassAttributes,
                 Options.RemoveComments,
                 Options.CustomFormatter,
-                Options.PreserveMediaQueries,
-                Options.UseEmailFormatter);
+                Options.PreserveMediaQueries);
 
             if (result.Warnings != null) {
                 foreach (string warning in result.Warnings) {
@@ -110,7 +109,7 @@ public class PreMailerClient {
         string? cssFilePath = null,
         bool stripIdAndClassAttributes = false,
         bool removeComments = false,
-        AngleSharp.Html.IMarkupFormatter? customFormatter = null,
+        global::AngleSharp.IMarkupFormatter? customFormatter = null,
         bool preserveMediaQueries = false,
         bool useEmailFormatter = false,
         bool addAnalyticsTags = false,
@@ -154,7 +153,7 @@ public class PreMailerClient {
         string? cssFilePath = null,
         bool stripIdAndClassAttributes = false,
         bool removeComments = false,
-        AngleSharp.Html.IMarkupFormatter? customFormatter = null,
+        global::AngleSharp.IMarkupFormatter? customFormatter = null,
         bool preserveMediaQueries = false,
         bool useEmailFormatter = false,
         bool addAnalyticsTags = false,

--- a/Sources/PSParseHTML/PreMailer/PreMailerOptions.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerOptions.cs
@@ -1,5 +1,5 @@
 using System;
-using AngleSharp.Html;
+using global::AngleSharp;
 
 namespace PSParseHTML;
 
@@ -29,7 +29,7 @@ public class PreMailerOptions {
     public bool RemoveComments { get; set; }
 
     /// <summary>Formatter used for generating HTML output.</summary>
-    public IMarkupFormatter? CustomFormatter { get; set; }
+    public global::AngleSharp.IMarkupFormatter? CustomFormatter { get; set; }
 
     /// <summary>Preserve media queries from style nodes.</summary>
     public bool PreserveMediaQueries { get; set; }


### PR DESCRIPTION
## Summary
- add xUnit test project with PreMailer option tests
- fix PreMailer client to work with current PreMailer.Net API
- include test project in the solution
- run `dotnet test` in Azure Pipelines CI

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --verbosity minimal`
- `pwsh -c './PSParseHTML.Tests.ps1'` *(fails: Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2648f30832e945e2a5cb8a9270a