### PR TITLE
Implement optional OutFile for Save-HTMLScreenshot

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -38,8 +38,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     public BrowserSession? Session { get; set; }
 
     /// <summary>File path for the screenshot.</summary>
-    [Parameter(Mandatory = true, Position = 1)]
-    public string OutFile { get; set; } = string.Empty;
+    [Parameter(Position = 1)]
+    public string? OutFile { get; set; }
 
     /// <summary>Browser engine to use for rendering.</summary>
     [Parameter(ParameterSetName = ParameterSetDefault)]
@@ -101,6 +101,19 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         BrowserSession? session = Session ?? (BrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+
+        if (string.IsNullOrWhiteSpace(OutFile)) {
+            if (Open.IsPresent) {
+                OutFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".png");
+            } else {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException("OutFile is required unless -Open is specified."),
+                    "MissingOutFile",
+                    ErrorCategory.InvalidArgument,
+                    null));
+                return;
+            }
+        }
 
         switch (ParameterSetName) {
             case ParameterSetClip:
@@ -167,10 +180,14 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
         }
 
         if (Open.IsPresent) {
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
-                FileName = FileUtilities.ResolvePath(OutFile),
-                UseShellExecute = true,
-            });
+            try {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
+                    FileName = FileUtilities.ResolvePath(OutFile),
+                    UseShellExecute = true,
+                });
+            } catch (System.Exception ex) {
+                WriteVerbose($"Failed to open file '{OutFile}': {ex.Message}");
+            }
         }
     }
 }

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -22,4 +22,14 @@ Describe 'Save-HTMLScreenshot' {
         Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50 -Selector '#loaded'
         (Test-Path $outfile) | Should -BeTrue
     }
+
+    It 'Defaults to temp file when using -Open without OutFile' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $before = Get-ChildItem ([System.IO.Path]::GetTempPath()) -Filter '*.png' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        $beforeTime = if ($before) { $before.LastWriteTime } else { [datetime]::MinValue }
+        Save-HTMLScreenshot -Url $uri -Open -Selector '#loaded'
+        $after = Get-ChildItem ([System.IO.Path]::GetTempPath()) -Filter '*.png' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        $after.LastWriteTime | Should -BeGreaterThan $beforeTime
+    }
 }


### PR DESCRIPTION
## Summary
- make `OutFile` optional in `Save-HTMLScreenshot`
- create temp file when `-Open` is used without `OutFile`
- handle failure to open screenshot gracefully
- test screenshot behaviour with default temp file

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684be850b974832e960823b3241400d7