### PR TITLE
Unify path parameters

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Dom;
 using System.Management.Automation;
 using System.Net.Http;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -82,7 +83,7 @@ public sealed class CmdletConvertFromHtmlAttributes : PSCmdlet {
                 Id,
                 Name),
             ParameterSetFile => HtmlParserExtensions.GetElementsFromFile(
-                Path,
+                FileUtilities.ResolvePath(Path),
                 Tag,
                 Class,
                 Id,

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -36,8 +37,8 @@ public sealed class CmdletConvertHtmlToText : PSCmdlet {
     /// Path to a HTML file.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetFile)]
-    [Alias("Path")]
-    public string File { get; set; } = string.Empty;
+    [Alias("File")]
+    public string Path { get; set; } = string.Empty;
 
     /// <summary>
     /// URL of a HTML page to download and convert.
@@ -68,7 +69,7 @@ public sealed class CmdletConvertHtmlToText : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string text = ParameterSetName switch {
-            ParameterSetFile => HtmlUtilities.ConvertFileToText(File),
+            ParameterSetFile => HtmlUtilities.ConvertFileToText(FileUtilities.ResolvePath(Path)),
             ParameterSetUrl => HtmlUtilities.ConvertToText(
                 HttpContentHelper.GetStringWithProperEncodingAsync(
                     HttpClientHelper.Create(Proxy, ProxyCredential),
@@ -77,7 +78,8 @@ public sealed class CmdletConvertHtmlToText : PSCmdlet {
         };
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            System.IO.File.WriteAllText(OutputFile, text);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            System.IO.File.WriteAllText(outPath, text);
         } else {
             WriteObject(text);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -18,8 +19,8 @@ public sealed class CmdletFormatCss : PSCmdlet {
 
     /// <summary>Path to a CSS file to format.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetFile)]
-    [Alias("Path")]
-    public string File { get; set; } = string.Empty;
+    [Alias("File")]
+    public string Path { get; set; } = string.Empty;
 
     /// <summary>CSS content to format.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
@@ -32,11 +33,12 @@ public sealed class CmdletFormatCss : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string formatted = ParameterSetName == ParameterSetFile
-            ? HtmlFormatter.FormatCssFile(File)
+            ? HtmlFormatter.FormatCssFile(FileUtilities.ResolvePath(Path))
             : HtmlFormatter.FormatCss(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            System.IO.File.WriteAllText(OutputFile, formatted);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            System.IO.File.WriteAllText(outPath, formatted);
         } else {
             WriteObject(formatted);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -16,8 +17,8 @@ public sealed class CmdletFormatHtml : PSCmdlet {
 
     /// <summary>Path to an HTML file.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetFile)]
-    [Alias("Path")]
-    public string File { get; set; } = string.Empty;
+    [Alias("File")]
+    public string Path { get; set; } = string.Empty;
 
     /// <summary>HTML content to format.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
@@ -63,7 +64,7 @@ public sealed class CmdletFormatHtml : PSCmdlet {
     protected override void ProcessRecord() {
         string result = ParameterSetName == ParameterSetFile
             ? HtmlFormatter.FormatHtmlFile(
-                File,
+                FileUtilities.ResolvePath(Path),
                 Indent,
                 BlockStartLine,
                 RemoveHTMLComments.IsPresent,
@@ -84,7 +85,8 @@ public sealed class CmdletFormatHtml : PSCmdlet {
             RemoveEmptyBlocks.IsPresent);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            System.IO.File.WriteAllText(OutputFile, result);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            System.IO.File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -23,8 +24,8 @@ public sealed class CmdletFormatJavaScript : PSCmdlet {
     /// Path to a JavaScript file to format.
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetFile)]
-    [Alias("Path")]
-    public string File { get; set; } = string.Empty;
+    [Alias("File")]
+    public string Path { get; set; } = string.Empty;
 
     /// <summary>
     /// Optional path to write the formatted JavaScript.
@@ -35,11 +36,12 @@ public sealed class CmdletFormatJavaScript : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string formatted = ParameterSetName == ParameterSetFile
-            ? HtmlFormatter.FormatJavaScriptFile(File)
+            ? HtmlFormatter.FormatJavaScriptFile(FileUtilities.ResolvePath(Path))
             : HtmlFormatter.FormatJavaScript(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            System.IO.File.WriteAllText(OutputFile, formatted);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            System.IO.File.WriteAllText(outPath, formatted);
         } else {
             WriteObject(formatted);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using PSParseHTML;
 using System.Threading.Tasks;
 
 namespace PSParseHTML.PowerShell;
@@ -111,7 +112,7 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                 }
                 break;
             case ParameterSetFile:
-                string fileUrl = new Uri(System.IO.Path.GetFullPath(Path!)).AbsoluteUri;
+                string fileUrl = new Uri(FileUtilities.ResolvePath(Path!)).AbsoluteUri;
                 await using (BrowserSession sess = await HtmlBrowserRenderer.OpenSessionAsync(
                     fileUrl,
                     Browser,

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -92,7 +92,7 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
         }
 
         string target = ParameterSetName == ParameterSetFile
-            ? new System.Uri(System.IO.Path.GetFullPath(Path!)).AbsoluteUri
+            ? new System.Uri(FileUtilities.ResolvePath(Path!)).AbsoluteUri
             : Url;
 
         if (Session.IsPresent) {
@@ -108,7 +108,8 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
-            await HtmlBrowserRenderer.SavePageContentAsync(target, OutFile, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
+            string outPath = FileUtilities.ResolvePath(OutFile);
+            await HtmlBrowserRenderer.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
         } else {
             string html = await HtmlBrowserRenderer.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
             WriteObject(html);

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -31,11 +32,12 @@ public sealed class CmdletOptimizeCss : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string result = ParameterSetName == ParameterSetPath
-            ? HtmlOptimizer.OptimizeCssFile(Path)
+            ? HtmlOptimizer.OptimizeCssFile(FileUtilities.ResolvePath(Path))
             : HtmlOptimizer.OptimizeCss(Css);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            File.WriteAllText(OutputFile, result);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -21,8 +22,8 @@ public sealed class CmdletOptimizeHtml : PSCmdlet {
 
     /// <summary>Path to a HTML file.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetFile)]
-    [Alias("Path")]
-    public string File { get; set; } = string.Empty;
+    [Alias("File")]
+    public string Path { get; set; } = string.Empty;
 
     /// <summary>Optional path to write the optimized HTML.</summary>
     [Parameter]
@@ -35,10 +36,11 @@ public sealed class CmdletOptimizeHtml : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string result = ParameterSetName == ParameterSetFile
-            ? HtmlOptimizer.OptimizeHtmlFile(File, CSSDecodeEscapes.IsPresent)
+            ? HtmlOptimizer.OptimizeHtmlFile(FileUtilities.ResolvePath(Path), CSSDecodeEscapes.IsPresent)
             : HtmlOptimizer.OptimizeHtml(Content, CSSDecodeEscapes.IsPresent);
         if (!string.IsNullOrEmpty(OutputFile)) {
-            System.IO.File.WriteAllText(OutputFile, result);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            System.IO.File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Management.Automation;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -31,11 +32,12 @@ public sealed class CmdletOptimizeJavaScript : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string optimized = ParameterSetName == ParameterSetFile
-            ? HtmlOptimizer.OptimizeJavaScriptFile(Path)
+            ? HtmlOptimizer.OptimizeJavaScriptFile(FileUtilities.ResolvePath(Path))
             : HtmlOptimizer.OptimizeJavaScript(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            File.WriteAllText(OutputFile, optimized);
+            string outPath = FileUtilities.ResolvePath(OutputFile);
+            File.WriteAllText(outPath, optimized);
         } else {
             WriteObject(optimized);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -28,6 +29,7 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
 
     /// <summary>Directory where downloads will be saved.</summary>
     [Parameter(Mandatory = true)]
+    [Alias("File")]
     public string Path { get; set; } = string.Empty;
 
     /// <summary>Browser engine to use for rendering.</summary>
@@ -49,11 +51,11 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
         List<string> files = ParameterSetName switch {
             ParameterSetSession => await HtmlBrowserRenderer.SavePageDownloadsAsync(
                 (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                Path,
+                FileUtilities.ResolvePath(Path),
                 Filter).ConfigureAwait(false),
             _ => await HtmlBrowserRenderer.SavePageDownloadsAsync(
                 Url,
-                Path,
+                FileUtilities.ResolvePath(Path),
                 Browser,
                 Clean.IsPresent,
                 Filter).ConfigureAwait(false)

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Management.Automation;
 using System.Threading.Tasks;
 using System.IO;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -105,7 +106,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
                     Url,
-                    OutFile,
+                    FileUtilities.ResolvePath(OutFile),
                     Browser,
                     Clean.IsPresent,
                     false,
@@ -118,8 +119,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                 break;
             case ParameterSetFileClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
-                    new System.Uri(System.IO.Path.GetFullPath(Path!)).AbsoluteUri,
-                    OutFile,
+                    new System.Uri(FileUtilities.ResolvePath(Path!)).AbsoluteUri,
+                    FileUtilities.ResolvePath(OutFile),
                     Browser,
                     Clean.IsPresent,
                     false,
@@ -133,7 +134,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    OutFile,
+                    FileUtilities.ResolvePath(OutFile),
                     false,
                     Delay,
                     Selector,
@@ -145,18 +146,18 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionDefault:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    OutFile,
+                    FileUtilities.ResolvePath(OutFile),
                     Full.IsPresent,
                     Delay,
                     Selector).ConfigureAwait(false);
                 break;
             default:
                 string target = ParameterSetName == ParameterSetFileDefault
-                    ? new System.Uri(System.IO.Path.GetFullPath(Path!)).AbsoluteUri
+                    ? new System.Uri(FileUtilities.ResolvePath(Path!)).AbsoluteUri
                     : Url;
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
                     target,
-                    OutFile,
+                    FileUtilities.ResolvePath(OutFile),
                     Browser,
                     Clean.IsPresent,
                     Full.IsPresent,
@@ -167,7 +168,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
 
         if (Open.IsPresent) {
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
-                FileName = OutFile,
+                FileName = FileUtilities.ResolvePath(OutFile),
                 UseShellExecute = true,
             });
         }

--- a/Sources/PSParseHTML/FileUtilities.cs
+++ b/Sources/PSParseHTML/FileUtilities.cs
@@ -5,7 +5,7 @@ namespace PSParseHTML {
     /// <summary>
     /// Helper methods for working with file paths.
     /// </summary>
-    internal static class FileUtilities {
+    public static class FileUtilities {
         /// <summary>
         /// Resolves the provided path to an absolute file system path.
         /// Environment variables are expanded and relative paths are

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -150,8 +150,9 @@ public static class HtmlBrowserRenderer {
         string? username = null,
         string? password = null,
         FormLoginOptions? formLogin = null) {
+        string fullPath = FileUtilities.ResolvePath(path);
         string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin).ConfigureAwait(false);
-        File.WriteAllText(path, content);
+        File.WriteAllText(fullPath, content);
     }
 
     /// <summary>
@@ -191,9 +192,10 @@ public static async Task CaptureScreenshotAsync(
             password,
             formLogin).ConfigureAwait(false);
 
+        string fullPath = FileUtilities.ResolvePath(path);
         await CaptureScreenshotAsync(
             session.Page,
-            path,
+            fullPath,
             fullPage,
             delayMs,
             selector,
@@ -223,7 +225,8 @@ public static async Task CaptureScreenshotAsync(
             await page.WaitForTimeoutAsync(delayMs);
         }
 
-        var options = new PageScreenshotOptions { Path = path, FullPage = fullPage };
+        string fullPath = FileUtilities.ResolvePath(path);
+        var options = new PageScreenshotOptions { Path = fullPath, FullPage = fullPage };
         if (clipX.HasValue && clipY.HasValue && clipWidth.HasValue && clipHeight.HasValue) {
             options.Clip = new Clip {
                 X = clipX.Value,
@@ -259,7 +262,8 @@ public static async Task CaptureScreenshotAsync(
             null,
             null).ConfigureAwait(false);
         var page = session.Page;
-        return await SavePageDownloadsAsync(page, directory, filter).ConfigureAwait(false);
+        string dir = FileUtilities.ResolvePath(directory);
+        return await SavePageDownloadsAsync(page, dir, filter).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -270,14 +274,15 @@ public static async Task CaptureScreenshotAsync(
         string directory,
         string? filter = null) {
 
-        Directory.CreateDirectory(directory);
+        string dir = FileUtilities.ResolvePath(directory);
+        Directory.CreateDirectory(dir);
         List<string> downloads = new();
         page.Download += async (_, dl) => {
             bool match = string.IsNullOrEmpty(filter) ||
                          dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
                          dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
             if (match) {
-                string filePath = Path.Combine(directory, dl.SuggestedFilename);
+                string filePath = Path.Combine(dir, dl.SuggestedFilename);
                 await dl.SaveAsAsync(filePath);
                 downloads.Add(filePath);
             }
@@ -294,7 +299,7 @@ public static async Task CaptureScreenshotAsync(
         var anchors = await page.QuerySelectorAllAsync(selector);
         foreach (var anchor in anchors) {
             var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
-            string filePath = Path.Combine(directory, download.SuggestedFilename);
+            string filePath = Path.Combine(dir, download.SuggestedFilename);
             await download.SaveAsAsync(filePath);
             if (!downloads.Contains(filePath)) {
                 downloads.Add(filePath);

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -22,10 +22,11 @@ public class PreMailerClient {
     /// </summary>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     public static PreMailerClient FromFile(string htmlFilePath, PreMailerOptions? options = null) {
-        if (!File.Exists(htmlFilePath)) {
-            throw new FileNotFoundException($"HTML file not found: {htmlFilePath}", htmlFilePath);
+        string path = FileUtilities.ResolvePath(htmlFilePath);
+        if (!File.Exists(path)) {
+            throw new FileNotFoundException($"HTML file not found: {htmlFilePath}", path);
         }
-        string html = File.ReadAllText(htmlFilePath);
+        string html = File.ReadAllText(path);
         return new PreMailerClient(html, options);
     }
 
@@ -43,10 +44,11 @@ public class PreMailerClient {
         try {
             string cssContent = Options.Css ?? string.Empty;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
-                if (!File.Exists(Options.CssFilePath)) {
-                    throw new FileNotFoundException($"CSS file not found: {Options.CssFilePath}", Options.CssFilePath);
+                string cssPath = FileUtilities.ResolvePath(Options.CssFilePath);
+                if (!File.Exists(cssPath)) {
+                    throw new FileNotFoundException($"CSS file not found: {Options.CssFilePath}", cssPath);
                 }
-                cssContent += File.ReadAllText(Options.CssFilePath);
+                cssContent += File.ReadAllText(cssPath);
             }
 
             PreMailer.Net.PreMailer preMailer = Options.BaseUri != null


### PR DESCRIPTION
## Summary
- standardize on `Path` parameter name with `File` alias for input files
- resolve the `Path` property using `FileUtilities` in affected cmdlets

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_684b1eaaa118832e80c62ae23b6d211e