### PR TITLE
Add Get-HTMLInteractable cmdlet and docs

### DIFF
--- a/Docs/Examples/03-GetInteractableElements/README.MD
+++ b/Docs/Examples/03-GetInteractableElements/README.MD
@@ -12,6 +12,8 @@ Typical use includes discovering links, buttons, or form elements a user or scri
 ```powershell
 Get-HTMLInteractable
     [-Session <BrowserSession>]
+    [-Url <string>]
+    [-Path <string>]
     [-IncludeHidden]
     [-Limit <int>]
 ```
@@ -22,9 +24,13 @@ Get-HTMLInteractable
 
 | Name             | Type     | Required | Description                                                                 |
 |------------------|----------|----------|-----------------------------------------------------------------------------|
-| `-Session`       | BrowserSession | Yes | The session object returned by `Start-HTMLSession`. |
+| `-Session`       | BrowserSession | Yes* | The session object returned by `Start-HTMLSession`. |
+| `-Url`           | string   | Yes* | Load a page at the specified URL and list elements. |
+| `-Path`          | string   | Yes* | Load a local HTML file. Alias: `-File`. |
 | `-IncludeHidden` | switch   | No       | If specified, includes elements not visible to the user (e.g. `display:none`).     |
 | `-Limit`         | int      | No       | Limits the number of results returned. Default is 100.                      |
+
+`*` Exactly one of `-Session`, `-Url` or `-Path` must be specified.
 
 ---
 
@@ -60,6 +66,18 @@ Index  Text         Tag     Selector                            Href
 
 ```powershell
 Get-HTMLInteractable -Session $Session
+```
+
+### 🧪 Load a URL directly
+
+```powershell
+Get-HTMLInteractable -Url 'https://example.com'
+```
+
+### 🧪 Parse a local HTML file
+
+```powershell
+Get-HTMLInteractable -Path './report.html'
 ```
 
 ### 🧪 Include hidden elements, limit results to 10

--- a/Docs/Examples/03-GetInteractableElements/README.MD
+++ b/Docs/Examples/03-GetInteractableElements/README.MD
@@ -1,0 +1,110 @@
+# `Get-HTMLInteractable`
+
+## 📖 Summary
+
+`Get-HTMLInteractable` lists all visible or optionally hidden clickable/interactable elements from the current HTML page inside a browser session.  
+Typical use includes discovering links, buttons, or form elements a user or script might want to interact with — ideal for automation or semi-interactive scripting.
+
+---
+
+## 🧰 Syntax
+
+```powershell
+Get-HTMLInteractable
+    [-Session <BrowserSession>]
+    [-IncludeHidden]
+    [-Limit <int>]
+```
+
+---
+
+## 📥 Parameters
+
+| Name             | Type     | Required | Description                                                                 |
+|------------------|----------|----------|-----------------------------------------------------------------------------|
+| `-Session`       | BrowserSession | Yes | The session object returned by `Start-HTMLSession`. |
+| `-IncludeHidden` | switch   | No       | If specified, includes elements not visible to the user (e.g. `display:none`).     |
+| `-Limit`         | int      | No       | Limits the number of results returned. Default is 100.                      |
+
+---
+
+## 📤 Output
+
+A list of objects with the following structure:
+
+| Property  | Type   | Description                                            |
+|-----------|--------|--------------------------------------------------------|
+| `Index`   | int    | Order number in result set                             |
+| `Text`    | string | Inner text or value of the element                     |
+| `Tag`     | string | Tag name (e.g., `a`, `button`, `input`)                |
+| `Selector`| string | First 80 characters of the outer HTML (for preview)    |
+| `Href`    | string | The `href` or `onclick` attribute value if applicable  |
+
+---
+
+## 📋 Example Output
+
+```plaintext
+Index  Text         Tag     Selector                            Href
+-----  ----         ---     --------                            ----
+0      Login        button  <button type="submit">              null
+1      Dashboard    a       <a href="/admin">Dashboard</a>      /admin
+2      Settings     a       <a href="/settings">Settings</a>    /settings
+```
+
+---
+
+## 💡 Examples
+
+### 🧪 Get interactable elements from current page
+
+```powershell
+Get-HTMLInteractable -Session $Session
+```
+
+### 🧪 Include hidden elements, limit results to 10
+
+```powershell
+Get-HTMLInteractable -Session $Session -IncludeHidden -Limit 10
+```
+
+### 🧪 Use interactively with `Out-GridView`
+
+```powershell
+$pick = Get-HTMLInteractable -Session $Session | Out-GridView -Title "Pick element" -PassThru
+Invoke-HTMLNavigation -Session $Session -Text $pick.Text
+```
+
+---
+
+## 🔧 Internal Behavior
+
+Internally, the following JavaScript logic is executed inside the Playwright context:
+
+```javascript
+(() => {
+    const isVisible = el => !!( el.offsetWidth || el.offsetHeight || el.getClientRects().length );
+    const elements = Array.from(document.querySelectorAll('a, button, input[type="submit"]'));
+    return elements
+        .filter(el => /* IncludeHidden? */ isVisible(el))
+        .map((el, index) => ({
+            Index: index,
+            Text: el.innerText || el.value || '',
+            Tag: el.tagName.toLowerCase(),
+            Selector: el.outerHTML.slice(0, 80),
+            Href: el.href || el.getAttribute('onclick') || null
+        }));
+})();
+```
+
+This provides a readable list of interactable elements useful for further automation or navigation.
+
+---
+
+## 🧼 Notes
+
+- This cmdlet does not perform any interaction — use `Invoke-HTMLNavigation` to act on returned elements.
+- Use `-Limit` to avoid processing overly large DOM trees.
+- Visibility filtering uses bounding box and layout heuristics (`getClientRects()`).
+
+---

