### PR TITLE
Add HTML screenshot cmdlet

### DIFF
--- a/Examples/Example-Screenshot1.ps1
+++ b/Examples/Example-Screenshot1.ps1
@@ -1,0 +1,5 @@
+﻿Import-Module .\PSParseHTML.psd1 -Force
+
+Save-HTMLScreenshot -Url 'https://www.goal.com/en-us/premier-league/table/2kwbbcootiqqgmrzs6o5inle5' -OutFile "$PSScriptRoot\Output\PremierLeague.png"
+
+Save-HTMLScreenshot -Url 'https://evotec.xyz' -OutFile "$PSScriptRoot\Output\EvotecPage.png"

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLScreenshot')
+    CmdletsToExport        = @('ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLScreenshot')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) Przemyslaw Klys. All rights reserved.'

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript')
+    CmdletsToExport        = @('ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLScreenshot')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) Przemyslaw Klys. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -22,7 +22,7 @@
 
 **PSParseHTML** started as a suite of data processing Cmdlets to help [PSWriteHTML](https://github.com/EvotecIT/PSWriteHTML), but it has gained functionality enough to be its own module. Basic usage instructions are described [on this blog post](https://evotec.xyz/formatting-and-minifying-resources-html-css-javascript-with-powershell/).
 
-**PSParseHTML** exposes a suite of PowerShell cmdlets that let you parse, format and optimise web resources right from the shell.  The module currently ships with twelve cmdlets:
+**PSParseHTML** exposes a suite of PowerShell cmdlets that let you parse, format and optimise web resources right from the shell.  The module currently ships with thirteen cmdlets:
 
 - `Convert-HTMLToText` – convert markup to plain text
 - `ConvertFrom-HtmlTable` – turn table elements into objects
@@ -37,6 +37,7 @@
 
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser
+- `Save-HTMLScreenshot` – capture page screenshots
 
 ### Cmdlet quick start
 
@@ -73,6 +74,7 @@ Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
 Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\\page.png'
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:
@@ -87,7 +89,7 @@ Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if n
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 
-It may not seem like much, but those twelve cmdlets are powerful enough to enable robust HTML processing in shell.
+It may not seem like much, but those thirteen cmdlets are powerful enough to enable robust HTML processing in shell.
 
 ## Examples
 

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@
 
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser
-- `Save-HTMLScreenshot` – capture page screenshots
+- `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open` and clipping parameters)
 
 ### Cmdlet quick start
 
@@ -74,7 +74,7 @@ Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
 Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
-Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\\page.png'
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:
@@ -86,6 +86,7 @@ Chromium 136.0.7103.25 (playwright build v1169) downloaded to C:\Users\USER\AppD
 ```
 
 Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if needed.
+Use `-Full` to capture the entire document, `-Open` to automatically view the image, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@
 
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser
-- `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open` and clipping parameters)
+- `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open`, clipping parameters and `-Delay`)
 
 ### Cmdlet quick start
 
@@ -74,7 +74,7 @@ Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
 Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
-Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:
@@ -86,7 +86,7 @@ Chromium 136.0.7103.25 (playwright build v1169) downloaded to C:\Users\USER\AppD
 ```
 
 Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if needed.
-Use `-Full` to capture the entire document, `-Open` to automatically view the image, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
+Use `-Full` to capture the entire document, `-Open` to automatically view the image, specify `-Delay` to wait for dynamic content, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -12,6 +13,7 @@ namespace PSParseHTML.PowerShell;
 [Cmdlet(VerbsData.Save, "HTMLScreenshot", DefaultParameterSetName = ParameterSetDefault)]
 public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     private const string ParameterSetDefault = "Default";
+    private const string ParameterSetClip = "Clip";
 
     /// <summary>URL of the web page.</summary>
     [Parameter(Mandatory = true, Position = 0)]
