### PR TITLE
Improve single-table and single-list handling

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
@@ -74,8 +74,18 @@ public sealed class CmdletConvertFromHtmlList : PSCmdlet {
         bool returnObjects = !AsString.IsPresent;
 
         if (IncludeMetadata.IsPresent) {
+            var listObjects = new List<PSObject>();
             foreach (var result in results) {
-                WriteObject(CreateListObject(result, returnObjects));
+                listObjects.Add(CreateListObject(result, returnObjects));
+            }
+
+            if (listObjects.Count == 1) {
+                WriteObject(listObjects[0], false);
+            } else {
+                if (listObjects.Count > 1) {
+                    WriteWarning($"{listObjects.Count} lists found. Returning array of lists.");
+                }
+                WriteObject(listObjects.ToArray(), false);
             }
         } else {
             var output = new List<object>();
@@ -86,7 +96,14 @@ public sealed class CmdletConvertFromHtmlList : PSCmdlet {
                     output.Add(result.Items.Select(i => string.Join(TagPlaceholder, i)).ToArray());
                 }
             }
-            WriteObject(output.ToArray(), false);
+            if (output.Count == 1) {
+                WriteObject(output[0], false);
+            } else {
+                if (output.Count > 1) {
+                    WriteWarning($"{output.Count} lists found. Returning array of lists.");
+                }
+                WriteObject(output.ToArray(), false);
+            }
         }
     }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -133,7 +133,15 @@ public sealed class CmdletConvertFromHtmlTable : PSCmdlet {
             foreach (var tableResult in detailedTables) {
                 tableArrays.Add(ConvertRows(tableResult.Data));
             }
-            WriteObject(tableArrays.ToArray(), false);
+
+            if (tableArrays.Count == 1) {
+                WriteObject(tableArrays[0], false);
+            } else {
+                if (tableArrays.Count > 1) {
+                    WriteWarning($"{tableArrays.Count} tables found. Returning array of tables.");
+                }
+                WriteObject(tableArrays.ToArray(), false);
+            }
         }
     }
 

--- a/Tests/ConvertFrom-HtmlList.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlList.Tests.ps1
@@ -33,4 +33,12 @@ Describe 'ConvertFrom-HtmlList' {
         $lists[0].Data[0].Column1 | Should -Be 'Item1'
         $lists[0].ListIndex | Should -Be 0
     }
+
+    It 'Returns single list when only one list is found' {
+        $path = Join-Path $PSScriptRoot 'Documents/single_list.html'
+        $content = Get-Content -LiteralPath $path -Raw
+        $list = ConvertFrom-HtmlList -Content $content -Engine AgilityPack
+        $list.Count | Should -Be 2
+        $list[0].Column1 | Should -Be 'Item1'
+    }
 }

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -10,10 +10,7 @@
         $Path = Join-Path $PSScriptRoot 'Documents/polish_table.html'
         $Content = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 
-        $Tables = ConvertFrom-HtmlTable -Content $Content -Engine AgilityPack
-        $Tables.Count | Should -Be 1
-
-        $Table = $Tables[0]
+        $Table = ConvertFrom-HtmlTable -Content $Content -Engine AgilityPack
         $Table.Count | Should -Be 2
 
         # Check that Polish characters are preserved correctly
@@ -27,10 +24,7 @@
         $Path = Join-Path $PSScriptRoot 'Documents/polish_table.html'
         $Content = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 
-        $Tables = ConvertFrom-HtmlTable -Content $Content -Engine AngleSharp
-        $Tables.Count | Should -Be 1
-
-        $Table = $Tables[0]
+        $Table = ConvertFrom-HtmlTable -Content $Content -Engine AngleSharp
         $Table.Count | Should -Be 2
 
         # Check that Polish characters are preserved correctly

--- a/Tests/Documents/single_list.html
+++ b/Tests/Documents/single_list.html
@@ -1,0 +1,4 @@
+<ul>
+  <li>Item1</li>
+  <li>Item2</li>
+</ul>


### PR DESCRIPTION
## Summary
- return a single object when only one table or list is detected
- warn when returning arrays for multiple results
- adjust tests for new behavior and add new single list sample

## Testing
- `pwsh -NoLogo -Command 'Get-Date'`
- `timeout 30s pwsh -NoLogo -NonInteractive -Command './PSParseHTML.Tests.ps1'` *(fails: network modules needed)*

------
https://chatgpt.com/codex/tasks/task_e_684c6807cd30832ebaf36887e95516d9