### PR TITLE
Fix default session support for Stop-HTMLVideoRecording

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,9 +1,5 @@
 ﻿## ChangeLog
 
-#### 1.0.3 - 2025.06.13
-- `Stop-HTMLVideoRecording` now respects the default session when `-Session` is not specified.
-- Added test coverage for default video recording workflow.
-
 #### 1.0.2 - 2024.02.19
 - Better detection of net framework
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 ﻿## ChangeLog
 
+#### 1.0.3 - 2025.06.13
+- `Stop-HTMLVideoRecording` now respects the default session when `-Session` is not specified.
+- Added test coverage for default video recording workflow.
+
 #### 1.0.2 - 2024.02.19
 - Better detection of net framework
 

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
@@ -3,18 +3,22 @@ using System.Threading.Tasks;
 
 namespace PSParseHTML.PowerShell;
 
+
 [Cmdlet(VerbsLifecycle.Stop, "HTMLVideoRecording")]
 public sealed class CmdletStopHtmlVideoRecording : AsyncPSCmdlet {
-    [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
-    public HtmlBrowserSession Session { get; set; } = null!;
+    [Parameter(ValueFromPipeline = true, Position = 0)]
+    public HtmlBrowserSession? Session { get; set; }
 
     [Parameter]
     public string? OutFile { get; set; }
 
     protected override async Task ProcessRecordAsync() {
-        await HtmlBrowser.StopVideoRecordingAsync(Session, OutFile).ConfigureAwait(false);
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.StopVideoRecordingAsync(session, OutFile).ConfigureAwait(false);
         object? defaultSession = GetVariableValue("PSParseHTML_DefaultSession");
-        if (defaultSession is HtmlBrowserSession sess && ReferenceEquals(sess, Session)) {
+        if (defaultSession is HtmlBrowserSession sess && ReferenceEquals(sess, session)) {
             SessionState.PSVariable.Remove("PSParseHTML_DefaultSession");
         }
     }

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -8,4 +8,14 @@ describe 'HTML Video Recording' {
         Stop-HTMLVideoRecording -Session $session
         (Test-Path $out) | Should -BeTrue
     }
+
+    it 'Uses default session variable' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $out = Join-Path $TestDrive 'default.webm'
+        $null = Start-HTMLVideoRecording -Url $uri -OutFile $out -Width 320 -Height 240
+        Invoke-HTMLNavigation -Url $uri
+        Stop-HTMLVideoRecording
+        (Test-Path $out) | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- support default sessions when stopping video recording
- test default session workflow for video recording
- note default session behaviour in the changelog

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684c84a192dc832eb1c611ecd12ab327