--- a/Examples/Example-BrowserSessionInteractable.ps1
+++ b/Examples/Example-BrowserSessionInteractable.ps1
@@ -1,0 +1,9 @@
+﻿Import-Module .\PSParseHTML.psd1 -Force
+
+$Session = Start-HTMLSession -Url 'https://evotec.xyz' -Session
+Save-HTMLScreenshot -Session $Session -OutFile "$PSScriptRoot\Output\Interactable1.png" -Open
+Get-HTMLInteractable -Session $Session | Format-Table
+
+Get-HTMLInteractable -Url 'https://evotec.xyz' | Format-Table
+
+Get-HTMLInteractable -Path "$PSScriptRoot\Input\azure_status.html" | Format-Table

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLAttachment')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLDownload', 'Save-HTMLScreenshot')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLDownload', 'Save-HTMLScreenshot')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) Przemyslaw Klys. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -42,6 +42,7 @@
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 - `Save-HTMLDownload` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLAttachment`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
+- `Get-HTMLInteractable` - list clickable elements from the current page
 - `Close-HTMLSession` - dispose an active browser session (`Stop-HTMLSession` alias)
 
 ### Cmdlet quick start

--- a/README.MD
+++ b/README.MD
@@ -42,7 +42,7 @@
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 - `Save-HTMLDownload` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLAttachment`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
-- `Get-HTMLInteractable` - list clickable elements from the current page
+- `Get-HTMLInteractable` - list clickable elements from a session, URL or file
 - `Close-HTMLSession` - dispose an active browser session (`Stop-HTMLSession` alias)
 
 ### Cmdlet quick start

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -1,18 +1,42 @@
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
 /// <summary>
 /// Cmdlet that lists clickable or interactable elements from a browser session.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "HTMLInteractable")]
+[Cmdlet(VerbsCommon.Get, "HTMLInteractable", DefaultParameterSetName = ParameterSetSession)]
 [OutputType(typeof(InteractableElement))]
 public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
+    private const string ParameterSetSession = "Session";
+    private const string ParameterSetUrl = "Url";
+    private const string ParameterSetFile = "File";
+
     /// <summary>Existing browser session.</summary>
-    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetSession, ValueFromPipeline = true)]
     public BrowserSession Session { get; set; } = null!;
