### PR TITLE
Add credential support for Invoke-HTMLRendering

### DIFF
--- a/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
+++ b/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
@@ -1856,4 +1856,104 @@
       </command:example>
     </command:examples>
   </command:command>
+  <!-- Cmdlet: Invoke-HTMLRendering -->
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-HTMLRendering</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>HTMLRendering</command:noun>
+      <maml:description>
+        <maml:para>Renders pages with a headless browser and supports basic authentication.</maml:para>
+      </maml:description>
+    </command:details>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-HTMLRendering</maml:name>
+        <command:parameter required="true" globbing="false" pipelineInput="false" position="0">
+          <maml:name>Url</maml:name>
+          <command:parameterValue required="true">string</command:parameterValue>
+          <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>OutFile</maml:name>
+          <command:parameterValue required="true">string</command:parameterValue>
+          <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>Browser</maml:name>
+          <command:parameterValue required="true">BrowserEngine</command:parameterValue>
+          <dev:type><maml:name>PSParseHTML.BrowserEngine</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>Clean</maml:name>
+          <command:parameterValue required="true">SwitchParameter</command:parameterValue>
+          <dev:type><maml:name>System.Management.Automation.SwitchParameter</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>Credential</maml:name>
+          <command:parameterValue required="true">PSCredential</command:parameterValue>
+          <dev:type><maml:name>System.Management.Automation.PSCredential</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>Username</maml:name>
+          <command:parameterValue required="true">string</command:parameterValue>
+          <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>Password</maml:name>
+          <command:parameterValue required="true">string</command:parameterValue>
+          <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" globbing="false" pipelineInput="false" position="0">
+        <maml:name>Url</maml:name>
+        <maml:description><maml:para>URL of the page to render.</maml:para></maml:description>
+        <command:parameterValue required="true">string</command:parameterValue>
+        <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>OutFile</maml:name>
+        <maml:description><maml:para>Optional file path for the rendered HTML.</maml:para></maml:description>
+        <command:parameterValue required="true">string</command:parameterValue>
+        <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>Browser</maml:name>
+        <maml:description><maml:para>Browser engine used for rendering.</maml:para></maml:description>
+        <command:parameterValue required="true">BrowserEngine</command:parameterValue>
+        <dev:type><maml:name>PSParseHTML.BrowserEngine</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>Clean</maml:name>
+        <maml:description><maml:para>Force re-download of browser runtimes.</maml:para></maml:description>
+        <command:parameterValue required="true">SwitchParameter</command:parameterValue>
+        <dev:type><maml:name>System.Management.Automation.SwitchParameter</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>Credential</maml:name>
+        <maml:description><maml:para>PSCredential for basic authentication.</maml:para></maml:description>
+        <command:parameterValue required="true">PSCredential</command:parameterValue>
+        <dev:type><maml:name>System.Management.Automation.PSCredential</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>Username</maml:name>
+        <maml:description><maml:para>Username for basic authentication.</maml:para></maml:description>
+        <command:parameterValue required="true">string</command:parameterValue>
+        <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>Password</maml:name>
+        <maml:description><maml:para>Password for basic authentication.</maml:para></maml:description>
+        <command:parameterValue required="true">string</command:parameterValue>
+        <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+      </command:parameter>
+    </command:parameters>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type><maml:name>System.String</maml:name><maml:uri /></dev:type>
+      </command:returnValue>
+    </command:returnValues>
+  </command:command>
 </helpItems>

--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@
 - `Optimize-HTML` – minify HTML
 
 - `Optimize-JavaScript` – minify JavaScript
-- `Invoke-HTMLRendering` – render pages with a headless browser
+- `Invoke-HTMLRendering` – render pages with a headless browser (supports basic authentication)
 
 ### Cmdlet quick start
 
@@ -73,6 +73,10 @@ Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
 Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
