### PR TITLE
Fix duplicate assignment in HtmlFormatter

### DIFF
--- a/Sources/PSParseHTML/HtmlFormatter.cs
+++ b/Sources/PSParseHTML/HtmlFormatter.cs
@@ -108,7 +108,6 @@ public static class HtmlFormatter {
         settings.JsSettings.PreserveFunctionNames = true;
         settings.JsSettings.LocalRenaming = NUglify.JavaScript.LocalRenaming.KeepAll;
         settings.JsSettings.NoAutoRenameList = true.ToString();
-        settings.JsSettings.PreserveFunctionNames = true;
         settings.JsSettings.ReorderScopeDeclarations = false;
         settings.JsSettings.TermSemicolons = true;
         settings.JsSettings.RemoveUnneededCode = false;


### PR DESCRIPTION
## Summary
- clean up repeated `PreserveFunctionNames` setting in `HtmlFormatter`

## Testing
- `pwsh -NoProfile -File ./PSParseHTML.Tests.ps1` *(fails: Proxy.Tests.ps1 expecting Proxy params)*

------
https://chatgpt.com/codex/tasks/task_e_68453721f194832e8d9672687579c4e5