+
+    /// <summary>URL of the page to inspect.</summary>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetUrl)]
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>Path to a local HTML file.</summary>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetFile)]
+    [Alias("Path")]
+    public string File { get; set; } = string.Empty;
+
+    /// <summary>Browser engine to use when loading <see cref="Url"/> or <see cref="File"/>.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public BrowserEngine Browser { get; set; } = BrowserEngine.Chromium;
+
+    /// <summary>Reinstall browser runtimes when using <see cref="Url"/> or <see cref="File"/>.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public SwitchParameter Clean { get; set; }
 
     /// <summary>Include elements hidden from view.</summary>
     [Parameter]
@@ -23,12 +47,79 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [ValidateRange(1, int.MaxValue)]
     public int Limit { get; set; } = 100;
 
+    /// <summary>Credentials for pages requiring authentication.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public PSCredential? Credential { get; set; }
+
+    /// <summary>Basic authentication username.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public string? Username { get; set; }
+
+    /// <summary>Basic authentication password.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public string? Password { get; set; }
+
+    /// <summary>URL of a login form.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public string? LoginUrl { get; set; }
+
+    /// <summary>CSS selector for the username field.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public string? UsernameSelector { get; set; }
+
+    /// <summary>CSS selector for the password field.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public string? PasswordSelector { get; set; }
+
+    /// <summary>CSS selector for the submit element.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    public string? SubmitSelector { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        List<InteractableElement> list = await HtmlBrowserRenderer.GetInteractableElementsAsync(
-            Session.Page,
-            IncludeHidden.IsPresent,
-            Limit).ConfigureAwait(false);
+        List<InteractableElement> list;
+        switch (ParameterSetName) {
+            case ParameterSetUrl:
+                string? user = Credential?.UserName ?? Username;
+                string? pass = Credential?.GetNetworkCredential().Password ?? Password;
+                FormLoginOptions? form = null;
+                if (!string.IsNullOrEmpty(LoginUrl) &&
+                    !string.IsNullOrEmpty(UsernameSelector) &&
+                    !string.IsNullOrEmpty(PasswordSelector) &&
+                    !string.IsNullOrEmpty(SubmitSelector)) {
+                    form = new FormLoginOptions {
+                        LoginUrl = LoginUrl!,
+                        UsernameSelector = UsernameSelector!,
+                        PasswordSelector = PasswordSelector!,
+                        SubmitSelector = SubmitSelector!
+                    };
+                }
+
+                list = await HtmlBrowserRenderer.GetInteractableElementsAsync(
+                    Url,
+                    Browser,
+                    Clean.IsPresent,
+                    IncludeHidden.IsPresent,
+                    Limit,
+                    user,
+                    pass,
+                    form).ConfigureAwait(false);
+                break;
+            case ParameterSetFile:
+                list = await HtmlBrowserRenderer.GetInteractableElementsFromFileAsync(
+                    File,
+                    Browser,
+                    Clean.IsPresent,
+                    IncludeHidden.IsPresent,
+                    Limit).ConfigureAwait(false);
+                break;
+            default:
+                list = await HtmlBrowserRenderer.GetInteractableElementsAsync(
+                    Session.Page,
+                    IncludeHidden.IsPresent,
+                    Limit).ConfigureAwait(false);
+                break;
+        }
 
         foreach (InteractableElement element in list) {
             WriteObject(element);

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that lists clickable or interactable elements from a browser session.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "HTMLInteractable")]
+[OutputType(typeof(InteractableElement))]
+public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
+    /// <summary>Existing browser session.</summary>
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    public BrowserSession Session { get; set; } = null!;
+
+    /// <summary>Include elements hidden from view.</summary>
+    [Parameter]
+    public SwitchParameter IncludeHidden { get; set; }
+
+    /// <summary>Maximum number of elements to return.</summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int Limit { get; set; } = 100;
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        List<InteractableElement> list = await HtmlBrowserRenderer.GetInteractableElementsAsync(
+            Session.Page,
+            IncludeHidden.IsPresent,
+            Limit).ConfigureAwait(false);
+
+        foreach (InteractableElement element in list) {
+            WriteObject(element);
+        }
+    }
+}

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -312,4 +312,56 @@ public static async Task CaptureScreenshotAsync(
         await page.WaitForTimeoutAsync(500);
         return downloads;
     }
