### PR TITLE
Add runtime Playwright driver installer

### DIFF
--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -36,6 +36,7 @@ public static class HtmlBrowserRenderer {
         if (Directory.Exists(path)) {
             Directory.Delete(path, recursive: true);
         }
+        PlaywrightInstaller.CleanDriver();
     }
 
     private static async Task<BrowserSession> CreatePageAsync(

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -49,6 +49,8 @@ public static class HtmlBrowserRenderer {
             CleanInstallDir();
         }
 
+        await PlaywrightInstaller.EnsureInstalledAsync().ConfigureAwait(false);
+
         string engine = browser.ToString().ToLowerInvariant();
         Microsoft.Playwright.Program.Main(new[] { "install", engine });
 

--- a/Sources/PSParseHTML/PSParseHTML.csproj
+++ b/Sources/PSParseHTML/PSParseHTML.csproj
@@ -22,7 +22,9 @@
         <PackageReference Include="NUglify" Version="1.21.15" />
         <PackageReference Include="PreMailer.Net" Version="2.7.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -55,7 +55,11 @@ internal static class PlaywrightInstaller
     {
         if (IsDriverPresent())
         {
-            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", GetDriverPath());
+            // PLAYWRIGHT_DRIVER_SEARCH_PATH must point to the directory containing
+            // the '.playwright' folder, not to the folder itself.
+            Environment.SetEnvironmentVariable(
+                "PLAYWRIGHT_DRIVER_SEARCH_PATH",
+                Path.GetDirectoryName(GetDriverPath()) ?? GetDriverPath());
             return;
         }
 
@@ -121,6 +125,7 @@ internal static class PlaywrightInstaller
         Directory.Delete(tempDir, true);
 
         File.WriteAllText(VersionFile, DriverVersion);
-        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", baseDir);
+        string driversRoot = Path.GetDirectoryName(baseDir) ?? baseDir;
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", driversRoot);
     }
 }

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -20,11 +20,11 @@ internal static class PlaywrightInstaller
                 return "win32_x64";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return RuntimeInformation.OSArchitecture == Architecture.Arm64
-                    ? "darwin-arm64"
-                    : "darwin-x64";
+                    ? "mac-arm64"
+                    : "mac";
             if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
                 return "linux-arm64";
-            return "linux-x64";
+            return "linux";
         }
     }
 

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -169,7 +170,20 @@ internal static class PlaywrightInstaller
 
         Directory.CreateDirectory(Path.Combine(baseDir, "node", PlatformId));
 
-        File.Move(Path.Combine(tempDir, NodeExecutable), Path.Combine(baseDir, "node", PlatformId, NodeExecutable));
+        string nodeDest = Path.Combine(baseDir, "node", PlatformId, NodeExecutable);
+        File.Move(Path.Combine(tempDir, NodeExecutable), nodeDest);
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            try
+            {
+                var chmod = Process.Start("chmod", $"+x \"{nodeDest}\"");
+                chmod?.WaitForExit();
+            }
+            catch
+            {
+                // ignore
+            }
+        }
         File.Move(Path.Combine(tempDir, "LICENSE"), Path.Combine(baseDir, "node", "LICENSE"));
 
         string packageSrc = Path.Combine(tempDir, "package");

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace PSParseHTML;
+
+internal static class PlaywrightInstaller
+{
+    private static string DriverVersion => typeof(Microsoft.Playwright.Playwright)
+        .Assembly.GetName().Version?.ToString(3) ?? "1.52.0";
+
+    private static string PlatformId
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return "win32_x64";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return RuntimeInformation.OSArchitecture == Architecture.Arm64
+                    ? "darwin-arm64"
+                    : "darwin-x64";
+            if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                return "linux-arm64";
+            return "linux-x64";
+        }
+    }
+
+    private static string NodeExecutable => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
+
+    private static string GetDriverPath()
+    {
+        string dir = Path.Combine(Path.GetDirectoryName(typeof(PlaywrightInstaller).Assembly.Location) ?? AppContext.BaseDirectory, ".playwright");
+        return Path.GetFullPath(dir);
+    }
+
+    private static string VersionFile => Path.Combine(GetDriverPath(), ".version");
+
+    private static bool IsDriverPresent()
+    {
+        string baseDir = GetDriverPath();
+        string nodePath = Path.Combine(baseDir, "node", PlatformId, NodeExecutable);
+        string packageDir = Path.Combine(baseDir, "package");
+        if (!File.Exists(nodePath) || !Directory.Exists(packageDir))
+            return false;
+        if (!File.Exists(VersionFile))
+            return false;
+        string version = File.ReadAllText(VersionFile).Trim();
+        return version == DriverVersion;
+    }
+
+    internal static async Task EnsureInstalledAsync()
+    {
+        if (IsDriverPresent())
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", GetDriverPath());
+            return;
+        }
+
+        string urlBase = "https://playwright.azureedge.net/builds/driver";
+        if (DriverVersion.Contains("-alpha") || DriverVersion.Contains("-beta") || DriverVersion.Contains("-next"))
+            urlBase += "/next";
+        string url = $"{urlBase}/playwright-{DriverVersion}-{PlatformId}.zip";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+
+        using var response = await client.GetAsync(url).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        string baseDir = GetDriverPath();
+        if (Directory.Exists(baseDir))
+            Directory.Delete(baseDir, true);
+        Directory.CreateDirectory(baseDir);
+
+        using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+        using (var archive = new ZipArchive(stream))
+        {
+            archive.ExtractToDirectory(baseDir);
+        }
+
+        File.WriteAllText(VersionFile, DriverVersion);
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", baseDir);
+    }
+}

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -30,10 +30,47 @@ internal static class PlaywrightInstaller
 
     private static string NodeExecutable => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
 
