### PR TITLE
Add PotentiallyHidden flag

### DIFF
--- a/Docs/Examples/03-GetInteractableElements/README.MD
+++ b/Docs/Examples/03-GetInteractableElements/README.MD
@@ -51,6 +51,8 @@ A list of objects with the following structure:
 | `Tag`     | string | Tag name (e.g., `a`, `button`, `input`)                |
 | `Selector`| string | First 80 characters of the outer HTML (for preview)    |
 | `Href`    | string | The `href` or `onclick` attribute value if applicable  |
+| `Visible` | bool   | `True` when Playwright reports the element as visible   |
+| `PotentiallyHidden` | bool | `True` when the element or an ancestor has attributes or styles that may hide it |
 
 ---
 

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -354,6 +354,21 @@ public static async Task CaptureScreenshotAsync(
             string? id = await el.GetAttributeAsync("id");
             string? cls = await el.GetAttributeAsync("class");
             bool visible = await el.IsVisibleAsync();
+            bool potentiallyHidden = await el.EvaluateAsync<bool>(@"el => {
+                const check = node => {
+                    if (!node) return false;
+                    if (node.getAttribute('aria-hidden') === 'true' || node.hidden) {
+                        return true;
+                    }
+                    const style = window.getComputedStyle(node);
+                    if (!style) return false;
+                    return style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity) === 0;
+                };
+                for (let n = el; n; n = n.parentElement) {
+                    if (check(n)) return true;
+                }
+                return false;
+            }");
             string selector = await el.EvaluateAsync<string>(@"el => {
                 const esc = (CSS && CSS.escape) ? CSS.escape : (s => s);
                 let sel = el.tagName.toLowerCase();
@@ -372,7 +387,8 @@ public static async Task CaptureScreenshotAsync(
                 Href = href,
                 Id = id,
                 Class = cls,
-                Visible = visible
+                Visible = visible,
+                PotentiallyHidden = potentiallyHidden
             });
         }
         return list;

--- a/Sources/PSParseHTML/Models/HtmlInteractableInfo.cs
+++ b/Sources/PSParseHTML/Models/HtmlInteractableInfo.cs
@@ -27,4 +27,10 @@ public sealed class HtmlInteractableInfo {
 
     /// <summary>Element class attribute if present.</summary>
     public string? Class { get; set; }
+
+    /// <summary>
+    /// True when the element or one of its ancestors has attributes or styles
+    /// that may hide it from assistive technologies.
+    /// </summary>
+    public bool PotentiallyHidden { get; set; }
 }

--- a/Sources/PSParseHTML/Models/HtmlInteractableInfo.cs
+++ b/Sources/PSParseHTML/Models/HtmlInteractableInfo.cs
@@ -13,6 +13,12 @@ public sealed class HtmlInteractableInfo {
     /// <summary>Indicates whether the element is visible.</summary>
     public bool Visible { get; set; }
 
+    /// <summary>
+    /// True when the element or one of its ancestors has attributes or styles
+    /// that may hide it from assistive technologies.
+    /// </summary>
+    public bool PotentiallyHidden { get; set; }
+
     /// <summary>CSS selector identifying the element.</summary>
     public string Selector { get; set; } = string.Empty;
 
@@ -27,10 +33,4 @@ public sealed class HtmlInteractableInfo {
 
     /// <summary>Element class attribute if present.</summary>
     public string? Class { get; set; }
-
-    /// <summary>
-    /// True when the element or one of its ancestors has attributes or styles
-    /// that may hide it from assistive technologies.
-    /// </summary>
-    public bool PotentiallyHidden { get; set; }
 }


### PR DESCRIPTION
## Summary
- track ancestor hiding of interactable elements
- surface `PotentiallyHidden` flag in documentation

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj` *(fails: NuGet.Config not valid)*
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: cmdlets not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_684882e49f5c832eb6cf4552cfa2d160