### PR TITLE
Add selector wait for Save-HTMLScreenshot

### DIFF
--- a/Examples/Example-DownloadItems.ps1
+++ b/Examples/Example-DownloadItems.ps1
@@ -1,15 +1,10 @@
 ﻿Import-Module .\PSParseHTML.psd1 -Force
 
-# $Lists = ConvertFrom-HtmlList -Content $Items -AsObject
-# $Lists.Count
-# $Lists[0] | Format-Table
-# $Lists[1] | Format-Table
-
+# Download all files
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Verbose
+# Download specific file
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip'
+# Download all zip files
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".zip"
+# Download all tar.gz files
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".tar.gz"
-
-
-
-

--- a/Examples/Example-DownloadItems.ps1
+++ b/Examples/Example-DownloadItems.ps1
@@ -5,7 +5,7 @@
 # $Lists[0] | Format-Table
 # $Lists[1] | Format-Table
 
-Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip' -Verbose
+Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip'
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".zip"
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".tar.gz"
 

--- a/Examples/Example-DownloadItems.ps1
+++ b/Examples/Example-DownloadItems.ps1
@@ -5,6 +5,7 @@
 # $Lists[0] | Format-Table
 # $Lists[1] | Format-Table
 
+Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Verbose
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip'
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".zip"
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".tar.gz"

--- a/Examples/Example-DownloadItems.ps1
+++ b/Examples/Example-DownloadItems.ps1
@@ -7,7 +7,7 @@
 # $Lists[0] | Format-Table
 # $Lists[1] | Format-Table
 
-Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" #-Filter 'DnsClientX-PowerShellModule.v0.4.0.zip' -Verbose
+Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip' -Verbose
 
 
 

--- a/Examples/Example-DownloadItems.ps1
+++ b/Examples/Example-DownloadItems.ps1
@@ -1,15 +1,13 @@
 ﻿Import-Module .\PSParseHTML.psd1 -Force
 
-#$Items = Invoke-HTMLRendering -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0'
-
 # $Lists = ConvertFrom-HtmlList -Content $Items -AsObject
 # $Lists.Count
 # $Lists[0] | Format-Table
 # $Lists[1] | Format-Table
 
 Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip' -Verbose
-
-
+Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".zip"
+Save-HTMLDownload -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Test" -Filter ".tar.gz"
 
 
 

--- a/README.MD
+++ b/README.MD
@@ -38,6 +38,7 @@
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser (supports basic and form authentication)
 - `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
+- `Save-HTMLDownload` – download files discovered on a rendered page (supports `-Filter`)
 
 ### Cmdlet quick start
 
@@ -86,6 +87,7 @@ Invoke-HTMLRendering -Url 'https://example.com/protected' `
     -PasswordSelector 'input[name=pwd]' `
     -SubmitSelector '#wp-submit'
 Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000 -Selector '#content'
+Save-HTMLDownload -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads' -Filter '.zip'
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser (supports basic and form authentication)
 - `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
-- `Save-HTMLDownload` – download files discovered on a rendered page (supports `-Filter`)
+- `Save-HTMLDownload` – download files discovered on a rendered page (optionally filter with `-Filter`)
 
 ### Cmdlet quick start
 
@@ -87,6 +87,7 @@ Invoke-HTMLRendering -Url 'https://example.com/protected' `
     -PasswordSelector 'input[name=pwd]' `
     -SubmitSelector '#wp-submit'
 Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000 -Selector '#content'
+Save-HTMLDownload -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads'
 Save-HTMLDownload -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads' -Filter '.zip'
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@
 
 - `Optimize-JavaScript` – minify JavaScript
 - `Invoke-HTMLRendering` – render pages with a headless browser (supports basic and form authentication)
-- `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open`, clipping parameters and `-Delay`)
+- `Save-HTMLScreenshot` – capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 
 ### Cmdlet quick start
 
@@ -85,7 +85,7 @@ Invoke-HTMLRendering -Url 'https://example.com/protected' `
     -UsernameSelector 'input[name=log]' `
     -PasswordSelector 'input[name=pwd]' `
     -SubmitSelector '#wp-submit'
-Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000 -Selector '#content'
 ```
 
 The first run triggers Playwright to download the selected browser. You'll see output similar to:
@@ -97,7 +97,7 @@ Chromium 136.0.7103.25 (playwright build v1169) downloaded to C:\Users\USER\AppD
 ```
 
 Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if needed.
-Use `-Full` to capture the entire document, `-Open` to automatically view the image, specify `-Delay` to wait for dynamic content, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
+Use `-Full` to capture the entire document, `-Open` to automatically view the image, specify `-Delay` or `-Selector` to wait for dynamic content, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -44,6 +44,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int Delay { get; set; } = 0;
 
+    /// <summary>CSS selector to wait for before capturing.</summary>
+    [Parameter]
+    public string? Selector { get; set; }
+
     /// <summary>X coordinate for a clip region.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
     public int X { get; set; }
@@ -63,9 +67,27 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         if (ParameterSetName == ParameterSetClip) {
-            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, false, Delay, X, Y, Width, Height).ConfigureAwait(false);
+            await HtmlBrowserRenderer.CaptureScreenshotAsync(
+                Url,
+                OutFile,
+                Browser,
+                Clean.IsPresent,
+                false,
+                Delay,
+                Selector,
+                X,
+                Y,
+                Width,
+                Height).ConfigureAwait(false);
         } else {
-            await HtmlBrowserRenderer.CaptureScreenshotAsync(Url, OutFile, Browser, Clean.IsPresent, Full.IsPresent, Delay).ConfigureAwait(false);
+            await HtmlBrowserRenderer.CaptureScreenshotAsync(
+                Url,
+                OutFile,
+                Browser,
+                Clean.IsPresent,
+                Full.IsPresent,
+                Delay,
+                Selector).ConfigureAwait(false);
         }
 
         if (Open.IsPresent) {

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -123,6 +123,7 @@ public static class HtmlBrowserRenderer {
     /// <param name="clean">Force re-download of browser runtimes.</param>
     /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
     /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
+    /// <param name="selector">Optional CSS selector to wait for before capturing.</param>
     /// <param name="clipX">Optional clip region X coordinate.</param>
     /// <param name="clipY">Optional clip region Y coordinate.</param>
     /// <param name="clipWidth">Optional clip region width.</param>
@@ -134,6 +135,7 @@ public static async Task CaptureScreenshotAsync(
     bool clean = false,
     bool fullPage = false,
     int delayMs = 0,
+    string? selector = null,
     int? clipX = null,
     int? clipY = null,
     int? clipWidth = null,
@@ -181,6 +183,9 @@ public static async Task CaptureScreenshotAsync(
         }
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        if (!string.IsNullOrEmpty(selector)) {
+            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+        }
         if (delayMs > 0) {
             await page.WaitForTimeoutAsync(delayMs);
         }
@@ -246,6 +251,9 @@ public static async Task CaptureScreenshotAsync(
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         if (!string.IsNullOrEmpty(filter)) {
+            await page.WaitForSelectorAsync(
+                $"a[href*=\"{filter}\"]",
+                new PageWaitForSelectorOptions { Timeout = 10000 });
             var anchors = await page.QuerySelectorAllAsync($"a[href*=\"{filter}\"]");
             foreach (var anchor in anchors) {
                 var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -252,18 +252,18 @@ public static async Task CaptureScreenshotAsync(
         await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-        if (!string.IsNullOrEmpty(filter)) {
-            await page.WaitForSelectorAsync(
-                $"a[href*=\"{filter}\"]",
-                new PageWaitForSelectorOptions { Timeout = 10000 });
-            var anchors = await page.QuerySelectorAllAsync($"a[href*=\"{filter}\"]");
-            foreach (var anchor in anchors) {
-                var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
-                string filePath = Path.Combine(directory, download.SuggestedFilename);
-                await download.SaveAsAsync(filePath);
-                if (!downloads.Contains(filePath)) {
-                    downloads.Add(filePath);
-                }
+        string selector = string.IsNullOrEmpty(filter)
+            ? "a[download],a[href*='/download/'],a[href*='/archive/']"
+            : $"a[href*=\"{filter}\"]";
+
+        await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+        var anchors = await page.QuerySelectorAllAsync(selector);
+        foreach (var anchor in anchors) {
+            var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
+            string filePath = Path.Combine(directory, download.SuggestedFilename);
+            await download.SaveAsAsync(filePath);
+            if (!downloads.Contains(filePath)) {
+                downloads.Add(filePath);
             }
         }
 

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -249,6 +249,8 @@ public static async Task CaptureScreenshotAsync(
 
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         if (!string.IsNullOrEmpty(filter)) {
             await page.WaitForSelectorAsync(

--- a/Tests/Documents/manual_download.html
+++ b/Tests/Documents/manual_download.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+</head>
+<body>
+    <a id="downloadLink" href="download.txt">download file</a>
+</body>
+</html>

--- a/Tests/Save-HTMLDownload.Tests.ps1
+++ b/Tests/Save-HTMLDownload.Tests.ps1
@@ -7,4 +7,22 @@ Describe 'Save-HTMLDownload' {
         Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
         $files | Should -Contain (Join-Path $dest 'download.txt')
     }
+
+    It 'Downloads links when no filter is specified' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/manual_download.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $dest = Join-Path $TestDrive 'all'
+        $files = Save-HTMLDownload -Url $uri -Path $dest
+        Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
+        $files | Should -Contain (Join-Path $dest 'download.txt')
+    }
+
+    It 'Downloads links when filtered' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/manual_download.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $dest = Join-Path $TestDrive 'filtered'
+        $files = Save-HTMLDownload -Url $uri -Path $dest -Filter 'download.txt'
+        Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
+        $files | Should -Contain (Join-Path $dest 'download.txt')
+    }
 }

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -3,7 +3,7 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'shot.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Delay 200
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded'
         (Test-Path $outfile) | Should -BeTrue
     }
 
@@ -11,7 +11,7 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'full.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full -Delay 200
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full -Selector '#loaded'
         (Test-Path $outfile) | Should -BeTrue
     }
 
@@ -19,7 +19,7 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'clip.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50 -Delay 200
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50 -Selector '#loaded'
         (Test-Path $outfile) | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary
- add optional CSS selector parameter to `Save-HTMLScreenshot`
- wait for the selector in `CaptureScreenshotAsync`
- wait for filtered anchors when saving downloads
- document the new `-Selector` option
- update tests for `Save-HTMLScreenshot`

## Testing
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Output Detailed` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68459d493494832eb954029ed9165900