+    private static string GetDriverRoot()
+    {
+        string? envRoot = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        if (!string.IsNullOrEmpty(envRoot))
+        {
+            if (envRoot.EndsWith(".playwright"))
+            {
+                envRoot = Path.GetDirectoryName(envRoot) ?? envRoot;
+            }
+            return Path.GetFullPath(envRoot);
+        }
+
+        string? browsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        if (browsersPath == "0")
+        {
+            string baseDir = Path.GetDirectoryName(typeof(PlaywrightInstaller).Assembly.Location) ?? AppContext.BaseDirectory;
+            return Path.Combine(baseDir, "ms-playwright-driver");
+        }
+
+        if (!string.IsNullOrEmpty(browsersPath))
+        {
+            string parent = Path.GetDirectoryName(Path.GetFullPath(browsersPath)) ?? Path.GetFullPath(browsersPath);
+            return Path.Combine(parent, "ms-playwright-driver");
+        }
+
+        string user = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return Path.Combine(localAppData, "ms-playwright-driver");
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Path.Combine(user, "Library", "Caches", "ms-playwright-driver");
+        }
+        return Path.Combine(user, ".cache", "ms-playwright-driver");
+    }
+
     private static string GetDriverPath()
     {
-        string dir = Path.Combine(Path.GetDirectoryName(typeof(PlaywrightInstaller).Assembly.Location) ?? AppContext.BaseDirectory, ".playwright");
-        return Path.GetFullPath(dir);
+        return Path.Combine(GetDriverRoot(), ".playwright");
     }
 
     private static string VersionFile => Path.Combine(GetDriverPath(), ".version");
@@ -59,7 +96,7 @@ internal static class PlaywrightInstaller
             // the '.playwright' folder, not to the folder itself.
             Environment.SetEnvironmentVariable(
                 "PLAYWRIGHT_DRIVER_SEARCH_PATH",
-                Path.GetDirectoryName(GetDriverPath()) ?? GetDriverPath());
+                GetDriverRoot());
             return;
         }
 
@@ -127,7 +164,6 @@ internal static class PlaywrightInstaller
         Directory.Delete(tempDir, true);
 
         File.WriteAllText(VersionFile, DriverVersion);
-        string driversRoot = Path.GetDirectoryName(baseDir) ?? baseDir;
-        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", driversRoot);
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", GetDriverRoot());
     }
 }

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -67,19 +67,54 @@ internal static class PlaywrightInstaller
         using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
         client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
 
