### PR TITLE
Fix example table pipeline order

### DIFF
--- a/Examples/Example-Table-CovidCasesAustralia.ps1
+++ b/Examples/Example-Table-CovidCasesAustralia.ps1
@@ -2,9 +2,8 @@
 
 $HTML = Invoke-HTMLRendering -Url 'https://infogram.com/daily-summary-of-covid-19-in-australia-1hzj4on55vpp2pw'
 
-$Tables1 | Format-List
-
 $Tables1 = ConvertFrom-HtmlTable -Content $HTML -IncludeMetadata
+$Tables1 | Format-List
 $Tables1[0].Data | Format-Table -AutoSize
 
 $Tables1[1].Data | Format-Table


### PR DESCRIPTION
## Summary
- fix Example-Table-CovidCasesAustralia.ps1 to parse tables before formatting

## Testing
- `pwsh -NoLogo -NoProfile -File PSParseHTML.Tests.ps1` *(fails: Save-HTMLScreenshot not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_684c4b8bef94832e8bb60d5bf895f8b0