### PR TITLE
Improve visibility check with IndexOf

### DIFF
--- a/Sources/PSParseHTML/HtmlTableParser.cs
+++ b/Sources/PSParseHTML/HtmlTableParser.cs
@@ -56,8 +56,9 @@ public static class HtmlTableParser {
 
             // Check visibility (simple check for display:none)
             var style = table.GetAttribute("style") ?? string.Empty;
-            metadata.IsVisible = !style.ToLowerInvariant().Contains("display:none") &&
-                                !style.ToLowerInvariant().Contains("display: none");
+            var containsDisplayNone = style.IndexOf("display:none", StringComparison.OrdinalIgnoreCase) >= 0;
+            var containsDisplaySpaceNone = style.IndexOf("display: none", StringComparison.OrdinalIgnoreCase) >= 0;
+            metadata.IsVisible = !(containsDisplayNone || containsDisplaySpaceNone);
 
             var rows = skipFooter ?
                 table.QuerySelectorAll("tr:not(tfoot tr)") :
@@ -301,8 +302,9 @@ public static class HtmlTableParser {
 
             // Check visibility (simple check for display:none)
             var style = table.GetAttributeValue("style", string.Empty);
-            metadata.IsVisible = !style.ToLowerInvariant().Contains("display:none") &&
-                                !style.ToLowerInvariant().Contains("display: none");
+            var containsDisplayNone = style.IndexOf("display:none", StringComparison.OrdinalIgnoreCase) >= 0;
+            var containsDisplaySpaceNone = style.IndexOf("display: none", StringComparison.OrdinalIgnoreCase) >= 0;
+            metadata.IsVisible = !(containsDisplayNone || containsDisplaySpaceNone);
 
             var rows = skipFooter ?
                 table.SelectNodes(".//tr[not(ancestor::tfoot)]") :


### PR DESCRIPTION
## Summary
- use `IndexOf` for checking style visibility
- avoid repeated allocations by storing case-insensitive checks

## Testing
- `pwsh -NoLogo -NoProfile -File PSParseHTML.Tests.ps1` *(fails: `Tests Passed: 11, Failed: 16`)*
- `dotnet build Sources/PSParseHTML/PSParseHTML.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68453743d20c832e9a0a9a19c4ce9831