### PR TITLE
Fix progress logging

### DIFF
--- a/Sources/PSParseHTML/Logging/InternalLogger.cs
+++ b/Sources/PSParseHTML/Logging/InternalLogger.cs
@@ -77,7 +77,7 @@ public class InternalLogger {
 
     public void WriteProgress(string activity, string currentOperation, int percentCompleted, int? currentSteps = null, int? totalSteps = null) {
         lock (_lock) {
-            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, totalSteps));
+            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, percentCompleted));
             if (IsProgress) {
                 if (currentSteps.HasValue && totalSteps.HasValue) {
                     Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentCompleted, currentSteps, totalSteps);


### PR DESCRIPTION
## Summary
- fix progress logging to use percentage value for events

## Testing
- `dotnet test Sources/PSParseHTML.sln --configuration Release --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -File PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6845555c97f8832ea3b9175da99c2544