### PR TITLE
Add Visible & SlowMo options for Playwright

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -42,6 +42,7 @@
   - `Open-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
   - `Start-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
+- `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
 - `Save-HTMLPdf` - generate a PDF of a rendered page
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
@@ -124,6 +125,7 @@ Chromium 136.0.7103.25 (playwright build v1169) downloaded to C:\Users\USER\AppD
 
 Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if needed.
 Use `-Full` to capture the entire document, `-Open` to automatically view the image, specify `-Delay` or `-Selector` to wait for dynamic content, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
+Use `-Visible` to see the browser window and `-SlowMo` to slow down actions for easier debugging.
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -40,6 +40,16 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetFile)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public SwitchParameter Visible { get; set; }
+
+    /// <summary>Slow down Playwright actions by the specified milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int SlowMo { get; set; } = 0;
+
     /// <summary>Include elements hidden from view.</summary>
     [Parameter]
     public SwitchParameter IncludeHidden { get; set; }
@@ -107,7 +117,9 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     Clean.IsPresent,
                     user,
                     pass,
-                    form).ConfigureAwait(false)) {
+                    form,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false)) {
                     list = await HtmlBrowserRenderer.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;
@@ -119,7 +131,9 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     Clean.IsPresent,
                     null,
                     null,
-                    null).ConfigureAwait(false)) {
+                    null,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false)) {
                     list = await HtmlBrowserRenderer.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -77,6 +77,15 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter NoDefault { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
+    [Parameter]
+    public SwitchParameter Visible { get; set; }
+
+    /// <summary>Slow down Playwright actions by the specified milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int SlowMo { get; set; } = 0;
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
@@ -102,16 +111,18 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 Clean.IsPresent,
                 user,
                 pass,
-                form).ConfigureAwait(false);
+                form,
+                headless: !Visible.IsPresent,
+                slowMo: SlowMo).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             string outPath = FileUtilities.ResolvePath(OutFile);
-            await HtmlBrowserRenderer.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
+            await HtmlBrowserRenderer.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowserRenderer.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form).ConfigureAwait(false);
+            string html = await HtmlBrowserRenderer.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -40,6 +40,15 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetDefault)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    public SwitchParameter Visible { get; set; }
+
+    /// <summary>Slow down Playwright actions by the specified milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int SlowMo { get; set; } = 0;
+
     /// <summary>Optional filter applied to download URLs or file names.</summary>
     [Parameter]
     public string? Filter { get; set; }
@@ -58,7 +67,9 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
                 FileUtilities.ResolvePath(Path),
                 Browser,
                 Clean.IsPresent,
-                Filter).ConfigureAwait(false)
+                Filter,
+                headless: !Visible.IsPresent,
+                slowMo: SlowMo).ConfigureAwait(false)
         };
 
         WriteObject(files.ToArray(), true);

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
@@ -43,6 +43,16 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetFile)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public SwitchParameter Visible { get; set; }
+
+    /// <summary>Slow down Playwright actions by the specified milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int SlowMo { get; set; } = 0;
+
     /// <summary>Open the PDF after saving.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
@@ -169,7 +179,9 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
                     FooterTemplate,
                     PreferCssPageSize.IsPresent,
                     outline: false,
-                    tagged: false).ConfigureAwait(false);
+                    tagged: false,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false);
                 break;
             default:
                 await HtmlBrowserRenderer.SavePagePdfAsync(
@@ -195,7 +207,9 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
                     FooterTemplate,
                     PreferCssPageSize.IsPresent,
                     outline: false,
-                    tagged: false).ConfigureAwait(false);
+                    tagged: false,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false);
                 break;
         }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -55,6 +55,15 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetFileClip)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
+    [Parameter]
+    public SwitchParameter Visible { get; set; }
+
+    /// <summary>Slow down Playwright actions by the specified milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int SlowMo { get; set; } = 0;
+
     /// <summary>Open the screenshot after saving.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
@@ -128,7 +137,9 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     X,
                     Y,
                     Width,
-                    Height).ConfigureAwait(false);
+                    Height,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false);
                 break;
             case ParameterSetFileClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
@@ -142,7 +153,9 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     X,
                     Y,
                     Width,
-                    Height).ConfigureAwait(false);
+                    Height,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false);
                 break;
             case ParameterSetSessionClip:
                 await HtmlBrowserRenderer.CaptureScreenshotAsync(
@@ -175,7 +188,9 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Clean.IsPresent,
                     Full.IsPresent,
                     Delay,
-                    Selector).ConfigureAwait(false);
+                    Selector,
+                    headless: !Visible.IsPresent,
+                    slowMo: SlowMo).ConfigureAwait(false);
                 break;
         }
 

--- a/Sources/PSParseHTML/HtmlBrowserRenderer.cs
+++ b/Sources/PSParseHTML/HtmlBrowserRenderer.cs
@@ -44,7 +44,9 @@ public static class HtmlBrowserRenderer {
         bool clean,
         string? username,
         string? password,
-        FormLoginOptions? formLogin) {
+        FormLoginOptions? formLogin,
+        bool headless = true,
+        int slowMo = 0) {
         if (clean) {
             CleanInstallDir();
         }
@@ -59,7 +61,10 @@ public static class HtmlBrowserRenderer {
             _ => playwright.Chromium,
         };
 
-        var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions {
+            Headless = headless,
+            SlowMo = slowMo
+        });
         BrowserNewContextOptions? contextOptions = null;
         if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
             contextOptions = new BrowserNewContextOptions {
@@ -103,8 +108,10 @@ public static class HtmlBrowserRenderer {
         bool clean = false,
         string? username = null,
         string? password = null,
-        FormLoginOptions? formLogin = null)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin);
+        FormLoginOptions? formLogin = null,
+        bool headless = true,
+        int slowMo = 0)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -125,14 +132,18 @@ public static class HtmlBrowserRenderer {
         bool clean = false,
         string? username = null,
         string? password = null,
-        FormLoginOptions? formLogin = null) {
+        FormLoginOptions? formLogin = null,
+        bool headless = true,
+        int slowMo = 0) {
         await using BrowserSession session = await OpenSessionAsync(
             url,
             browser,
             clean,
             username,
             password,
-            formLogin).ConfigureAwait(false);
+            formLogin,
+            headless,
+            slowMo).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -142,16 +153,18 @@ public static class HtmlBrowserRenderer {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(
+public static async Task SavePageContentAsync(
         string url,
         string path,
         BrowserEngine browser = BrowserEngine.Chromium,
         bool clean = false,
         string? username = null,
         string? password = null,
-        FormLoginOptions? formLogin = null) {
+        FormLoginOptions? formLogin = null,
+        bool headless = true,
+        int slowMo = 0) {
         string fullPath = FileUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin).ConfigureAwait(false);
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 
@@ -183,14 +196,18 @@ public static async Task CaptureScreenshotAsync(
     int? clipHeight = null,
     string? username = null,
     string? password = null,
-    FormLoginOptions? formLogin = null) {
+    FormLoginOptions? formLogin = null,
+    bool headless = true,
+    int slowMo = 0) {
         await using BrowserSession session = await OpenSessionAsync(
             url,
             browser,
             clean,
             username,
             password,
-            formLogin).ConfigureAwait(false);
+            formLogin,
+            headless,
+            slowMo).ConfigureAwait(false);
 
         string fullPath = FileUtilities.ResolvePath(path);
         await CaptureScreenshotAsync(
@@ -242,7 +259,7 @@ public static async Task CaptureScreenshotAsync(
     /// <summary>
     /// Saves a PDF of the specified page URL to disk.
     /// </summary>
-    public static async Task SavePagePdfAsync(
+public static async Task SavePagePdfAsync(
         string url,
         string path,
         BrowserEngine browser = BrowserEngine.Chromium,
@@ -268,14 +285,18 @@ public static async Task CaptureScreenshotAsync(
         bool tagged = false,
         string? username = null,
         string? password = null,
-        FormLoginOptions? formLogin = null) {
+        FormLoginOptions? formLogin = null,
+        bool headless = true,
+        int slowMo = 0) {
         await using BrowserSession session = await OpenSessionAsync(
             url,
             browser,
             clean,
             username,
             password,
-            formLogin).ConfigureAwait(false);
+            formLogin,
+            headless,
+            slowMo).ConfigureAwait(false);
 
         await SavePagePdfAsync(
             session.Page,
@@ -370,19 +391,23 @@ public static async Task CaptureScreenshotAsync(
     /// <param name="clean">Reinstall the browser runtime.</param>
     /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
     /// <returns>Paths of downloaded files.</returns>
-    public static async Task<List<string>> SavePageDownloadsAsync(
+public static async Task<List<string>> SavePageDownloadsAsync(
         string url,
         string directory,
         BrowserEngine browser = BrowserEngine.Chromium,
         bool clean = false,
-        string? filter = null) {
+        string? filter = null,
+        bool headless = true,
+        int slowMo = 0) {
         await using BrowserSession session = await OpenSessionAsync(
             url,
             browser,
             clean,
             null,
             null,
-            null).ConfigureAwait(false);
+            null,
+            headless,
+            slowMo).ConfigureAwait(false);
         var page = session.Page;
         string dir = FileUtilities.ResolvePath(directory);
         return await SavePageDownloadsAsync(page, dir, filter).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- allow running Playwright browsers in headed mode via `Visible` switch
- add `SlowMo` parameter to slow down Playwright actions
- wire new parameters through HtmlBrowserRenderer helpers
- document `Visible` and `SlowMo` in README

## Testing
- `dotnet build --no-restore` *(fails: reference assemblies missing)*
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: `Save-HTMLScreenshot` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf023188c832e89bb6bc0655f9fb4