### PR TITLE
Update dynamic HTML example to new cmdlet

### DIFF
--- a/Examples/Example-GetDynamicHTML.ps1
+++ b/Examples/Example-GetDynamicHTML.ps1
@@ -16,8 +16,8 @@ Downloading Winldd playwright build v1007 from https://cdn.playwright.dev/dbazur
 Winldd playwright build v1007 downloaded to C:\Users\przemyslaw.klys\AppData\Local\ms-playwright\winldd-1007
 #>
 
-$HTML = Get-RenderedHtml -Url "https://www.evotec.xyz"
+$HTML = Invoke-HTMLRendering -Url "https://www.evotec.xyz"
 $HTML
 
-#$HTML = Get-RenderedHtml -Url "https://www.evotec.xyz" -OutFile "$PSScriptRoot\Output\evotec.html"
+#$HTML = Invoke-HTMLRendering -Url "https://www.evotec.xyz" -OutFile "$PSScriptRoot\Output\evotec.html"
 #$HTML


### PR DESCRIPTION
## Summary
- update `Example-GetDynamicHTML.ps1` to use `Invoke-HTMLRendering`
- ensure commented example uses new cmdlet
- verify no other references remain

## Testing
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1` *(fails: Expected 'Proxy'...)*

------
https://chatgpt.com/codex/tasks/task_e_68456a2a096c832e8e28208053918a26