### PR TITLE
Add headless table test cases

### DIFF
--- a/Sources/PSParseHTML.Tests/HeadlessTableTests.cs
+++ b/Sources/PSParseHTML.Tests/HeadlessTableTests.cs
@@ -18,4 +18,17 @@ public class HeadlessTableTests {
         Assert.True(tables[0].Data.Count > 0);
         Assert.Equal("Column1", tables[0].Metadata.Headers[0]);
     }
+
+    [Fact]
+    public void ParseHeadlessTable_DetectsAllTables() {
+        string html = GetHtml();
+        var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, true);
+
+        Assert.Equal(4, tables.Count);
+
+        Assert.Equal("Data64-bit", tables[0].Data[0]["Column3"]);
+        Assert.Equal("Source", tables[2].Data[0]["Column1"]);
+        Assert.Equal("D:", tables[2].Data[0]["Column2"]);
+        Assert.Contains("Column3", tables[3].Metadata.Headers);
+    }
 }

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -14,4 +14,21 @@ Describe -Name 'ConvertFrom-HtmlTable' {
         $doc = ConvertFrom-HTML -Url 'https://example.com'
         $doc | Should -Not -BeNullOrEmpty
     }
+
+    It 'Parses headless_table.html and detects four tables' {
+        $Path = Join-Path $PSScriptRoot 'Documents/headless_table.html'
+        $Content = Get-Content -LiteralPath $Path -Raw
+        $Tables = ConvertFrom-HtmlTable -Content $Content -Engine AgilityPack -IncludeMetadata
+
+        $Tables.Count | Should -Be 4
+
+        $Tables[0].TableIndex | Should -Be 0
+        $Tables[0].ColumnCount | Should -Be 3
+        $Tables[0].Data[0].Column3 | Should -Be 'Data64-bit'
+
+        $Tables[2].Data[0].Column1 | Should -Be 'Source'
+        $Tables[2].Data[0].Column2 | Should -Be 'D:'
+
+        $Tables[3].Data[1].Column3 | Should -Match 'PrepareCopying failed'
+    }
 }


### PR DESCRIPTION
## Summary
- expand PowerShell tests for ConvertFrom-HtmlTable to validate parsing of `headless_table.html`
- extend C# tests with coverage for all four tables in `headless_table.html`

## Testing
- `pwsh -NoLogo -File ./PSParseHTML.Tests.ps1`
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68448d25a8e8832e95a0e19f44f02d6e