### PR TITLE
Add video recording cmdlets

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -44,6 +44,7 @@
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
 - `Save-HTMLPdf` - generate a PDF of a rendered page
+- `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a video file
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -1,0 +1,96 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Start, "HTMLVideoRecording", DefaultParameterSetName = ParameterSetSession)]
+[OutputType(typeof(HtmlBrowserSession))]
+public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
+    private const string ParameterSetUrl = "Url";
+    private const string ParameterSetFile = "File";
+    private const string ParameterSetSession = "Session";
+
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetUrl)]
+    public string Url { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetFile)]
+    [Alias("File")]
+    public string? Path { get; set; }
+
+    [Parameter(Position = 0, ParameterSetName = ParameterSetSession, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string OutFile { get; set; } = string.Empty;
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public HtmlBrowserEngine Browser { get; set; } = HtmlBrowserEngine.Chromium;
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public SwitchParameter Clean { get; set; }
+
+    [Parameter]
+    public SwitchParameter Visible { get; set; }
+
+    [Parameter]
+    [ValidateRange(0,int.MaxValue)]
+    public int SlowMo { get; set; } = 0;
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int Width { get; set; } = 800;
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int Height { get; set; } = 600;
+
+    [Parameter]
+    public SwitchParameter NoDefault { get; set; }
+
+    protected override async Task ProcessRecordAsync() {
+        string target;
+        HtmlBrowserEngine engine = Browser;
+        bool clean = Clean.IsPresent;
+        bool headless = !Visible.IsPresent;
+
+        switch (ParameterSetName) {
+            case ParameterSetSession:
+                Session ??= (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+                    ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+                target = Session.Page.Url;
+                engine = Session.Browser.BrowserType.Name switch {
+                    "firefox" => HtmlBrowserEngine.Firefox,
+                    "webkit" => HtmlBrowserEngine.Webkit,
+                    _ => HtmlBrowserEngine.Chromium
+                };
+                break;
+            case ParameterSetFile:
+                target = new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri;
+                break;
+            default:
+                target = Url;
+                break;
+        }
+
+        HtmlBrowserSession sess = await HtmlBrowser.StartVideoRecordingAsync(
+            target,
+            OutFile,
+            engine,
+            clean,
+            null,
+            null,
+            null,
+            headless,
+            SlowMo,
+            Width,
+            Height).ConfigureAwait(false);
+
+        if (!NoDefault.IsPresent) {
+            SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
+        }
+
+        WriteObject(sess);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
@@ -1,0 +1,21 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Stop, "HTMLVideoRecording")]
+public sealed class CmdletStopHtmlVideoRecording : AsyncPSCmdlet {
+    [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
+    public HtmlBrowserSession Session { get; set; } = null!;
+
+    [Parameter]
+    public string? OutFile { get; set; }
+
+    protected override async Task ProcessRecordAsync() {
+        await HtmlBrowser.StopVideoRecordingAsync(Session, OutFile).ConfigureAwait(false);
+        object? defaultSession = GetVariableValue("PSParseHTML_DefaultSession");
+        if (defaultSession is HtmlBrowserSession sess && ReferenceEquals(sess, Session)) {
+            SessionState.PSVariable.Remove("PSParseHTML_DefaultSession");
+        }
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML;
+
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Starts a new browser session with video recording enabled.
+    /// </summary>
+    public static Task<HtmlBrowserSession> StartVideoRecordingAsync(
+        string url,
+        string videoPath,
+        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
+        bool clean = false,
+        string? username = null,
+        string? password = null,
+        HtmlFormLogin? formLogin = null,
+        bool headless = true,
+        int slowMo = 0,
+        int width = 800,
+        int height = 600)
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height);
+
+    /// <summary>
+    /// Stops the specified video recording session and saves the file.
+    /// </summary>
+    public static async Task StopVideoRecordingAsync(HtmlBrowserSession session, string? path = null) {
+        string outFile = path ?? session.VideoPath ?? throw new System.ArgumentException("Output path required.");
+        IVideo? video = session.Video;
+        if (video != null) {
+            await session.Context.CloseAsync().ConfigureAwait(false);
+            string fullPath = HtmlUtilities.ResolvePath(outFile);
+            await video.SaveAsAsync(fullPath).ConfigureAwait(false);
+            await session.Browser.CloseAsync().ConfigureAwait(false);
+            session.Playwright.Dispose();
+        } else {
+            await session.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -14,7 +14,18 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Creates a new Playwright browser session and navigates to the specified URL.
     /// </summary>
-    private static async Task<HtmlBrowserSession> CreatePageAsync(string url, HtmlBrowserEngine browser, bool clean, string? username, string? password, HtmlFormLogin? formLogin, bool headless = true, int slowMo = 0) {
+    private static async Task<HtmlBrowserSession> CreatePageAsync(
+        string url,
+        HtmlBrowserEngine browser,
+        bool clean,
+        string? username,
+        string? password,
+        HtmlFormLogin? formLogin,
+        bool headless = true,
+        int slowMo = 0,
+        string? videoPath = null,
+        int videoWidth = 800,
+        int videoHeight = 600) {
         if (clean) {
             CleanInstallDir();
         }
@@ -46,6 +57,12 @@ public static partial class HtmlBrowser {
         }
         contextOptions ??= new BrowserNewContextOptions();
         contextOptions.IgnoreHTTPSErrors = true;
+        if (!string.IsNullOrEmpty(videoPath)) {
+            string dir = Path.GetDirectoryName(HtmlUtilities.ResolvePath(videoPath))!;
+            Directory.CreateDirectory(dir);
+            contextOptions.RecordVideoDir = dir;
+            contextOptions.RecordVideoSize = new RecordVideoSize { Width = videoWidth, Height = videoHeight };
+        }
 
         var context = await browserInstance.NewContextAsync(contextOptions);
         var page = await context.NewPageAsync();
@@ -66,14 +83,30 @@ public static partial class HtmlBrowser {
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-        return new HtmlBrowserSession(playwright, browserInstance, context, page);
+        IVideo? video = null;
+        if (!string.IsNullOrEmpty(videoPath)) {
+            video = page.Video;
+        }
+
+        return new HtmlBrowserSession(playwright, browserInstance, context, page, video, videoPath);
     }
 
     /// <summary>
     /// Creates a new <see cref="HtmlBrowserSession"/> and navigates to the specified URL.
     /// </summary>
-    public static Task<HtmlBrowserSession> OpenSessionAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo);
+    public static Task<HtmlBrowserSession> OpenSessionAsync(
+        string url,
+        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
+        bool clean = false,
+        string? username = null,
+        string? password = null,
+        HtmlFormLogin? formLogin = null,
+        bool headless = true,
+        int slowMo = 0,
+        string? videoPath = null,
+        int videoWidth = 800,
+        int videoHeight = 600)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight);
 
     /// <summary>
     /// Disposes the specified browser session.

--- a/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
@@ -12,15 +12,19 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     public IBrowser Browser { get; }
     public IBrowserContext Context { get; }
     public IPage Page { get; }
+    public IVideo? Video { get; }
+    public string? VideoPath { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HtmlBrowserSession"/> class.
     /// /// </summary>
-    public HtmlBrowserSession(IPlaywright playwright, IBrowser browser, IBrowserContext context, IPage page) {
+    public HtmlBrowserSession(IPlaywright playwright, IBrowser browser, IBrowserContext context, IPage page, IVideo? video = null, string? videoPath = null) {
         Playwright = playwright;
         Browser = browser;
         Context = context;
         Page = page;
+        Video = video;
+        VideoPath = videoPath;
     }
 
     /// <summary>

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -1,0 +1,11 @@
+describe 'HTML Video Recording' {
+    it 'Records a short video' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $out = Join-Path $TestDrive 'video.webm'
+        $session = Start-HTMLVideoRecording -Url $uri -OutFile $out -Width 320 -Height 240
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        Stop-HTMLVideoRecording -Session $session
+        (Test-Path $out) | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- support video recording in HtmlBrowser with Start/Stop methods
- expose new Start-HTMLVideoRecording and Stop-HTMLVideoRecording cmdlets
- export new cmdlets in module manifest
- document new feature in README
- test start/stop recording

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684c77754930832eac57653409486b40