### PR TITLE
Limit HTML video recording to webm files

### DIFF
--- a/Examples/Example-Video.ps1
+++ b/Examples/Example-Video.ps1
@@ -15,6 +15,8 @@ $invokeHTMLRenderingSplat = @{
 # Default session is always used unless you specify NoSession
 $null = Open-HTMLSession @invokeHTMLRenderingSplat
 
+Save-HTMLScreenshot -OutFile "$PSScriptRoot\Output\WP1.png" -Open
+
 Start-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.webm"
 
 Get-HTMLInteractable -Filter "Media" -IncludeHidden | Format-Table

--- a/Examples/Example-Video.ps1
+++ b/Examples/Example-Video.ps1
@@ -15,8 +15,8 @@ $invokeHTMLRenderingSplat = @{
 # Default session is always used unless you specify NoSession
 $null = Open-HTMLSession @invokeHTMLRenderingSplat
 
-Start-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.mp4"
+Start-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.webm"
 
 Get-HTMLInteractable -Filter "Media" -IncludeHidden | Format-Table
 
-Stop-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.mp4"
+Stop-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.webm"

--- a/README.MD
+++ b/README.MD
@@ -44,7 +44,7 @@
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
 - `Save-HTMLPdf` - generate a PDF of a rendered page
-- `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a video file
+- `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a `.webm` video file
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -21,6 +21,12 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     public HtmlBrowserSession? Session { get; set; }
 
     [Parameter(Mandatory = true)]
+    [ValidateScript({
+        if ([System.IO.Path]::GetExtension($_) -ne '.webm') {
+            throw [System.ArgumentException] 'Only .webm files are supported.'
+        }
+        $true
+    })]
     public string OutFile { get; set; } = string.Empty;
 
     [Parameter(ParameterSetName = ParameterSetUrl)]

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
@@ -10,6 +10,12 @@ public sealed class CmdletStopHtmlVideoRecording : AsyncPSCmdlet {
     public HtmlBrowserSession? Session { get; set; }
 
     [Parameter]
+    [ValidateScript({
+        if ($_ -and [System.IO.Path]::GetExtension($_) -ne '.webm') {
+            throw [System.ArgumentException] 'Only .webm files are supported.'
+        }
+        $true
+    })]
     public string? OutFile { get; set; }
 
     protected override async Task ProcessRecordAsync() {


### PR DESCRIPTION
## Summary
- enforce WEBM file extension for Start/Stop-HTMLVideoRecording cmdlets
- use WEBM extension in the example script
- mention WEBM format in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "./PSParseHTML.Tests.ps1"` *(fails: Start-HTMLVideoRecording not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a4e7bd0832e87ff01e2de342a1f