### PR TITLE
Add Azure status parsing tests

### DIFF
--- a/Sources/PSParseHTML.Tests/AzureStatusHtmlTests.cs
+++ b/Sources/PSParseHTML.Tests/AzureStatusHtmlTests.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class AzureStatusHtmlTests {
+    private static string GetAzureStatusHtml() {
+        var baseDir = AppContext.BaseDirectory;
+        var path = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "Documents", "azure_status.html"));
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void ParseAzureStatus_WithHtmlAgilityPack_ReturnsTables() {
+        string html = GetAzureStatusHtml();
+        var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html);
+        var dataTables = tables.Where(t => t.Metadata.RowCount > 1).ToList();
+
+        Assert.True(dataTables.Count >= 7);
+        foreach (var t in dataTables) {
+            Assert.True(t.Metadata.ColumnCount >= 4);
+            Assert.Contains("Products and services", t.Metadata.Headers);
+        }
+
+        var first = dataTables[0];
+        Assert.Contains("*Non-Regional", first.Metadata.Headers);
+        Assert.Contains("East US", first.Metadata.Headers);
+        Assert.Equal("Compute", first.Data[0]["Products and services"]);
+    }
+
+    [Fact]
+    public void ParseAzureStatus_WithAngleSharp_ReturnsTables() {
+        string html = GetAzureStatusHtml();
+        var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(html);
+        var dataTables = tables.Where(t => t.Metadata.RowCount > 1).ToList();
+
+        Assert.True(dataTables.Count >= 7);
+        foreach (var t in dataTables) {
+            Assert.True(t.Metadata.ColumnCount >= 4);
+            Assert.Contains("Products and services", t.Metadata.Headers);
+        }
+
+        var first = dataTables[0];
+        Assert.Contains("*Non-Regional", first.Metadata.Headers);
+        Assert.Contains("East US", first.Metadata.Headers);
+        Assert.Equal("Compute", first.Data[0]["Products and services"]);
+    }
+}

--- a/Tests/AzureStatus.Tests.ps1
+++ b/Tests/AzureStatus.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'AzureStatus HTML parsing' {
+    It 'ConvertFrom-HtmlTableDetailed parses tables with headers' {
+        $Path = Join-Path $PSScriptRoot 'Documents/azure_status.html'
+        $Content = Get-Content -LiteralPath $Path -Raw
+        $Tables = [PSParseHTML.HtmlParser]::ParseTablesWithHtmlAgilityPackDetailed($Content)
+        $DataTables = $Tables | Where-Object { $_.Metadata.RowCount -gt 1 }
+
+        $DataTables.Count | Should -BeGreaterThanOrEqual 7
+
+        foreach ($table in $DataTables) {
+            $table.Metadata.ColumnCount | Should -BeGreaterThanOrEqual 4
+            $table.Metadata.Headers | Should -Contain 'Products and services'
+        }
+
+        $First = $DataTables[0]
+        $First.Metadata.Headers | Should -Contain '*Non-Regional'
+        $First.Metadata.Headers | Should -Contain 'East US'
+        $First.Data[0].'Products and services' | Should -Be 'Compute'
+    }
+}


### PR DESCRIPTION
## Summary
- add PowerShell Pester test for parsing `azure_status.html`
- add C# tests validating detailed parsing via HtmlAgilityPack and AngleSharp

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj`
- `pwsh -NoLogo -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Path Tests/AzureStatus.Tests.ps1 -Passthru"` *(fails: Parameter set cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6843ddc681ac832eb6ae1caf71ae3432