### PR TITLE
Fix PS 5.1 encoding in test

### DIFF
--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -1,4 +1,4 @@
-Describe -Name 'ConvertFrom-HtmlTable' {
+﻿Describe -Name 'ConvertFrom-HtmlTable' {
     It 'Given a HTML table online with polish chars - Should convert it to a PowerShell object' {
         $Url = 'https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm'
 


### PR DESCRIPTION
## Summary
- add UTF-8 BOM to the Polish table Pester test so PowerShell 5.1 reads it correctly

## Testing
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1` *(fails: `Save-HTMLDownload` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c45c299c832eb59bac9e027765af