+
+# Render a protected page using credentials
+$cred = Get-Credential
+Invoke-HTMLRendering -Url 'https://example.com' -Credential $cred
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -30,12 +30,27 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Credentials used when accessing authenticated pages.</summary>
+    [Parameter]
+    public PSCredential? Credential { get; set; }
+
+    /// <summary>Username for pages secured with basic authentication.</summary>
+    [Parameter]
+    public string? Username { get; set; }
+
+    /// <summary>Password for pages secured with basic authentication.</summary>
+    [Parameter]
+    public string? Password { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        string? user = Credential?.UserName ?? Username;
+        string? pass = Credential?.GetNetworkCredential().Password ?? Password;
+
         if (!string.IsNullOrEmpty(OutFile)) {
-            await HtmlBrowserRenderer.SavePageContentAsync(Url, OutFile, Browser, Clean.IsPresent).ConfigureAwait(false);
+            await HtmlBrowserRenderer.SavePageContentAsync(Url, OutFile, Browser, Clean.IsPresent, user, pass).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowserRenderer.GetPageContentAsync(Url, Browser, Clean.IsPresent).ConfigureAwait(false);
+            string html = await HtmlBrowserRenderer.GetPageContentAsync(Url, Browser, Clean.IsPresent, user, pass).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -49,7 +49,7 @@ public static class HtmlBrowserRenderer {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false) {
+    public static async Task<string> GetPageContentAsync(string url, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -62,7 +62,17 @@ public static class HtmlBrowserRenderer {
             _ => playwright.Chromium,
         };
         await using var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
-        var page = await browserInstance.NewPageAsync();
+        BrowserNewContextOptions? contextOptions = null;
+        if (!string.IsNullOrEmpty(username) && password != null) {
+            contextOptions = new BrowserNewContextOptions {
+                HttpCredentials = new HttpCredentials {
+                    Username = username,
+                    Password = password
+                }
+            };
+        }
+        await using var context = await browserInstance.NewContextAsync(contextOptions);
+        var page = await context.NewPageAsync();
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         return await page.ContentAsync();
@@ -73,8 +83,8 @@ public static class HtmlBrowserRenderer {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false) {
-        string content = await GetPageContentAsync(url, browser, clean).ConfigureAwait(false);
+    public static async Task SavePageContentAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null) {
+        string content = await GetPageContentAsync(url, browser, clean, username, password).ConfigureAwait(false);
         File.WriteAllText(path, content);
     }
 }

--- a/Tests/Credential.Tests.ps1
+++ b/Tests/Credential.Tests.ps1
@@ -1,0 +1,8 @@
+Describe 'Credential parameters' {
+    It 'Invoke-HTMLRendering exposes credential parameters' {
+        $params = (Get-Command Invoke-HTMLRendering).Parameters.Keys
+        $params | Should -Contain 'Credential'
+        $params | Should -Contain 'Username'
+        $params | Should -Contain 'Password'
+    }
+}

--- a/Tests/Documents/auth.html
+++ b/Tests/Documents/auth.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="secret">Authenticated</p>
+</body>
+</html>

--- a/Tests/Invoke-HTMLRendering.Auth.Tests.ps1
+++ b/Tests/Invoke-HTMLRendering.Auth.Tests.ps1
@@ -1,0 +1,14 @@
+Describe 'Invoke-HTMLRendering with authentication' {
+    It 'Loads content from a basic auth protected page' {
+        $server = Start-Process -FilePath python3 -ArgumentList '-u', (Join-Path $PSScriptRoot 'basic_auth_server.py') -WorkingDirectory $PSScriptRoot -PassThru
+        Start-Sleep -Seconds 1
+        try {
+            $uri = 'http://localhost:8000/Documents/auth.html'
+            $cred = New-Object PSCredential('user', (ConvertTo-SecureString 'pass' -AsPlainText -Force))
+            $html = Invoke-HTMLRendering -Url $uri -Credential $cred
+            $html | Should -Match 'Authenticated'
+        } finally {
+            $server | Stop-Process
+        }
+    }
+}

--- a/Tests/basic_auth_server.py
+++ b/Tests/basic_auth_server.py
@@ -1,0 +1,21 @@
+import http.server
+import base64
+import os
+
+USERNAME = os.environ.get('BASIC_USER', 'user')
+PASSWORD = os.environ.get('BASIC_PASS', 'pass')
+PORT = int(os.environ.get('PORT', '8000'))
+
+auth_string = 'Basic ' + base64.b64encode(f'{USERNAME}:{PASSWORD}'.encode()).decode()
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.headers.get('Authorization') != auth_string:
+            self.send_response(401)
+            self.send_header('WWW-Authenticate', 'Basic realm="Test"')
+            self.end_headers()
+            return
+        super().do_GET()
+
+if __name__ == '__main__':
+    http.server.test(Handler, port=PORT)


### PR DESCRIPTION
## Summary
- support optional credentials for Invoke-HTMLRendering
- update HtmlBrowserRenderer to pass credentials to Playwright
- document new parameters in README and help xml
- add tests covering authenticated page

## Testing
- `pwsh -NoLogo -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68456a6ae718832ea7f584835f74114c