### PR TITLE
Fix close session examples

### DIFF
--- a/Examples/Example-Screenshot3.ps1
+++ b/Examples/Example-Screenshot3.ps1
@@ -15,4 +15,4 @@ $Session = Invoke-HTMLRendering @invokeHTMLRenderingSplat
 Save-HTMLScreenshot -Session $Session -OutFile "$PSScriptRoot\Output\EvotecPageAdmin1.png" -Open
 $null = $Session.Page.GotoAsync('https://evotec.xyz/wp-admin/edit.php')
 Save-HTMLScreenshot -Session $Session -OutFile "$PSScriptRoot\Output\EvotecPageAdmin2.png" -Open
-$null = [PSParseHTML.HtmlBrowserRenderer]::CloseSessionAsync($Session).GetAwaiter().GetResult()
+$null = Close-HTMLSession -Session $Session

--- a/Examples/Example-ScreenshotWithSession.ps1
+++ b/Examples/Example-ScreenshotWithSession.ps1
@@ -12,4 +12,4 @@ Save-HTMLScreenshot -Session $session -OutFile "$PSScriptRoot\Output\secure.png"
 # navigate to downloads using the same session
 $session.Page.GotoAsync('https://example.com/downloads') | Out-Null
 Save-HTMLAttachment -Session $session -Path "$PSScriptRoot\Output" -Filter '.pdf'
-[PSParseHTML.HtmlBrowserRenderer]::CloseSessionAsync($session).GetAwaiter().GetResult()
+[PSParseHTML.HtmlBrowser]::CloseSessionAsync($session).GetAwaiter().GetResult()


### PR DESCRIPTION
## Summary
- use `Close-HTMLSession` or `HtmlBrowser.CloseSessionAsync` instead of `HtmlBrowserRenderer.CloseSessionAsync`
- keep screenshot examples functional

## Testing
- `dotnet test Sources/PSParseHTML.sln`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684c4b735380832e928948c06606072f