### PR TITLE
Allow recording login in video sessions

### DIFF
--- a/Examples/Example-Video.ps1
+++ b/Examples/Example-Video.ps1
@@ -2,19 +2,21 @@ Import-Module .\PSParseHTML.psd1 -Force
 
 $Credentials = [PSCredential]::new('TestUser', (ConvertTo-SecureString -String $Env:WordpressPassword -AsPlainText -Force))
 
-$videoParams = @{
+$sessionParams = @{
     Url              = 'https://evotec.xyz/wp-admin'
     LoginUrl         = 'https://evotec.xyz/wp-login.php'
     UsernameSelector = '#user_login'
     PasswordSelector = '#user_pass'
     SubmitSelector   = '#wp-submit'
     Credential       = $Credentials
-    OutFile          = "$PSScriptRoot\Output\WP1.webm"
+    Session          = $true
 }
 
-$session = Start-HTMLVideoRecording @videoParams
+$session = Open-HTMLSession @sessionParams
 
 Save-HTMLScreenshot -Session $session -OutFile "$PSScriptRoot\Output\WP1.png" -Open
+
+$session = Start-HTMLVideoRecording -Session $session -OutFile "$PSScriptRoot\Output\WP1.webm"
 
 Get-HTMLInteractable -Session $session -Filter "Media" -IncludeHidden | Format-Table
 

--- a/Examples/Example-Video.ps1
+++ b/Examples/Example-Video.ps1
@@ -13,11 +13,22 @@ $sessionParams = @{
 }
 
 $session = Open-HTMLSession @sessionParams
-
-Save-HTMLScreenshot -Session $session -OutFile "$PSScriptRoot\Output\WP1.png" -Open
-
 $session = Start-HTMLVideoRecording -Session $session -OutFile "$PSScriptRoot\Output\WP1.webm"
-
+# Get interactable elements from the session
 Get-HTMLInteractable -Session $session -Filter "Media" -IncludeHidden | Format-Table
-
+# # We should add new cmdlet that will navigate to the page we tell it to navigate to
+Invoke-HTMLNavigation -Session $Session -Url 'https://evotec.xyz/wp-admin/edit.php'
+# # We should add new cmdlet that will navigate to the page we tell it to navigate to
+Invoke-HTMLNavigation -Session $Session -Url 'https://evotec.xyz/wp-admin/edit.php'
+# # Navigate to plugins page and save screenshot
+Invoke-HTMLNavigation -Session $Session -Url 'https://evotec.xyz/wp-admin/edit.php?post_type=page'
+# # Navigate to team members page and save screenshot
+Invoke-HTMLNavigation -Session $Session -Url 'https://evotec.xyz/wp-admin/edit.php?post_type=thegem_team_person'
+# Navigate to profile page, this should error because of multiple elements with the same text
+Invoke-HTMLNavigation -Session $Session -Text "Profile"
+# Be exact with the text to avoid multiple elements with the same text
+Invoke-HTMLNavigation -Session $Session -Text "Profile" -Exact
+# Close video recording
 Stop-HTMLVideoRecording -Session $session
+# Close the session using new cmdlet alias (Stop-HTMLSession)
+Close-HTMLSession -Session $Session | Out-Null

--- a/Examples/Example-Video.ps1
+++ b/Examples/Example-Video.ps1
@@ -1,24 +1,21 @@
-﻿Import-Module .\PSParseHTML.psd1 -Force
+Import-Module .\PSParseHTML.psd1 -Force
 
 $Credentials = [PSCredential]::new('TestUser', (ConvertTo-SecureString -String $Env:WordpressPassword -AsPlainText -Force))
-# Use Invoke-HTMLRendering to create a session, alternatively use Start-HTMLSession, Open-HTMLSession which should be an alias for Invoke-HTMLRendering
-$invokeHTMLRenderingSplat = @{
+
+$videoParams = @{
     Url              = 'https://evotec.xyz/wp-admin'
     LoginUrl         = 'https://evotec.xyz/wp-login.php'
     UsernameSelector = '#user_login'
     PasswordSelector = '#user_pass'
     SubmitSelector   = '#wp-submit'
     Credential       = $Credentials
-    Session          = $true
+    OutFile          = "$PSScriptRoot\Output\WP1.webm"
 }
-# When using Session, you can either save $Session variable or use the "default" session
-# Default session is always used unless you specify NoSession
-$null = Open-HTMLSession @invokeHTMLRenderingSplat
 
-Save-HTMLScreenshot -OutFile "$PSScriptRoot\Output\WP1.png" -Open
+$session = Start-HTMLVideoRecording @videoParams
 
-Start-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.webm"
+Save-HTMLScreenshot -Session $session -OutFile "$PSScriptRoot\Output\WP1.png" -Open
 
-Get-HTMLInteractable -Filter "Media" -IncludeHidden | Format-Table
+Get-HTMLInteractable -Session $session -Filter "Media" -IncludeHidden | Format-Table
 
-Stop-HTMLVideoRecording -OutFile "$PSScriptRoot\Output\WP1.webm"
+Stop-HTMLVideoRecording -Session $session

--- a/README.MD
+++ b/README.MD
@@ -47,6 +47,7 @@
 - `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a `.webm` video file
   - supports the same authentication options as `Invoke-HTMLRendering` so you can capture the login process
   - can start recording from an existing session to capture later steps
+  - the temporary Playwright video file is cleaned up automatically when stopping
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file

--- a/README.MD
+++ b/README.MD
@@ -46,6 +46,7 @@
 - `Save-HTMLPdf` - generate a PDF of a rendered page
 - `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a `.webm` video file
   - supports the same authentication options as `Invoke-HTMLRendering` so you can capture the login process
+  - can start recording from an existing session to capture later steps
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file

--- a/README.MD
+++ b/README.MD
@@ -45,6 +45,7 @@
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
 - `Save-HTMLPdf` - generate a PDF of a rendered page
 - `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a `.webm` video file
+  - supports the same authentication options as `Invoke-HTMLRendering` so you can capture the login process
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -119,7 +119,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     pass,
                     form,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false)) {
+                    slowMo: SlowMo,
+                    storageStatePath: null).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;
@@ -133,7 +134,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     null,
                     null,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false)) {
+                    slowMo: SlowMo,
+                    storageStatePath: null).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -113,7 +113,8 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 pass,
                 form,
                 headless: !Visible.IsPresent,
-                slowMo: SlowMo).ConfigureAwait(false);
+                slowMo: SlowMo,
+                storageStatePath: null).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -127,18 +127,26 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
             }
         }
 
-        HtmlBrowserSession sess = await HtmlBrowser.StartVideoRecordingAsync(
-            target,
-            OutFile,
-            engine,
-            clean,
-            user,
-            pass,
-            form,
-            headless,
-            SlowMo,
-            Width,
-            Height).ConfigureAwait(false);
+        HtmlBrowserSession sess = ParameterSetName == ParameterSetSession
+            ? await HtmlBrowser.StartVideoRecordingAsync(
+                Session!,
+                OutFile,
+                headless,
+                SlowMo,
+                Width,
+                Height).ConfigureAwait(false)
+            : await HtmlBrowser.StartVideoRecordingAsync(
+                target,
+                OutFile,
+                engine,
+                clean,
+                user,
+                pass,
+                form,
+                headless,
+                SlowMo,
+                Width,
+                Height).ConfigureAwait(false);
 
         if (!NoDefault.IsPresent) {
             SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -49,12 +49,6 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     public string? SubmitSelector { get; set; }
 
     [Parameter(Mandatory = true)]
-    [ValidateScript({
-        if ([System.IO.Path]::GetExtension($_) -ne '.webm') {
-            throw [System.ArgumentException] 'Only .webm files are supported.'
-        }
-        $true
-    })]
     public string OutFile { get; set; } = string.Empty;
 
     [Parameter(ParameterSetName = ParameterSetUrl)]
@@ -84,6 +78,9 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     public SwitchParameter NoDefault { get; set; }
 
     protected override async Task ProcessRecordAsync() {
+        if (System.IO.Path.GetExtension(OutFile) != ".webm") {
+            throw new PSArgumentException("Only .webm files are supported.", nameof(OutFile));
+        }
         string target;
         HtmlBrowserEngine engine = Browser;
         bool clean = Clean.IsPresent;

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -20,6 +20,34 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     [Parameter(Position = 0, ParameterSetName = ParameterSetSession, ValueFromPipeline = true)]
     public HtmlBrowserSession? Session { get; set; }
 
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public PSCredential? Credential { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? Username { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? Password { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? LoginUrl { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? UsernameSelector { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? PasswordSelector { get; set; }
+
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? SubmitSelector { get; set; }
+
     [Parameter(Mandatory = true)]
     [ValidateScript({
         if ([System.IO.Path]::GetExtension($_) -ne '.webm') {
@@ -60,6 +88,9 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
         HtmlBrowserEngine engine = Browser;
         bool clean = Clean.IsPresent;
         bool headless = !Visible.IsPresent;
+        string? user = null;
+        string? pass = null;
+        HtmlFormLogin? form = null;
 
         switch (ParameterSetName) {
             case ParameterSetSession:
@@ -80,14 +111,30 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 break;
         }
 
+        if (ParameterSetName != ParameterSetSession) {
+            user = Credential?.UserName ?? Username;
+            pass = Credential?.GetNetworkCredential().Password ?? Password;
+            if (!string.IsNullOrEmpty(LoginUrl) &&
+                !string.IsNullOrEmpty(UsernameSelector) &&
+                !string.IsNullOrEmpty(PasswordSelector) &&
+                !string.IsNullOrEmpty(SubmitSelector)) {
+                form = new HtmlFormLogin {
+                    LoginUrl = LoginUrl!,
+                    UsernameSelector = UsernameSelector!,
+                    PasswordSelector = PasswordSelector!,
+                    SubmitSelector = SubmitSelector!
+                };
+            }
+        }
+
         HtmlBrowserSession sess = await HtmlBrowser.StartVideoRecordingAsync(
             target,
             OutFile,
             engine,
             clean,
-            null,
-            null,
-            null,
+            user,
+            pass,
+            form,
             headless,
             SlowMo,
             Width,

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
@@ -10,15 +10,13 @@ public sealed class CmdletStopHtmlVideoRecording : AsyncPSCmdlet {
     public HtmlBrowserSession? Session { get; set; }
 
     [Parameter]
-    [ValidateScript({
-        if ($_ -and [System.IO.Path]::GetExtension($_) -ne '.webm') {
-            throw [System.ArgumentException] 'Only .webm files are supported.'
-        }
-        $true
-    })]
     public string? OutFile { get; set; }
 
     protected override async Task ProcessRecordAsync() {
+        if (!string.IsNullOrEmpty(OutFile) && System.IO.Path.GetExtension(OutFile) != ".webm") {
+            throw new PSArgumentException("Only .webm files are supported.", nameof(OutFile));
+        }
+
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
 

--- a/Sources/PSParseHTML/PSParseHTML.csproj
+++ b/Sources/PSParseHTML/PSParseHTML.csproj
@@ -1,38 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<Company>Evotec</Company>
-		<Authors>Przemyslaw Klys</Authors>
-		<VersionPrefix>2.0.0</VersionPrefix>
-		<TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
-		<AssemblyName>PSParseHTML</AssemblyName>
-		<AssemblyTitle>PSParseHTML</AssemblyTitle>
-		<Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
-                <LangVersion>latest</LangVersion>
-                <Nullable>enable</Nullable>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Company>Evotec</Company>
+        <Authors>Przemyslaw Klys</Authors>
+        <VersionPrefix>2.0.0</VersionPrefix>
+        <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
+        <AssemblyName>PSParseHTML</AssemblyName>
+        <AssemblyTitle>PSParseHTML</AssemblyTitle>
+        <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
 
-  <ItemGroup>
+    <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.3.0" />
-		<PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.154" />
-		<PackageReference Include="AngleSharp.Diffing" Version="1.0.0" />
-		<PackageReference Include="AngleSharp.Js" Version="1.0.0-beta.43" />
-		<PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
-		<PackageReference Include="Jsbeautifier" Version="0.0.1" />
+        <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.154" />
+        <PackageReference Include="AngleSharp.Diffing" Version="1.0.0" />
+        <PackageReference Include="AngleSharp.Js" Version="1.0.0-beta.43" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+        <PackageReference Include="Jsbeautifier" Version="0.0.1" />
         <PackageReference Include="NUglify" Version="1.21.15" />
         <PackageReference Include="PreMailer.Net" Version="2.7.0" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
-  </ItemGroup>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Using Include="System.Net.Http" />
-  </ItemGroup>
+    <ItemGroup>
+        <Using Include="System.Net.Http" />
+    </ItemGroup>
 
 
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
-		<DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>
-	</PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
+        <DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -30,7 +30,8 @@ public static partial class HtmlBrowser {
             null,
             null,
             headless,
-            slowMo).ConfigureAwait(false);
+            slowMo,
+            null).ConfigureAwait(false);
         var page = session.Page;
         string dir = HtmlUtilities.ResolvePath(directory);
         return await SavePageDownloadsAsync(page, dir, filter).ConfigureAwait(false);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -52,7 +52,8 @@ public static partial class HtmlBrowser {
             password,
             formLogin,
             headless,
-            slowMo).ConfigureAwait(false);
+            slowMo,
+            null).ConfigureAwait(false);
 
         await SavePagePdfAsync(
             session.Page,

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -51,7 +51,8 @@ public static partial class HtmlBrowser {
             password,
             formLogin,
             headless,
-            slowMo).ConfigureAwait(false);
+            slowMo,
+            null).ConfigureAwait(false);
 
         string fullPath = HtmlUtilities.ResolvePath(path);
         await CaptureScreenshotAsync(

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -69,6 +69,16 @@ public static partial class HtmlBrowser {
             await session.Context.CloseAsync().ConfigureAwait(false);
             string fullPath = HtmlUtilities.ResolvePath(outFile);
             await video.SaveAsAsync(fullPath).ConfigureAwait(false);
+            try {
+                string tempPath = await video.PathAsync().ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(tempPath) &&
+                    !string.Equals(tempPath, fullPath, System.StringComparison.OrdinalIgnoreCase) &&
+                    System.IO.File.Exists(tempPath)) {
+                    System.IO.File.Delete(tempPath);
+                }
+            } catch {
+                // Ignore cleanup errors
+            }
             await session.Browser.CloseAsync().ConfigureAwait(false);
             session.Playwright.Dispose();
         } else {

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -20,7 +20,44 @@ public static partial class HtmlBrowser {
         int slowMo = 0,
         int width = 800,
         int height = 600)
-        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height);
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null);
+
+    /// <summary>
+    /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
+    /// </summary>
+    public static async Task<HtmlBrowserSession> StartVideoRecordingAsync(
+        HtmlBrowserSession session,
+        string videoPath,
+        bool headless = true,
+        int slowMo = 0,
+        int width = 800,
+        int height = 600) {
+        string temp = Path.GetTempFileName();
+        await session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = temp }).ConfigureAwait(false);
+        string url = session.Page.Url;
+        HtmlBrowserEngine engine = session.Browser.BrowserType.Name switch {
+            "firefox" => HtmlBrowserEngine.Firefox,
+            "webkit" => HtmlBrowserEngine.Webkit,
+            _ => HtmlBrowserEngine.Chromium
+        };
+
+        HtmlBrowserSession newSession = await OpenSessionAsync(
+            url,
+            engine,
+            clean: false,
+            username: null,
+            password: null,
+            formLogin: null,
+            headless: headless,
+            slowMo: slowMo,
+            videoPath: videoPath,
+            videoWidth: width,
+            videoHeight: height,
+            storageStatePath: temp).ConfigureAwait(false);
+
+        File.Delete(temp);
+        return newSession;
+    }
 
     /// <summary>
     /// Stops the specified video recording session and saves the file.

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -25,7 +25,8 @@ public static partial class HtmlBrowser {
         int slowMo = 0,
         string? videoPath = null,
         int videoWidth = 800,
-        int videoHeight = 600) {
+        int videoHeight = 600,
+        string? storageStatePath = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -57,6 +58,9 @@ public static partial class HtmlBrowser {
         }
         contextOptions ??= new BrowserNewContextOptions();
         contextOptions.IgnoreHTTPSErrors = true;
+        if (!string.IsNullOrEmpty(storageStatePath)) {
+            contextOptions.StorageStatePath = storageStatePath;
+        }
         if (!string.IsNullOrEmpty(videoPath)) {
             string dir = Path.GetDirectoryName(HtmlUtilities.ResolvePath(videoPath))!;
             Directory.CreateDirectory(dir);
@@ -105,8 +109,9 @@ public static partial class HtmlBrowser {
         int slowMo = 0,
         string? videoPath = null,
         int videoWidth = 800,
-        int videoHeight = 600)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight);
+        int videoHeight = 600,
+        string? storageStatePath = null)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -130,7 +135,8 @@ public static partial class HtmlBrowser {
             password,
             formLogin,
             headless,
-            slowMo).ConfigureAwait(false);
+            slowMo,
+            null).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -18,4 +18,15 @@ describe 'HTML Video Recording' {
         Stop-HTMLVideoRecording
         (Test-Path $out) | Should -BeTrue
     }
+
+    it 'Starts recording from existing session' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        $out = Join-Path $TestDrive 'existing.webm'
+        $record = Start-HTMLVideoRecording -Session $session -OutFile $out -Width 320 -Height 240
+        Invoke-HTMLNavigation -Session $record -Url $uri
+        Stop-HTMLVideoRecording -Session $record
+        (Test-Path $out) | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- expose authentication parameters on `Start-HTMLVideoRecording`
- update example script to start the recorded session with credentials
- document that video recording supports authentication

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: `Save-HTMLScreenshot` not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_684c8df97348832e8ef8b03f73117127