### PR TITLE
Improve proxy docs for HTML cmdlets

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtml.cs
@@ -6,11 +6,19 @@ using HtmlAgilityPack;
 
 namespace PSParseHTML.PowerShell;
 
-/// <summary>
-/// Cmdlet that parses HTML content from a string or URL.
-/// </summary>
+/// <summary>Parses HTML content from a string or a remote page.</summary>
+/// <para>
+/// The cmdlet can read raw HTML or download a web page specified with
+/// <c>-Url</c>. When downloading, optional <c>-Proxy</c> and
+/// <c>-ProxyCredential</c> parameters control the web request.
+/// </para>
 /// <example>
-/// <code>ConvertFrom-HTML -Url https://example.com</code>
+///   <summary>Download a web page and parse it</summary>
+///   <code>ConvertFrom-HTML -Url https://example.com</code>
+/// </example>
+/// <example>
+///   <summary>Use a proxy server when downloading</summary>
+///   <code>ConvertFrom-HTML -Url https://example.com -Proxy http://proxy:8080</code>
 /// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HTML", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(object))]
@@ -32,9 +40,16 @@ public sealed class CmdletConvertFromHtml : PSCmdlet {
     [ValidateSet("AngleSharp", "AgilityPack")]
     public string Engine { get; set; } = "AgilityPack";
 
+    /// <summary>
+    /// Optional proxy server address used when fetching content from <see cref="Url"/>.
+    /// Include the protocol and port number if required.
+    /// </summary>
     [Parameter]
     public string? Proxy { get; set; }
 
+    /// <summary>
+    /// Credentials used to authenticate against the <see cref="Proxy"/> server.
+    /// </summary>
     [Parameter]
     public PSCredential? ProxyCredential { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
@@ -4,9 +4,19 @@ using System.Net.Http;
 
 namespace PSParseHTML.PowerShell;
 
-/// <summary>
-/// Cmdlet that extracts elements from HTML by tag, class, id or name attributes.
-/// </summary>
+/// <summary>Extracts HTML elements by tag, class, id or name attributes.</summary>
+/// <para>
+/// Input can be raw HTML or a page retrieved from <c>-Url</c>. Use
+/// <c>-Proxy</c> when the page must be downloaded through a proxy server.
+/// </para>
+/// <example>
+///   <summary>Extract links from a page</summary>
+///   <code>ConvertFrom-HtmlAttributes -Url https://example.com -Tag a</code>
+/// </example>
+/// <example>
+///   <summary>Specify a proxy while downloading</summary>
+///   <code>ConvertFrom-HtmlAttributes -Url https://example.com -Proxy http://proxy:8080 -Tag a</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlAttributes", DefaultParameterSetName = ParameterSetContent)]
 [Alias("ConvertFrom-HTMLTag", "ConvertFrom-HTMLClass")]
 [OutputType(typeof(string), typeof(IElement))]
@@ -39,9 +49,16 @@ public sealed class CmdletConvertFromHtmlAttributes : PSCmdlet {
     [Parameter]
     public string? Name { get; set; }
 
+    /// <summary>
+    /// Proxy server address used when <see cref="Url"/> is specified.
+    /// Include protocol and port if necessary.
+    /// </summary>
     [Parameter]
     public string? Proxy { get; set; }
 
+    /// <summary>
+    /// Credentials used with the <see cref="Proxy"/> server.
+    /// </summary>
     [Parameter]
     public PSCredential? ProxyCredential { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -7,11 +7,18 @@ using System.Net.Http;
 
 namespace PSParseHTML.PowerShell;
 
-/// <summary>
-/// Cmdlet that converts HTML tables into PowerShell objects.
-/// </summary>
+/// <summary>Converts HTML tables into PowerShell objects.</summary>
+/// <para>
+/// The cmdlet accepts raw HTML or downloads a page using <c>-Url</c>. When
+/// downloading you can specify <c>-Proxy</c> and <c>-ProxyCredential</c>.
+/// </para>
 /// <example>
-/// <code>ConvertFrom-HtmlTable -Url https://example.com</code>
+///   <summary>Parse the first table from a URL</summary>
+///   <code>ConvertFrom-HtmlTable -Url https://example.com</code>
+/// </example>
+/// <example>
+///   <summary>Download through a proxy server</summary>
+///   <code>ConvertFrom-HtmlTable -Url https://example.com -Proxy http://proxy:8080</code>
 /// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlTable", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(PSObject[]))]
@@ -64,9 +71,16 @@ public sealed class CmdletConvertFromHtmlTable : PSCmdlet {
     [Parameter]
     public SwitchParameter SkipFooter { get; set; }
 
+    /// <summary>
+    /// Proxy server address used when <see cref="Url"/> is specified.
+    /// Include protocol and port if required.
+    /// </summary>
     [Parameter]
     public string? Proxy { get; set; }
 
+    /// <summary>
+    /// Credentials used for authenticating with the specified <see cref="Proxy"/> server.
+    /// </summary>
     [Parameter]
     public PSCredential? ProxyCredential { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -6,11 +6,18 @@ using System.Management.Automation;
 
 namespace PSParseHTML.PowerShell;
 
-/// <summary>
-/// Cmdlet that converts HTML content to plain text.
-/// </summary>
+/// <summary>Converts HTML content to plain text.</summary>
+/// <para>
+/// You can provide raw HTML, a local file, or download a page with <c>-Url</c>.
+/// When downloading, optional <c>-Proxy</c> and <c>-ProxyCredential</c> can be used.
+/// </para>
 /// <example>
-/// <code>Convert-HTMLToText -Content "&lt;p&gt;Hello&lt;/p&gt;"</code>
+///   <summary>Convert a simple HTML string</summary>
+///   <code>Convert-HTMLToText -Content "&lt;p&gt;Hello&lt;/p&gt;"</code>
+/// </example>
+/// <example>
+///   <summary>Download through a proxy</summary>
+///   <code>Convert-HTMLToText -Url https://example.com -Proxy http://proxy:8080</code>
 /// </example>
 [Cmdlet(VerbsData.Convert, "HTMLToText", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(string))]
@@ -44,9 +51,16 @@ public sealed class CmdletConvertHtmlToText : PSCmdlet {
     [Parameter]
     public string? OutputFile { get; set; }
 
+    /// <summary>
+    /// Proxy server address used when downloading from <see cref="Url"/>.
+    /// Include the protocol and port if necessary.
+    /// </summary>
     [Parameter]
     public string? Proxy { get; set; }
 
+    /// <summary>
+    /// Credentials used for the <see cref="Proxy"/> server.
+    /// </summary>
     [Parameter]
     public PSCredential? ProxyCredential { get; set; }
 


### PR DESCRIPTION
## Summary
- document optional Proxy and ProxyCredential parameters on ConvertFrom-HTML* and Convert-HTMLToText cmdlets
- add more detailed cmdlet and parameter descriptions with examples

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -property:WarningLevel=0`

------
https://chatgpt.com/codex/tasks/task_e_684498f0bb74832ea115f03238a7395f