-        using var response = await client.GetAsync(url).ConfigureAwait(false);
+        using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
+
+        var total = response.Content.Headers.ContentLength ?? -1L;
+        var mem = new MemoryStream();
+        var buffer = new byte[81920];
+        var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        long read = 0;
+        int lastProgress = 0;
+        while (true)
+        {
+            int n = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+            if (n == 0)
+                break;
+            await mem.WriteAsync(buffer, 0, n).ConfigureAwait(false);
+            if (total > 0)
+            {
+                read += n;
+                int progress = (int)(read * 100 / total);
+                if (progress != lastProgress)
+                {
+                    Console.Write($"\rDownloading Playwright driver... {progress}%   ");
+                    lastProgress = progress;
+                }
+            }
+        }
+        Console.WriteLine();
+        mem.Position = 0;
 
         string baseDir = GetDriverPath();
         if (Directory.Exists(baseDir))
             Directory.Delete(baseDir, true);
-        Directory.CreateDirectory(baseDir);
 
-        using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-        using (var archive = new ZipArchive(stream))
+        string tempDir = Path.Combine(Path.GetTempPath(), "pwdriver_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        using (var archive = new ZipArchive(mem))
         {
-            archive.ExtractToDirectory(baseDir);
+            archive.ExtractToDirectory(tempDir);
         }
+
+        Directory.CreateDirectory(Path.Combine(baseDir, "node", PlatformId));
+        Directory.CreateDirectory(Path.Combine(baseDir, "package"));
+
+        File.Move(Path.Combine(tempDir, NodeExecutable), Path.Combine(baseDir, "node", PlatformId, NodeExecutable));
+        File.Move(Path.Combine(tempDir, "LICENSE"), Path.Combine(baseDir, "node", "LICENSE"));
+        Directory.Move(Path.Combine(tempDir, "package"), Path.Combine(baseDir, "package"));
+        Directory.Delete(tempDir, true);
 
         File.WriteAllText(VersionFile, DriverVersion);
         Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", baseDir);

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -109,11 +109,15 @@ internal static class PlaywrightInstaller
         }
 
         Directory.CreateDirectory(Path.Combine(baseDir, "node", PlatformId));
-        Directory.CreateDirectory(Path.Combine(baseDir, "package"));
 
         File.Move(Path.Combine(tempDir, NodeExecutable), Path.Combine(baseDir, "node", PlatformId, NodeExecutable));
         File.Move(Path.Combine(tempDir, "LICENSE"), Path.Combine(baseDir, "node", "LICENSE"));
-        Directory.Move(Path.Combine(tempDir, "package"), Path.Combine(baseDir, "package"));
+
+        string packageSrc = Path.Combine(tempDir, "package");
+        string packageDest = Path.Combine(baseDir, "package");
+        if (Directory.Exists(packageDest))
+            Directory.Delete(packageDest, true);
+        Directory.Move(packageSrc, packageDest);
         Directory.Delete(tempDir, true);
 
         File.WriteAllText(VersionFile, DriverVersion);

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -88,6 +88,22 @@ internal static class PlaywrightInstaller
         return version == DriverVersion;
     }
 
+    internal static void CleanDriver()
+    {
+        string root = GetDriverRoot();
+        if (Directory.Exists(root))
+        {
+            try
+            {
+                Directory.Delete(root, true);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
     internal static async Task EnsureInstalledAsync()
     {
         if (IsDriverPresent())

--- a/Sources/PSParseHTML/PlaywrightInstaller.cs
+++ b/Sources/PSParseHTML/PlaywrightInstaller.cs
@@ -80,6 +80,7 @@ internal static class PlaywrightInstaller
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         long read = 0;
         int lastProgress = 0;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         while (true)
         {
             int n = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
@@ -92,7 +93,8 @@ internal static class PlaywrightInstaller
                 int progress = (int)(read * 100 / total);
                 if (progress != lastProgress)
                 {
-                    Console.Write($"\rDownloading Playwright driver... {progress}%   ");
+                    double speed = read / 1024d / 1024d / sw.Elapsed.TotalSeconds;
+                    Console.Write($"\rDownloading Playwright driver... {progress}% ({speed:F1} MB/s)");
                     lastProgress = progress;
                 }
             }


### PR DESCRIPTION
## Summary
- install Playwright driver on demand
- load Playwright assets before launching browsers
- reference compression libs for .NET Framework

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684bcbe7fe6c832ea27fdc7055a9f055