### PR TITLE
Fix OptimizeHTML02 example

### DIFF
--- a/Examples/Example-OptimizeHTML02.ps1
+++ b/Examples/Example-OptimizeHTML02.ps1
@@ -1,3 +1,3 @@
 ﻿Import-Module .\PSParseHTML.psd1 -Force
 
-Optimize-HTML -Content $HTML -File $PSScriptRoot\Output\Example.Wikipedia.html -OutputFile $PSScriptRoot\Output\Example.WikipediaMinimized.html
+Optimize-HTML -File $PSScriptRoot\Output\Example.Wikipedia.html -OutputFile $PSScriptRoot\Output\Example.WikipediaMinimized.html


### PR DESCRIPTION
## Summary
- correct `Example-OptimizeHTML02.ps1` to only use `-File` and `-OutputFile`

## Testing
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command ./PSParseHTML.Tests.ps1` *(fails: `Save-HTMLScreenshot` not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_684c4b78a108832ebc95a166c0317cca