@@ -29,8 +31,43 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Open the screenshot after saving.</summary>
+    [Parameter]
+    public SwitchParameter Open { get; set; }
+
+    /// <summary>Capture the entire page.</summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    public SwitchParameter Full { get; set; }
+
+    /// <summary>X coordinate for a clip region.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
+    public int X { get; set; }
+
+    /// <summary>Y coordinate for a clip region.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
+    public int Y { get; set; }
+
+    /// <summary>Width of the clip region.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
+    public int Width { get; set; }
+
+    /// <summary>Height of the clip region.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
+    public int Height { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent).ConfigureAwait(false);
+        if (ParameterSetName == ParameterSetClip) {
+            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, false, X, Y, Width, Height).ConfigureAwait(false);
+        } else {
+            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, Full.IsPresent).ConfigureAwait(false);
+        }
+
+        if (Open.IsPresent) {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
+                FileName = OutFile,
+                UseShellExecute = true,
+            });
+        }
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -1,0 +1,36 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that captures a screenshot of a web page using a headless browser.
+/// </summary>
+/// <example>
+/// <code>Save-HTMLScreenshot -Url https://example.com -OutFile page.png</code>
+/// </example>
+[Cmdlet(VerbsData.Save, "HTMLScreenshot", DefaultParameterSetName = ParameterSetDefault)]
+public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
+    private const string ParameterSetDefault = "Default";
+
+    /// <summary>URL of the web page.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>File path for the screenshot.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string OutFile { get; set; } = string.Empty;
+
+    /// <summary>Browser engine to use for rendering.</summary>
+    [Parameter]
+    public BrowserEngine Browser { get; set; } = BrowserEngine.Chromium;
+
+    /// <summary>Force re-download of browser runtimes.</summary>
+    [Parameter]
+    public SwitchParameter Clean { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent).ConfigureAwait(false);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -39,6 +39,11 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetDefault)]
     public SwitchParameter Full { get; set; }
 
+    /// <summary>Milliseconds to wait after the page loads.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int Delay { get; set; } = 0;
+
     /// <summary>X coordinate for a clip region.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
     public int X { get; set; }
