### PR TITLE
Fix Azure Pipeline tests

### DIFF
--- a/PSParseHTML.AzurePipelines.yml
+++ b/PSParseHTML.AzurePipelines.yml
@@ -20,7 +20,7 @@ pr:
     - v2-speedygonzales
 
 variables:
-  buildConfiguration: 'Release'
+  buildConfiguration: 'Debug'
   dotNetVersion: '8.x'
 
 stages:


### PR DESCRIPTION
I noticed all the tests seem to be failing because it's looking for the DLLs in the Debug folder, so this should probably do the trick.