### PR TITLE
Add forms login support to Invoke-HTMLRendering

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@
 - `Optimize-HTML` – minify HTML
 
 - `Optimize-JavaScript` – minify JavaScript
-- `Invoke-HTMLRendering` – render pages with a headless browser (supports basic authentication)
+- `Invoke-HTMLRendering` – render pages with a headless browser (supports basic and form authentication)
 - `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open`, clipping parameters and `-Delay`)
 
 ### Cmdlet quick start
@@ -78,6 +78,13 @@ Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
 # Render a protected page using credentials
 $cred = Get-Credential
 Invoke-HTMLRendering -Url 'https://example.com' -Credential $cred
+# Login using a form and render the target page
+Invoke-HTMLRendering -Url 'https://example.com/protected' `
+    -Credential $cred `
+    -LoginUrl 'https://example.com/wp-login.php' `
+    -UsernameSelector 'input[name=log]' `
+    -PasswordSelector 'input[name=pwd]' `
+    -SubmitSelector '#wp-submit'
 Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000
 ```
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -42,15 +43,40 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [Parameter]
     public string? Password { get; set; }
 
+    /// <summary>URL for login form when using form authentication.</summary>
+    [Parameter]
+    public string? LoginUrl { get; set; }
+
+    /// <summary>CSS selector for the username field of the login form.</summary>
+    [Parameter]
+    public string? UsernameSelector { get; set; }
+
+    /// <summary>CSS selector for the password field of the login form.</summary>
+    [Parameter]
+    public string? PasswordSelector { get; set; }
+
+    /// <summary>CSS selector for the submit element of the login form.</summary>
+    [Parameter]
+    public string? SubmitSelector { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
         string? pass = Credential?.GetNetworkCredential().Password ?? Password;
+        FormLoginOptions? form = null;
+        if (!string.IsNullOrEmpty(LoginUrl) && !string.IsNullOrEmpty(UsernameSelector) && !string.IsNullOrEmpty(PasswordSelector) && !string.IsNullOrEmpty(SubmitSelector)) {
+            form = new FormLoginOptions {
+                LoginUrl = LoginUrl!,
+                UsernameSelector = UsernameSelector!,
+                PasswordSelector = PasswordSelector!,
+                SubmitSelector = SubmitSelector!
+            };
+        }
 
         if (!string.IsNullOrEmpty(OutFile)) {
-            await HtmlBrowserRenderer.SavePageContentAsync(Url, OutFile, Browser, Clean.IsPresent, user, pass).ConfigureAwait(false);
+            await HtmlBrowserRenderer.SavePageContentAsync(Url, OutFile, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowserRenderer.GetPageContentAsync(Url, Browser, Clean.IsPresent, user, pass).ConfigureAwait(false);
+            string html = await HtmlBrowserRenderer.GetPageContentAsync(Url, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML/FormLoginOptions.cs
+++ b/Sources/PSParseHTML/FormLoginOptions.cs
@@ -1,0 +1,18 @@
+namespace PSParseHTML;
+
+/// <summary>
+/// Options controlling form based authentication.
+/// </summary>
+public sealed class FormLoginOptions {
+    /// <summary>URL of the login page.</summary>
+    public string LoginUrl { get; set; } = string.Empty;
+
+    /// <summary>CSS selector for the username field.</summary>
+    public string UsernameSelector { get; set; } = string.Empty;
+
+    /// <summary>CSS selector for the password field.</summary>
+    public string PasswordSelector { get; set; } = string.Empty;
+
+    /// <summary>CSS selector for the submit element.</summary>
+    public string SubmitSelector { get; set; } = string.Empty;
+}

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -49,7 +49,13 @@ public static class HtmlBrowserRenderer {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null) {
+    public static async Task<string> GetPageContentAsync(
+        string url,
+        BrowserEngine browser = BrowserEngine.Chromium,
+        bool clean = false,
+        string? username = null,
+        string? password = null,
+        FormLoginOptions? formLogin = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -63,7 +69,7 @@ public static class HtmlBrowserRenderer {
         };
         await using var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
         BrowserNewContextOptions? contextOptions = null;
-        if (!string.IsNullOrEmpty(username) && password != null) {
+        if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
             contextOptions = new BrowserNewContextOptions {
                 HttpCredentials = new HttpCredentials {
                     Username = username,
@@ -73,6 +79,18 @@ public static class HtmlBrowserRenderer {
         }
         await using var context = await browserInstance.NewContextAsync(contextOptions);
         var page = await context.NewPageAsync();
+        if (formLogin != null) {
+            await page.GotoAsync(formLogin.LoginUrl);
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            if (username != null) {
+                await page.FillAsync(formLogin.UsernameSelector, username);
+            }
+            if (password != null) {
+                await page.FillAsync(formLogin.PasswordSelector, password);
+            }
+            await page.ClickAsync(formLogin.SubmitSelector);
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         return await page.ContentAsync();
@@ -83,8 +101,15 @@ public static class HtmlBrowserRenderer {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, BrowserEngine browser = BrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null) {
-        string content = await GetPageContentAsync(url, browser, clean, username, password).ConfigureAwait(false);
+    public static async Task SavePageContentAsync(
+        string url,
+        string path,
+        BrowserEngine browser = BrowserEngine.Chromium,
+        bool clean = false,
+        string? username = null,
+        string? password = null,
+        FormLoginOptions? formLogin = null) {
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin).ConfigureAwait(false);
         File.WriteAllText(path, content);
     }
 
@@ -111,7 +136,10 @@ public static async Task CaptureScreenshotAsync(
     int? clipX = null,
     int? clipY = null,
     int? clipWidth = null,
-    int? clipHeight = null) {
+    int? clipHeight = null,
+    string? username = null,
+    string? password = null,
+    FormLoginOptions? formLogin = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -127,7 +155,29 @@ public static async Task CaptureScreenshotAsync(
         };
 
         await using var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
-        var page = await browserInstance.NewPageAsync();
+        BrowserNewContextOptions? contextOptions = null;
+        if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
+            contextOptions = new BrowserNewContextOptions {
+                HttpCredentials = new HttpCredentials {
+                    Username = username,
+                    Password = password
+                }
+            };
+        }
+        await using var context = await browserInstance.NewContextAsync(contextOptions);
+        var page = await context.NewPageAsync();
+        if (formLogin != null) {
+            await page.GotoAsync(formLogin.LoginUrl);
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            if (username != null) {
+                await page.FillAsync(formLogin.UsernameSelector, username);
+            }
+            if (password != null) {
+                await page.FillAsync(formLogin.PasswordSelector, password);
+            }
+            await page.ClickAsync(formLogin.SubmitSelector);
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         if (delayMs > 0) {

--- a/Tests/Credential.Tests.ps1
+++ b/Tests/Credential.Tests.ps1
@@ -4,5 +4,9 @@ Describe 'Credential parameters' {
         $params | Should -Contain 'Credential'
         $params | Should -Contain 'Username'
         $params | Should -Contain 'Password'
+        $params | Should -Contain 'LoginUrl'
+        $params | Should -Contain 'UsernameSelector'
+        $params | Should -Contain 'PasswordSelector'
+        $params | Should -Contain 'SubmitSelector'
     }
 }

--- a/Tests/Invoke-HTMLRendering.FormsAuth.Tests.ps1
+++ b/Tests/Invoke-HTMLRendering.FormsAuth.Tests.ps1
@@ -1,0 +1,15 @@
+Describe 'Invoke-HTMLRendering with form authentication' {
+    It 'Loads content from a form protected page' {
+        $server = Start-Process -FilePath python3 -ArgumentList '-u', (Join-Path $PSScriptRoot 'forms_auth_server.py') -WorkingDirectory $PSScriptRoot -PassThru
+        Start-Sleep -Seconds 1
+        try {
+            $uri = 'http://localhost:8000/secret.html'
+            $cred = New-Object PSCredential('user', (ConvertTo-SecureString 'pass' -AsPlainText -Force))
+            $html = Invoke-HTMLRendering -Url $uri -Credential $cred -LoginUrl 'http://localhost:8000/login' -UsernameSelector "input[name=user]" -PasswordSelector "input[name=pass]" -SubmitSelector "input[type=submit]"
+            $html | Should -Match 'Authenticated'
+        }
+        finally {
+            $server | Stop-Process
+        }
+    }
+}

--- a/Tests/forms_auth_server.py
+++ b/Tests/forms_auth_server.py
@@ -1,0 +1,54 @@
+import http.server
+import urllib.parse
+import os
+
+USERNAME = os.environ.get('FORM_USER', 'user')
+PASSWORD = os.environ.get('FORM_PASS', 'pass')
+PORT = int(os.environ.get('PORT', '8000'))
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/login':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+            self.wfile.write(b"""
+<html><body>
+<form method='post' action='/login'>
+<input type='text' name='user'>
+<input type='password' name='pass'>
+<input type='submit' value='Login'>
+</form>
+</body></html>""")
+        elif self.path == '/secret.html':
+            if self.headers.get('Cookie') != 'session=1':
+                self.send_response(302)
+                self.send_header('Location', '/login')
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+            self.wfile.write(b"<p id='secret'>Authenticated</p>")
+        else:
+            super().do_GET()
+
+    def do_POST(self):
+        if self.path == '/login':
+            length = int(self.headers.get('Content-Length', 0))
+            data = self.rfile.read(length).decode()
+            params = urllib.parse.parse_qs(data)
+            if params.get('user', [''])[0] == USERNAME and params.get('pass', [''])[0] == PASSWORD:
+                self.send_response(302)
+                self.send_header('Set-Cookie', 'session=1')
+                self.send_header('Location', '/secret.html')
+                self.end_headers()
+            else:
+                self.send_response(302)
+                self.send_header('Location', '/login')
+                self.end_headers()
+        else:
+            self.send_error(404)
+
+if __name__ == '__main__':
+    http.server.test(Handler, port=PORT)


### PR DESCRIPTION
## Summary
- enable form-based authentication in HtmlBrowserRenderer
- extend Invoke-HTMLRendering cmdlet to use form login
- document new parameters and usage
- add tests for parameter exposure and form auth
- provide helper server for tests

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Keyboard interrupt during Playwright download)*

------
https://chatgpt.com/codex/tasks/task_e_684598096f18832e95353c1bf2b4f18e