+
+    /// <summary>
+    /// Returns clickable or interactable elements found on an already loaded page.
+    /// </summary>
+    public static async Task<List<InteractableElement>> GetInteractableElementsAsync(
+        IPage page,
+        bool includeHidden = false,
+        int limit = 100) {
+        string filter = includeHidden ? "true" : "isVisible(el)";
+        string script = $@"(() => {{
+    const isVisible = el => !!( el.offsetWidth || el.offsetHeight || el.getClientRects().length );
+    const elements = Array.from(document.querySelectorAll('a, button, input[type=""submit""]'));
+    return elements
+        .filter(el => {filter})
+        .slice(0, {limit})
+        .map((el, index) => {{
+            return {{
+                Index: index,
+                Text: el.innerText || el.value || '',
+                Tag: el.tagName.toLowerCase(),
+                Selector: el.outerHTML.slice(0, 80),
+                Href: el.href || el.getAttribute('onclick') || null
+            }};
+        }});
+}})();";
+
+        var result = await page.EvaluateAsync<InteractableElement[]>(script).ConfigureAwait(false);
+        return new List<InteractableElement>(result);
+    }
+
+    /// <summary>
+    /// Opens a page at the specified URL and returns clickable elements.
+    /// </summary>
+    public static async Task<List<InteractableElement>> GetInteractableElementsAsync(
+        string url,
+        BrowserEngine browser = BrowserEngine.Chromium,
+        bool clean = false,
+        bool includeHidden = false,
+        int limit = 100,
+        string? username = null,
+        string? password = null,
+        FormLoginOptions? formLogin = null) {
+        await using BrowserSession session = await OpenSessionAsync(
+            url,
+            browser,
+            clean,
+            username,
+            password,
+            formLogin).ConfigureAwait(false);
+
+        return await GetInteractableElementsAsync(session.Page, includeHidden, limit).ConfigureAwait(false);
+    }
 }

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -364,4 +364,25 @@ public static async Task CaptureScreenshotAsync(
 
         return await GetInteractableElementsAsync(session.Page, includeHidden, limit).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Loads a local HTML file and returns clickable elements.
+    /// </summary>
+    public static async Task<List<InteractableElement>> GetInteractableElementsFromFileAsync(
+        string path,
+        BrowserEngine browser = BrowserEngine.Chromium,
+        bool clean = false,
+        bool includeHidden = false,
+        int limit = 100) {
+        string fileUrl = new Uri(Path.GetFullPath(path)).AbsoluteUri;
+        await using BrowserSession session = await OpenSessionAsync(
+            fileUrl,
+            browser,
+            clean,
+            null,
+            null,
+            null).ConfigureAwait(false);
+
+        return await GetInteractableElementsAsync(session.Page, includeHidden, limit).ConfigureAwait(false);
+    }
 }

--- a/Sources/PSParseHTML/InteractableElement.cs
+++ b/Sources/PSParseHTML/InteractableElement.cs
@@ -1,0 +1,21 @@
+namespace PSParseHTML;
+
+/// <summary>
+/// Represents a clickable or interactable element on a web page.
+/// </summary>
+public sealed class InteractableElement {
+    /// <summary>Index of the element in the result set.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Inner text or value of the element.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Tag name of the element.</summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>First 80 characters of the outer HTML.</summary>
+    public string Selector { get; set; } = string.Empty;
+
+    /// <summary>Hyperlink or onclick attribute value.</summary>
+    public string? Href { get; set; }
+}


### PR DESCRIPTION
## Summary
- implement `Get-HTMLInteractable` as a compiled cmdlet
- return interactable elements via Playwright
- document cmdlet parameters and usage

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command "./PSParseHTML.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6846fce14704832ebf9efa139e2fa5c7