### PR TITLE
Add flexible session navigation features

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
@@ -16,6 +16,10 @@ public sealed class CmdletCloseHtmlSession : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         await HtmlBrowserRenderer.CloseSessionAsync(Session).ConfigureAwait(false);
+        object? defaultSession = GetVariableValue("PSParseHTML_DefaultSession");
+        if (defaultSession is BrowserSession sess && ReferenceEquals(sess, Session)) {
+            SessionState.PSVariable.Remove("PSParseHTML_DefaultSession");
+        }
     }
 }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlNavigation.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlNavigation.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 
 namespace PSParseHTML.PowerShell;
@@ -7,22 +8,84 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that navigates an existing browser session to a new URL.
 /// </summary>
-[Cmdlet(VerbsLifecycle.Invoke, "HTMLNavigation")]
+[Cmdlet(VerbsLifecycle.Invoke, "HTMLNavigation", DefaultParameterSetName = ParameterSetUrl)]
 [OutputType(typeof(BrowserSession))]
 public sealed class CmdletInvokeHtmlNavigation : AsyncPSCmdlet {
+    private const string ParameterSetUrl = "ByUrl";
+    private const string ParameterSetText = "ByText";
+    private const string ParameterSetSelector = "BySelector";
+
     /// <summary>Existing browser session.</summary>
-    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
-    public BrowserSession Session { get; set; } = null!;
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public BrowserSession? Session { get; set; }
 
     /// <summary>Destination URL.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
-    public string Url { get; set; } = string.Empty;
+    [Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetUrl)]
+    public string? Url { get; set; }
+
+    /// <summary>Text of the element to click.</summary>
+    [Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetText)]
+    public string? Text { get; set; }
+
+    /// <summary>CSS selector of the element to click.</summary>
+    [Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetSelector)]
+    public string? Selector { get; set; }
+
+    /// <summary>Use exact text match.</summary>
+    [Parameter(ParameterSetName = ParameterSetText)]
+    public SwitchParameter Exact { get; set; }
+
+    /// <summary>Regular expression for text match.</summary>
+    [Parameter(ParameterSetName = ParameterSetText)]
+    public string? Regex { get; set; }
+
+    /// <summary>Wait for navigation event after clicking.</summary>
+    [Parameter(ParameterSetName = ParameterSetText)]
+    [Parameter(ParameterSetName = ParameterSetSelector)]
+    public SwitchParameter WaitForNavigation { get; set; }
+
+    /// <summary>Return the session object.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        await Session.Page.GotoAsync(Url).ConfigureAwait(false);
-        await Session.Page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
-        WriteObject(Session);
+        BrowserSession session = Session ?? (BrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        switch (ParameterSetName) {
+            case ParameterSetUrl:
+                await session.Page.GotoAsync(Url!).ConfigureAwait(false);
+                await session.Page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
+                break;
+            case ParameterSetSelector:
+                if (WaitForNavigation.IsPresent) {
+                    await session.Page.RunAndWaitForNavigationAsync(() => session.Page.ClickAsync(Selector!)).ConfigureAwait(false);
+                } else {
+                    await session.Page.ClickAsync(Selector!).ConfigureAwait(false);
+                }
+                break;
+            case ParameterSetText:
+                ILocator locator;
+                if (!string.IsNullOrEmpty(Regex)) {
+                    locator = session.Page.GetByText(new Regex(Regex));
+                } else if (Exact.IsPresent) {
+                    locator = session.Page.GetByText(Text!, new PageGetByTextOptions { Exact = true });
+                } else {
+                    locator = session.Page.GetByText(Text!);
+                }
+
+                if (WaitForNavigation.IsPresent) {
+                    await session.Page.RunAndWaitForNavigationAsync(() => locator.ClickAsync()).ConfigureAwait(false);
+                } else {
+                    await locator.ClickAsync().ConfigureAwait(false);
+                }
+                break;
+        }
+
+        if (PassThru.IsPresent) {
+            WriteObject(session);
+        }
     }
 }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -64,6 +64,10 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Session { get; set; }
 
+    /// <summary>Do not set the opened session as the default session.</summary>
+    [Parameter]
+    public SwitchParameter NoDefault { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
@@ -86,6 +90,9 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 user,
                 pass,
                 form).ConfigureAwait(false);
+            if (!NoDefault.IsPresent) {
+                SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
+            }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             await HtmlBrowserRenderer.SavePageContentAsync(Url, OutFile, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -23,9 +23,9 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     public string Url { get; set; } = string.Empty;
 
     /// <summary>Existing browser session.</summary>
-    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetSessionDefault, ValueFromPipeline = true)]
-    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetSessionClip, ValueFromPipeline = true)]
-    public BrowserSession Session { get; set; } = null!;
+    [Parameter(Position = 0, ParameterSetName = ParameterSetSessionDefault, ValueFromPipeline = true)]
+    [Parameter(Position = 0, ParameterSetName = ParameterSetSessionClip, ValueFromPipeline = true)]
+    public BrowserSession? Session { get; set; }
 
     /// <summary>File path for the screenshot.</summary>
     [Parameter(Mandatory = true, Position = 1)]
@@ -81,6 +81,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        BrowserSession? session = Session ?? (BrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+
         switch (ParameterSetName) {
             case ParameterSetClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
@@ -98,7 +100,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                 break;
             case ParameterSetSessionClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
-                    Session.Page,
+                    (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
                     OutFile,
                     false,
                     Delay,
@@ -110,7 +112,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                 break;
             case ParameterSetSessionDefault:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
-                    Session.Page,
+                    (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
                     OutFile,
                     Full.IsPresent,
                     Delay,


### PR DESCRIPTION
## Summary
- support clicking by text, regex, or selector in `Invoke-HTMLNavigation`
- allow cmdlets to fallback to a global session variable
- optionally persist new sessions and remove them on close
- resolve sessions in `Save-HTMLScreenshot`

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6846fbac63cc832e87933eba12252f1e