### PR TITLE
Add Save-HTMLDownload cmdlet

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript')
+    CmdletsToExport        = @('ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLRendering', 'Save-HTMLDownload', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) Przemyslaw Klys. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -22,7 +22,7 @@
 
 **PSParseHTML** started as a suite of data processing Cmdlets to help [PSWriteHTML](https://github.com/EvotecIT/PSWriteHTML), but it has gained functionality enough to be its own module. Basic usage instructions are described [on this blog post](https://evotec.xyz/formatting-and-minifying-resources-html-css-javascript-with-powershell/).
 
-**PSParseHTML** exposes a suite of PowerShell cmdlets that let you parse, format and optimise web resources right from the shell.  The module currently ships with twelve cmdlets:
+**PSParseHTML** exposes a suite of PowerShell cmdlets that let you parse, format and optimise web resources right from the shell.  The module currently ships with thirteen cmdlets:
 
 - `Convert-HTMLToText` – convert markup to plain text
 - `ConvertFrom-HtmlTable` – turn table elements into objects
@@ -37,6 +37,7 @@
 
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser
+- `Save-HTMLDownload` – save files downloaded by a web page
 
 ### Cmdlet quick start
 
@@ -73,6 +74,12 @@ Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
 Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
+
+# Save files downloaded by a page
+Save-HTMLDownload -Url 'https://example.com/download.html' -Path 'C:\temp'
+
+# Click a specific download link on the page
+Save-HTMLDownload -Url 'https://example.com/download.html' -Path 'C:\temp' -Filter 'report.zip'
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:
@@ -87,7 +94,7 @@ Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if n
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 
-It may not seem like much, but those twelve cmdlets are powerful enough to enable robust HTML processing in shell.
+It may not seem like much, but those thirteen cmdlets are powerful enough to enable robust HTML processing in shell.
 
 ## Examples
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlDownload.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlDownload.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that saves files downloaded while rendering a web page.
+/// </summary>
+/// <example>
+///   <code>Save-HTMLDownload -Url https://example.com/download.html -Path C:\temp</code>
+/// </example>
+[Cmdlet(VerbsData.Save, "HTMLDownload", DefaultParameterSetName = ParameterSetDefault)]
+[OutputType(typeof(string[]))]
+public sealed class CmdletSaveHtmlDownload : AsyncPSCmdlet {
+    private const string ParameterSetDefault = "Default";
+
+    /// <summary>URL of the web page.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>Directory where downloads will be saved.</summary>
+    [Parameter(Mandatory = true)]
+    [Alias("Path")]
+    public string Destination { get; set; } = string.Empty;
+
+    /// <summary>Browser engine to use for rendering.</summary>
+    [Parameter]
+    public BrowserEngine Browser { get; set; } = BrowserEngine.Chromium;
+
+    /// <summary>Force re-download of browser runtimes.</summary>
+    [Parameter]
+    public SwitchParameter Clean { get; set; }
+
+    /// <summary>Optional filter applied to download URLs or file names.</summary>
+    [Parameter]
+    public string? Filter { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        List<string> files = await HtmlBrowserRenderer.SavePageDownloadsAsync(
+            Url,
+            Destination,
+            Browser,
+            Clean.IsPresent,
+            Filter).ConfigureAwait(false);
+
+        WriteObject(files.ToArray(), true);
+    }
+}

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Microsoft.Playwright;
 
 namespace PSParseHTML;
@@ -76,5 +77,68 @@ public static class HtmlBrowserRenderer {
     public static async Task SavePageContentAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false) {
         string content = await GetPageContentAsync(url, browser, clean).ConfigureAwait(false);
         File.WriteAllText(path, content);
+    }
+
+    /// <summary>
+    /// Saves any files downloaded while loading the specified URL.
+    /// </summary>
+    /// <param name="url">URL to load.</param>
+    /// <param name="directory">Directory where downloads should be saved.</param>
+    /// <param name="browser">Browser engine to use.</param>
+    /// <param name="clean">Reinstall the browser runtime.</param>
+    /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
+    /// <returns>Paths of downloaded files.</returns>
+    public static async Task<List<string>> SavePageDownloadsAsync(
+        string url,
+        string directory,
+        BrowserEngine browser = BrowserEngine.Chromium,
+        bool clean = false,
+        string? filter = null) {
+        if (clean) {
+            CleanInstallDir();
+        }
+
+        string engine = browser.ToString().ToLowerInvariant();
+        Microsoft.Playwright.Program.Main(new[] { "install", engine });
+
+        using var playwright = await Playwright.CreateAsync();
+        IBrowserType type = browser switch {
+            BrowserEngine.Firefox => playwright.Firefox,
+            BrowserEngine.Webkit => playwright.Webkit,
+            _ => playwright.Chromium,
+        };
+        await using var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browserInstance.NewPageAsync();
+
+        Directory.CreateDirectory(directory);
+        List<string> downloads = new();
+        page.Download += async (_, dl) => {
+            bool match = string.IsNullOrEmpty(filter) ||
+                         dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                         dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+            if (match) {
+                string filePath = Path.Combine(directory, dl.SuggestedFilename);
+                await dl.SaveAsAsync(filePath);
+                downloads.Add(filePath);
+            }
+        };
+
+        await page.GotoAsync(url);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        if (!string.IsNullOrEmpty(filter)) {
+            var anchors = await page.QuerySelectorAllAsync($"a[href*=\"{filter}\"]");
+            foreach (var anchor in anchors) {
+                var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
+                string filePath = Path.Combine(directory, download.SuggestedFilename);
+                await download.SaveAsAsync(filePath);
+                if (!downloads.Contains(filePath)) {
+                    downloads.Add(filePath);
+                }
+            }
+        }
+
+        await page.WaitForTimeoutAsync(500);
+        return downloads;
     }
 }

--- a/Tests/Documents/download.html
+++ b/Tests/Documents/download.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('downloadLink').click();
+    });
+  </script>
+</head>
+<body>
+  <a id="downloadLink" href="download.txt" download>download file</a>
+</body>
+</html>

--- a/Tests/Documents/download.txt
+++ b/Tests/Documents/download.txt
@@ -1,0 +1,1 @@
+This is a downloaded file.

--- a/Tests/Documents/manual-download.html
+++ b/Tests/Documents/manual-download.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <a id="file" href="download.txt">download file</a>
+</body>
+</html>

--- a/Tests/Save-HTMLDownload.Tests.ps1
+++ b/Tests/Save-HTMLDownload.Tests.ps1
@@ -1,0 +1,19 @@
+Describe 'Save-HTMLDownload' {
+    It 'Saves downloads triggered by the page' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/download.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $dest = Join-Path $TestDrive 'dl'
+        $files = Save-HTMLDownload -Url $uri -Path $dest
+        Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
+        $files | Should -Contain (Join-Path $dest 'download.txt')
+    }
+
+    It 'Clicks links when a filter is specified' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/manual-download.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $dest = Join-Path $TestDrive 'manual'
+        $files = Save-HTMLDownload -Url $uri -Path $dest -Filter 'download.txt'
+        Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
+        $files | Should -Contain (Join-Path $dest 'download.txt')
+    }
+}


### PR DESCRIPTION
## Summary
- restore `Invoke-HTMLRendering` behaviour
- add `Save-HTMLDownload` cmdlet to capture page downloads
- implement helper `SavePageDownloadsAsync` in renderer
- document the new cmdlet and usage
- add tests and sample files for download handling
- allow clicking download links when filter used

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Release`
- `Invoke-Pester -Output Detailed` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456a764448832e8dd52bc44340a500