@@ -58,9 +63,9 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         if (ParameterSetName == ParameterSetClip) {
-            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, false, X, Y, Width, Height).ConfigureAwait(false);
+            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, false, Delay, X, Y, Width, Height).ConfigureAwait(false);
         } else {
-            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, Full.IsPresent).ConfigureAwait(false);
+            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, Full.IsPresent, Delay).ConfigureAwait(false);
         }
 
         if (Open.IsPresent) {

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -85,7 +85,12 @@ public static class HtmlBrowserRenderer {
     /// <param name="path">File path for the screenshot.</param>
     /// <param name="browser">Browser engine to use.</param>
     /// <param name="clean">Force re-download of browser runtimes.</param>
-    public static async Task CaptureScreenshotAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false) {
+    /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
+    /// <param name="clipX">Optional clip region X coordinate.</param>
+    /// <param name="clipY">Optional clip region Y coordinate.</param>
+    /// <param name="clipWidth">Optional clip region width.</param>
+    /// <param name="clipHeight">Optional clip region height.</param>
+    public static async Task CaptureScreenshotAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false, bool fullPage = false, int? clipX = null, int? clipY = null, int? clipWidth = null, int? clipHeight = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -104,6 +109,17 @@ public static class HtmlBrowserRenderer {
         var page = await browserInstance.NewPageAsync();
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await page.ScreenshotAsync(new PageScreenshotOptions { Path = path });
+
+        var options = new PageScreenshotOptions { Path = path, FullPage = fullPage };
+        if (clipX.HasValue && clipY.HasValue && clipWidth.HasValue && clipHeight.HasValue) {
+            options.Clip = new Clip {
+                X = clipX.Value,
+                Y = clipY.Value,
+                Width = clipWidth.Value,
+                Height = clipHeight.Value,
+            };
+        }
+
+        await page.ScreenshotAsync(options);
     }
 }

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -86,11 +86,22 @@ public static class HtmlBrowserRenderer {
     /// <param name="browser">Browser engine to use.</param>
     /// <param name="clean">Force re-download of browser runtimes.</param>
     /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
+    /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
     /// <param name="clipX">Optional clip region X coordinate.</param>
     /// <param name="clipY">Optional clip region Y coordinate.</param>
     /// <param name="clipWidth">Optional clip region width.</param>
     /// <param name="clipHeight">Optional clip region height.</param>
-    public static async Task CaptureScreenshotAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false, bool fullPage = false, int? clipX = null, int? clipY = null, int? clipWidth = null, int? clipHeight = null) {
+public static async Task CaptureScreenshotAsync(
+    string url,
+    string path,
+    BrowserEngine browser = BrowserEngine.Chromium,
+    bool clean = false,
+    bool fullPage = false,
+    int delayMs = 0,
+    int? clipX = null,
+    int? clipY = null,
+    int? clipWidth = null,
+    int? clipHeight = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -109,6 +120,9 @@ public static class HtmlBrowserRenderer {
         var page = await browserInstance.NewPageAsync();
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        if (delayMs > 0) {
+            await page.WaitForTimeoutAsync(delayMs);
+        }
 
         var options = new PageScreenshotOptions { Path = path, FullPage = fullPage };
         if (clipX.HasValue && clipY.HasValue && clipWidth.HasValue && clipHeight.HasValue) {

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -77,4 +77,33 @@ public static class HtmlBrowserRenderer {
         string content = await GetPageContentAsync(url, browser, clean).ConfigureAwait(false);
         File.WriteAllText(path, content);
     }
+
+    /// <summary>
+    /// Captures a screenshot of the specified page.
+    /// </summary>
+    /// <param name="url">URL to load.</param>
+    /// <param name="path">File path for the screenshot.</param>
+    /// <param name="browser">Browser engine to use.</param>
+    /// <param name="clean">Force re-download of browser runtimes.</param>
+    public static async Task CaptureScreenshotAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false) {
+        if (clean) {
+            CleanInstallDir();
+        }
+
+        string engine = browser.ToString().ToLowerInvariant();
+        Microsoft.Playwright.Program.Main(new[] { "install", engine });
+
+        using var playwright = await Playwright.CreateAsync();
+        IBrowserType type = browser switch {
+            BrowserEngine.Firefox => playwright.Firefox,
+            BrowserEngine.Webkit => playwright.Webkit,
+            _ => playwright.Chromium,
+        };
+
+        await using var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browserInstance.NewPageAsync();
+        await page.GotoAsync(url);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = path });
+    }
 }

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -6,4 +6,20 @@ Describe 'Save-HTMLScreenshot' {
         Save-HTMLScreenshot -Url $uri -OutFile $outfile
         (Test-Path $outfile) | Should -BeTrue
     }
+
+    It 'Creates a full page screenshot' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'full.png'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full
+        (Test-Path $outfile) | Should -BeTrue
+    }
+
+    It 'Creates a clipped screenshot' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'clip.png'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50
+        (Test-Path $outfile) | Should -BeTrue
+    }
 }

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -3,7 +3,7 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'shot.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Delay 200
         (Test-Path $outfile) | Should -BeTrue
     }
 
@@ -11,7 +11,7 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'full.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full -Delay 200
         (Test-Path $outfile) | Should -BeTrue
     }
 
@@ -19,7 +19,7 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'clip.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50 -Delay 200
         (Test-Path $outfile) | Should -BeTrue
     }
 }

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Save-HTMLScreenshot' {
+    It 'Creates a screenshot file' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'shot.png'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile
+        (Test-Path $outfile) | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- extend `HtmlBrowserRenderer` with `CaptureScreenshotAsync`
- implement new `Save-HTMLScreenshot` cmdlet
- document screenshot usage
- export new cmdlet in module manifest
- add Pester test for screenshot capture

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68456a3e1b04832e8cb3cdf5b3ba7a9a