### PR TITLE
Add Playwright interaction cmdlets

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLInput', 'Set-HTMLChecked', 'Set-HTMLSelectOption', 'Invoke-HTMLClick')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlClick.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlClick.cs
@@ -1,0 +1,53 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that performs a mouse click on an element.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Invoke, "HTMLClick")]
+[OutputType(typeof(HtmlBrowserSession))]
+public sealed class CmdletInvokeHtmlClick : AsyncPSCmdlet {
+    /// <summary>Existing browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>CSS selector of the element to click.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Selector { get; set; } = string.Empty;
+
+    /// <summary>Mouse button to use.</summary>
+    [Parameter]
+    public MouseButton Button { get; set; } = MouseButton.Left;
+
+    /// <summary>Number of clicks.</summary>
+    [Parameter]
+    public int ClickCount { get; set; } = 1;
+
+    /// <summary>Keyboard modifiers.</summary>
+    [Parameter]
+    public KeyboardModifier[]? Modifier { get; set; }
+
+    /// <summary>Timeout in milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int Timeout { get; set; } = 30000;
+
+    /// <summary>Return the session object.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.MouseClickAsync(session, Selector, Button, ClickCount, Modifier, Timeout).ConfigureAwait(false);
+
+        if (PassThru.IsPresent) {
+            WriteObject(session);
+        }
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlChecked.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlChecked.cs
@@ -1,0 +1,44 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that sets the checked state of a checkbox or radio button.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "HTMLChecked")]
+[OutputType(typeof(HtmlBrowserSession))]
+public sealed class CmdletSetHtmlChecked : AsyncPSCmdlet {
+    /// <summary>Existing browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>CSS selector of the element.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Selector { get; set; } = string.Empty;
+
+    /// <summary>Uncheck the element instead of checking it.</summary>
+    [Parameter]
+    public SwitchParameter Uncheck { get; set; }
+
+    /// <summary>Timeout in milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int Timeout { get; set; } = 30000;
+
+    /// <summary>Return the session object.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.SetCheckedAsync(session, Selector, !Uncheck.IsPresent, Timeout).ConfigureAwait(false);
+
+        if (PassThru.IsPresent) {
+            WriteObject(session);
+        }
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlInput.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlInput.cs
@@ -1,0 +1,44 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that fills text into an input element.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "HTMLInput")]
+[OutputType(typeof(HtmlBrowserSession))]
+public sealed class CmdletSetHtmlInput : AsyncPSCmdlet {
+    /// <summary>Existing browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>CSS selector of the input element.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Selector { get; set; } = string.Empty;
+
+    /// <summary>Value to enter.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>Timeout in milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int Timeout { get; set; } = 30000;
+
+    /// <summary>Return the session object.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.FillInputAsync(session, Selector, Value, Timeout).ConfigureAwait(false);
+
+        if (PassThru.IsPresent) {
+            WriteObject(session);
+        }
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlSelectOption.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlSelectOption.cs
@@ -1,0 +1,44 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that selects options from a &lt;select&gt; element.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "HTMLSelectOption")]
+[OutputType(typeof(HtmlBrowserSession))]
+public sealed class CmdletSetHtmlSelectOption : AsyncPSCmdlet {
+    /// <summary>Existing browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>CSS selector of the &lt;select&gt; element.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Selector { get; set; } = string.Empty;
+
+    /// <summary>Option values to select.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public string[] Value { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Timeout in milliseconds.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int Timeout { get; set; } = 30000;
+
+    /// <summary>Return the session object.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.SelectOptionAsync(session, Selector, Value, Timeout).ConfigureAwait(false);
+
+        if (PassThru.IsPresent) {
+            WriteObject(session);
+        }
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Forms.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Forms.cs
@@ -1,0 +1,78 @@
+using Microsoft.Playwright;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Helper methods for interacting with form elements using Playwright.
+/// </summary>
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Fills text into an element identified by a CSS selector.
+    /// </summary>
+    public static async Task FillInputAsync(IPage page, string selector, string value, int timeout = 30000) {
+        var locator = page.Locator(selector);
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
+        await locator.FillAsync(value, new LocatorFillOptions { Timeout = timeout });
+    }
+
+    /// <summary>
+    /// Fills text into an element using an existing browser session.
+    /// </summary>
+    public static Task FillInputAsync(HtmlBrowserSession session, string selector, string value, int timeout = 30000)
+        => FillInputAsync(session.Page, selector, value, timeout);
+
+    /// <summary>
+    /// Sets the checked state of a checkbox or radio input.
+    /// </summary>
+    public static async Task SetCheckedAsync(IPage page, string selector, bool check = true, int timeout = 30000) {
+        var locator = page.Locator(selector);
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
+        if (check) {
+            await locator.CheckAsync(new LocatorCheckOptions { Timeout = timeout });
+        } else {
+            await locator.UncheckAsync(new LocatorUncheckOptions { Timeout = timeout });
+        }
+    }
+
+    /// <summary>
+    /// Sets the checked state of a checkbox or radio input using a session.
+    /// </summary>
+    public static Task SetCheckedAsync(HtmlBrowserSession session, string selector, bool check = true, int timeout = 30000)
+        => SetCheckedAsync(session.Page, selector, check, timeout);
+
+    /// <summary>
+    /// Selects option values from a &lt;select&gt; element.
+    /// </summary>
+    public static async Task SelectOptionAsync(IPage page, string selector, IEnumerable<string> values, int timeout = 30000) {
+        var locator = page.Locator(selector);
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
+        await locator.SelectOptionAsync(values, new LocatorSelectOptionOptions { Timeout = timeout });
+    }
+
+    /// <summary>
+    /// Selects option values from a &lt;select&gt; element using a session.
+    /// </summary>
+    public static Task SelectOptionAsync(HtmlBrowserSession session, string selector, IEnumerable<string> values, int timeout = 30000)
+        => SelectOptionAsync(session.Page, selector, values, timeout);
+
+    /// <summary>
+    /// Performs a mouse click on an element.
+    /// </summary>
+    public static async Task MouseClickAsync(IPage page, string selector, MouseButton button = MouseButton.Left, int clickCount = 1, KeyboardModifier[]? modifiers = null, int timeout = 30000) {
+        var locator = page.Locator(selector);
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
+        var options = new LocatorClickOptions { Button = button, ClickCount = clickCount, Timeout = timeout };
+        if (modifiers != null) {
+            options.Modifiers = modifiers;
+        }
+        await locator.ClickAsync(options);
+    }
+
+    /// <summary>
+    /// Performs a mouse click on an element using a session.
+    /// </summary>
+    public static Task MouseClickAsync(HtmlBrowserSession session, string selector, MouseButton button = MouseButton.Left, int clickCount = 1, KeyboardModifier[]? modifiers = null, int timeout = 30000)
+        => MouseClickAsync(session.Page, selector, button, clickCount, modifiers, timeout);
+}


### PR DESCRIPTION
## Summary
- add helper methods for text input, form controls and mouse actions
- expose new cmdlets to PowerShell module

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684c76cd6e18832e98c89049fc214da2