### PR TITLE
Add Save-HTMLPdf cmdlet

### DIFF
--- a/Examples/Example-BrowserSessionDefault.ps1
+++ b/Examples/Example-BrowserSessionDefault.ps1
@@ -19,6 +19,8 @@ Get-HTMLInteractable -Filter "Media" -IncludeHidden | Format-Table
 
 Save-HTMLScreenshot -OutFile "$PSScriptRoot\Output\WP1.png" -Open
 
+Save-HTMLPdf -OutFile "$PSScriptRoot\Output\WP1.pdf" -Open
+
 Get-HTMLInteractable -Filter "Galleries" -IncludeHidden | Format-Table
 
 Invoke-HTMLNavigation -Text "Galleries" -Exact

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLScreenshot')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLScreenshot', 'Save-HTMLPdf')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) Przemyslaw Klys. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,7 @@
 ## Browsing
 - `Invoke-HTMLRendering` - render pages with a headless browser (supports basic and form authentication)
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
+- `Save-HTMLPdf` - generate a PDF of a rendered page
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file
@@ -93,7 +94,8 @@ Invoke-HTMLRendering -Url 'https://example.com/protected' `
     -UsernameSelector 'input[name=log]' `
     -PasswordSelector 'input[name=pwd]' `
     -SubmitSelector '#wp-submit'
-Save-HTMLScreenshot -Url 'https://example.com' -OutFile '.\page.png' -Full -Open -Delay 1000 -Selector '#content'
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\page.png -Full -Open -Delay 1000 -Selector '#content'
+Save-HTMLPdf -Url 'https://example.com' -OutFile .\page.pdf -PrintBackground
 Save-HTMLAttachment -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads'
 Save-HTMLAttachment -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads' -Filter '.zip'
 # Keep a logged in browser session and reuse it

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that generates a PDF from a web page using a headless browser.
+/// </summary>
+/// <example>
+///   <code>Save-HTMLPdf -Url https://example.com -OutFile page.pdf</code>
+/// </example>
+[Cmdlet(VerbsData.Save, "HTMLPdf", DefaultParameterSetName = ParameterSetSession)]
+public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
+    private const string ParameterSetDefault = "Default";
+    private const string ParameterSetFile = "File";
+    private const string ParameterSetSession = "Session";
+
+    /// <summary>URL of the web page.</summary>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetDefault)]
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>Path to a local HTML file.</summary>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetFile)]
+    [Alias("File")]
+    public string? Path { get; set; }
+
+    /// <summary>Existing browser session.</summary>
+    [Parameter(Position = 0, ParameterSetName = ParameterSetSession, ValueFromPipeline = true)]
+    public BrowserSession? Session { get; set; }
+
+    /// <summary>File path for the PDF.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string OutFile { get; set; } = string.Empty;
+
+    /// <summary>Browser engine to use for rendering.</summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public BrowserEngine Browser { get; set; } = BrowserEngine.Chromium;
+
+    /// <summary>Force re-download of browser runtimes.</summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public SwitchParameter Clean { get; set; }
+
+    /// <summary>Open the PDF after saving.</summary>
+    [Parameter]
+    public SwitchParameter Open { get; set; }
+
+    /// <summary>Milliseconds to wait after the page loads.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int Delay { get; set; } = 0;
+
+    /// <summary>CSS selector to wait for before generating the PDF.</summary>
+    [Parameter]
+    public string? Selector { get; set; }
+
+    /// <summary>Render the page in landscape orientation.</summary>
+    [Parameter]
+    public SwitchParameter Landscape { get; set; }
+
+    /// <summary>Include background graphics.</summary>
+    [Parameter]
+    public SwitchParameter PrintBackground { get; set; }
+
+    /// <summary>Paper format (e.g. A4).</summary>
+    [Parameter]
+    public string? Format { get; set; }
+
+    /// <summary>Paper width (e.g. 8.5in).</summary>
+    [Parameter]
+    public string? Width { get; set; }
+
+    /// <summary>Paper height (e.g. 11in).</summary>
+    [Parameter]
+    public string? Height { get; set; }
+
+    /// <summary>Top margin.</summary>
+    [Parameter]
+    public string? MarginTop { get; set; }
+
+    /// <summary>Right margin.</summary>
+    [Parameter]
+    public string? MarginRight { get; set; }
+
+    /// <summary>Bottom margin.</summary>
+    [Parameter]
+    public string? MarginBottom { get; set; }
+
+    /// <summary>Left margin.</summary>
+    [Parameter]
+    public string? MarginLeft { get; set; }
+
+    /// <summary>Page ranges to print.</summary>
+    [Parameter]
+    public string? PageRanges { get; set; }
+
+    /// <summary>Scaling factor.</summary>
+    [Parameter]
+    [ValidateRange(0.1, 2.0)]
+    public float? Scale { get; set; }
+
+    /// <summary>Display headers and footers.</summary>
+    [Parameter]
+    public SwitchParameter DisplayHeaderFooter { get; set; }
+
+    /// <summary>Header HTML template.</summary>
+    [Parameter]
+    public string? HeaderTemplate { get; set; }
+
+    /// <summary>Footer HTML template.</summary>
+    [Parameter]
+    public string? FooterTemplate { get; set; }
+
+    /// <summary>Prefer CSS @page size rules.</summary>
+    [Parameter]
+    public SwitchParameter PreferCssPageSize { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        BrowserSession? session = Session ?? (BrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        switch (ParameterSetName) {
+            case ParameterSetSession:
+                await HtmlBrowserRenderer.SavePagePdfAsync(
+                    (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
+                    OutFile,
+                    Delay,
+                    Selector,
+                    Landscape.IsPresent,
+                    PrintBackground.IsPresent,
+                    Format,
+                    Width,
+                    Height,
+                    MarginTop,
+                    MarginRight,
+                    MarginBottom,
+                    MarginLeft,
+                    PageRanges,
+                    Scale,
+                    DisplayHeaderFooter.IsPresent,
+                    HeaderTemplate,
+                    FooterTemplate,
+                    PreferCssPageSize.IsPresent,
+                    outline: false,
+                    tagged: false).ConfigureAwait(false);
+                break;
+            case ParameterSetFile:
+                await HtmlBrowserRenderer.SavePagePdfAsync(
+                    new System.Uri(System.IO.Path.GetFullPath(Path!)).AbsoluteUri,
+                    OutFile,
+                    Browser,
+                    Clean.IsPresent,
+                    Delay,
+                    Selector,
+                    Landscape.IsPresent,
+                    PrintBackground.IsPresent,
+                    Format,
+                    Width,
+                    Height,
+                    MarginTop,
+                    MarginRight,
+                    MarginBottom,
+                    MarginLeft,
+                    PageRanges,
+                    Scale,
+                    DisplayHeaderFooter.IsPresent,
+                    HeaderTemplate,
+                    FooterTemplate,
+                    PreferCssPageSize.IsPresent,
+                    outline: false,
+                    tagged: false).ConfigureAwait(false);
+                break;
+            default:
+                await HtmlBrowserRenderer.SavePagePdfAsync(
+                    Url,
+                    OutFile,
+                    Browser,
+                    Clean.IsPresent,
+                    Delay,
+                    Selector,
+                    Landscape.IsPresent,
+                    PrintBackground.IsPresent,
+                    Format,
+                    Width,
+                    Height,
+                    MarginTop,
+                    MarginRight,
+                    MarginBottom,
+                    MarginLeft,
+                    PageRanges,
+                    Scale,
+                    DisplayHeaderFooter.IsPresent,
+                    HeaderTemplate,
+                    FooterTemplate,
+                    PreferCssPageSize.IsPresent,
+                    outline: false,
+                    tagged: false).ConfigureAwait(false);
+                break;
+        }
+
+        if (Open.IsPresent) {
+            Process.Start(new ProcessStartInfo {
+                FileName = OutFile,
+                UseShellExecute = true,
+            });
+        }
+    }
+}

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -237,6 +237,128 @@ public static async Task CaptureScreenshotAsync(
     }
 
     /// <summary>
+    /// Saves a PDF of the specified page URL to disk.
+    /// </summary>
+    public static async Task SavePagePdfAsync(
+        string url,
+        string path,
+        BrowserEngine browser = BrowserEngine.Chromium,
+        bool clean = false,
+        int delayMs = 0,
+        string? selector = null,
+        bool landscape = false,
+        bool printBackground = false,
+        string? format = null,
+        string? width = null,
+        string? height = null,
+        string? marginTop = null,
+        string? marginRight = null,
+        string? marginBottom = null,
+        string? marginLeft = null,
+        string? pageRanges = null,
+        float? scale = null,
+        bool displayHeaderFooter = false,
+        string? headerTemplate = null,
+        string? footerTemplate = null,
+        bool preferCssPageSize = false,
+        bool outline = false,
+        bool tagged = false,
+        string? username = null,
+        string? password = null,
+        FormLoginOptions? formLogin = null) {
+        await using BrowserSession session = await OpenSessionAsync(
+            url,
+            browser,
+            clean,
+            username,
+            password,
+            formLogin).ConfigureAwait(false);
+
+        await SavePagePdfAsync(
+            session.Page,
+            path,
+            delayMs,
+            selector,
+            landscape,
+            printBackground,
+            format,
+            width,
+            height,
+            marginTop,
+            marginRight,
+            marginBottom,
+            marginLeft,
+            pageRanges,
+            scale,
+            displayHeaderFooter,
+            headerTemplate,
+            footerTemplate,
+            preferCssPageSize,
+            outline,
+            tagged).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Saves a PDF from an already loaded page.
+    /// </summary>
+    public static async Task SavePagePdfAsync(
+        IPage page,
+        string path,
+        int delayMs = 0,
+        string? selector = null,
+        bool landscape = false,
+        bool printBackground = false,
+        string? format = null,
+        string? width = null,
+        string? height = null,
+        string? marginTop = null,
+        string? marginRight = null,
+        string? marginBottom = null,
+        string? marginLeft = null,
+        string? pageRanges = null,
+        float? scale = null,
+        bool displayHeaderFooter = false,
+        string? headerTemplate = null,
+        string? footerTemplate = null,
+        bool preferCssPageSize = false,
+        bool outline = false,
+        bool tagged = false) {
+        if (!string.IsNullOrEmpty(selector)) {
+            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+        }
+        if (delayMs > 0) {
+            await page.WaitForTimeoutAsync(delayMs);
+        }
+
+        var options = new PagePdfOptions {
+            Path = path,
+            Landscape = landscape,
+            PrintBackground = printBackground,
+            Format = format,
+            Width = width,
+            Height = height,
+            PageRanges = pageRanges,
+            Scale = scale,
+            DisplayHeaderFooter = displayHeaderFooter,
+            HeaderTemplate = headerTemplate,
+            FooterTemplate = footerTemplate,
+            PreferCSSPageSize = preferCssPageSize,
+            Outline = outline,
+            Tagged = tagged
+        };
+        if (marginTop != null || marginRight != null || marginBottom != null || marginLeft != null) {
+            options.Margin = new Margin {
+                Top = marginTop,
+                Right = marginRight,
+                Bottom = marginBottom,
+                Left = marginLeft
+            };
+        }
+
+        await page.PdfAsync(options).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Saves any files downloaded while loading the specified URL.
     /// </summary>
     /// <param name="url">URL to load.</param>

--- a/Tests/Save-HTMLPdf.Tests.ps1
+++ b/Tests/Save-HTMLPdf.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Save-HTMLPdf' {
+    It 'Creates a PDF file' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'page.pdf'
+        Save-HTMLPdf -Url $uri -OutFile $outfile -Selector '#loaded'
+        (Test-Path $outfile) | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- enable PDF generation with `Save-HTMLPdf`
- document the new cmdlet and example usage
- export the new cmdlet in the module manifest
- test coverage for `Save-HTMLPdf`

## Testing
- `Invoke-Pester -Path Tests -Output Detailed` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1fe176c0832e885462a73cfda688