### PR TITLE
Default ConvertFrom-HtmlList to object output

### DIFF
--- a/Examples/Example-Table-UefaChampionsLeague.ps1
+++ b/Examples/Example-Table-UefaChampionsLeague.ps1
@@ -14,7 +14,7 @@ foreach ($Url in $Urls) {
         $Tables[$Count] | Format-Table -AutoSize *
     }
 
-    $List = ConvertFrom-HtmlList -Content $HTML -IncludeMetadata -AsObject
+    $List = ConvertFrom-HtmlList -Content $HTML -IncludeMetadata
     for ($Count = 0; $Count -lt $List.Count; $Count++) {
         $List[$Count].Data | Format-Table -AutoSize *
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
@@ -6,10 +6,10 @@ using System.Net.Http;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>
-/// Converts HTML lists into PowerShell string arrays.
+/// Converts HTML lists into PowerShell objects by default.
 /// </summary>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlList", DefaultParameterSetName = ParameterSetContent)]
-[OutputType(typeof(string[]))]
+[OutputType(typeof(PSObject[]))]
 public sealed class CmdletConvertFromHtmlList : PSCmdlet {
     private const string ParameterSetContent = "Content";
     private const string ParameterSetUrl = "Url";
@@ -32,9 +32,9 @@ public sealed class CmdletConvertFromHtmlList : PSCmdlet {
     [Parameter]
     public SwitchParameter IncludeMetadata { get; set; }
 
-    /// <summary>Return each list item as an object with properties.</summary>
+    /// <summary>Return list items as strings.</summary>
     [Parameter]
-    public SwitchParameter AsObject { get; set; }
+    public SwitchParameter AsString { get; set; }
 
     /// <summary>Placeholder inserted between text segments when joining item text.</summary>
     [Parameter]
@@ -71,14 +71,16 @@ public sealed class CmdletConvertFromHtmlList : PSCmdlet {
             }
         }
 
+        bool returnObjects = !AsString.IsPresent;
+
         if (IncludeMetadata.IsPresent) {
             foreach (var result in results) {
-                WriteObject(CreateListObject(result));
+                WriteObject(CreateListObject(result, returnObjects));
             }
         } else {
             var output = new List<object>();
             foreach (var result in results) {
-                if (AsObject.IsPresent) {
+                if (returnObjects) {
                     output.Add(ConvertItems(result.Items));
                 } else {
                     output.Add(result.Items.Select(i => string.Join(TagPlaceholder, i)).ToArray());
@@ -103,9 +105,9 @@ public sealed class CmdletConvertFromHtmlList : PSCmdlet {
         return list.ToArray();
     }
 
-    private PSObject CreateListObject(ListParseResult result) {
+    private PSObject CreateListObject(ListParseResult result, bool returnObjects) {
         PSObject listObject = new();
-        if (AsObject.IsPresent) {
+        if (returnObjects) {
             listObject.Properties.Add(new PSNoteProperty("Data", ConvertItems(result.Items)));
         } else {
             listObject.Properties.Add(new PSNoteProperty("Data", result.Items.Select(i => string.Join(TagPlaceholder, i)).ToArray()));

--- a/Tests/ConvertFrom-HtmlList.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlList.Tests.ps1
@@ -4,8 +4,8 @@ Describe 'ConvertFrom-HtmlList' {
         $content = Get-Content -LiteralPath $path -Raw
         $lists = ConvertFrom-HtmlList -Content $content -Engine AgilityPack
         $lists.Count | Should -Be 2
-        $lists[0] | Should -Be @('Item1','Item2')
-        $lists[1] | Should -Be @('First','Second')
+        $lists[0][0].Column1 | Should -Be 'Item1'
+        $lists[1][1].Column1 | Should -Be 'Second'
     }
 
     It 'Parses sample lists using AngleSharp' {
@@ -13,6 +13,14 @@ Describe 'ConvertFrom-HtmlList' {
         $content = Get-Content -LiteralPath $path -Raw
         $lists = ConvertFrom-HtmlList -Content $content -Engine AngleSharp
         $lists.Count | Should -Be 2
+        $lists[0][0].Column1 | Should -Be 'Item1'
+        $lists[1][1].Column1 | Should -Be 'Second'
+    }
+
+    It 'Returns strings when AsString is used' {
+        $path = Join-Path $PSScriptRoot 'Documents/sample_lists.html'
+        $content = Get-Content -LiteralPath $path -Raw
+        $lists = ConvertFrom-HtmlList -Content $content -AsString
         $lists[0] | Should -Be @('Item1','Item2')
         $lists[1] | Should -Be @('First','Second')
     }
@@ -20,7 +28,7 @@ Describe 'ConvertFrom-HtmlList' {
     It 'Parses sample lists with metadata and objects' {
         $path = Join-Path $PSScriptRoot 'Documents/sample_lists.html'
         $content = Get-Content -LiteralPath $path -Raw
-        $lists = ConvertFrom-HtmlList -Content $content -IncludeMetadata -AsObject
+        $lists = ConvertFrom-HtmlList -Content $content -IncludeMetadata
         $lists.Count | Should -Be 2
         $lists[0].Data[0].Column1 | Should -Be 'Item1'
         $lists[0].ListIndex | Should -Be 0


### PR DESCRIPTION
## Summary
- make `ConvertFrom-HtmlList` return objects by default
- add `-AsString` switch to request string output
- drop the `AsObject` parameter
- update tests to expect objects and cover `-AsString`
- adjust example to use new default

## Testing
- `Invoke-Pester -Configuration @{Run=@{Path='./Tests'; Exit=$false}}` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_68474cf23a20832ea4b834f0daa71951