### PR TITLE
Add example for skipping table footer

### DIFF
--- a/Examples/Example-ConvertFromTableWithFooter.ps1
+++ b/Examples/Example-ConvertFromTableWithFooter.ps1
@@ -1,1 +1,7 @@
-﻿
+﻿Import-Module './PSParseHTML.psd1' -Force
+
+$Path = Join-Path $PSScriptRoot 'Input\easy_table_with_footer.html'
+$Content = Get-Content -LiteralPath $Path -Raw
+
+$Tables = ConvertFrom-HtmlTable -Content $Content -SkipFooter
+$Tables[0] | Format-Table -AutoSize


### PR DESCRIPTION
## Summary
- populate Example-ConvertFromTableWithFooter.ps1 to show using `ConvertFrom-HtmlTable -SkipFooter`

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4b862750832e94f160047079aa56