### PR TITLE
Add code coverage badge

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           name: coverage-reports-windows
           path: '**/coverage.cobertura.xml'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: '**/coverage.cobertura.xml'
 
   test-ubuntu:
     name: 'Ubuntu'
@@ -83,6 +87,10 @@ jobs:
         with:
           name: test-results-ubuntu
           path: '**/*.trx'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: '**/coverage.cobertura.xml'
 
   test-macos:
     name: 'macOS'
@@ -111,3 +119,7 @@ jobs:
         with:
           name: test-results-macos
           path: '**/*.trx'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: '**/coverage.cobertura.xml'

--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,6 @@
 ﻿<p align="center">
   <a href="https://github.com/EvotecIT/PSParseHTML/actions/workflows/dotnet-tests.yml"><img src="https://github.com/EvotecIT/PSParseHTML/actions/workflows/dotnet-tests.yml/badge.svg"></a>
+  <a href="https://codecov.io/gh/EvotecIT/PSParseHTML"><img src="https://codecov.io/gh/EvotecIT/PSParseHTML/branch/v2-speedygonzales/graph/badge.svg"></a>
   <a href="https://www.powershellgallery.com/packages/PSParseHTML"><img src="https://img.shields.io/powershellgallery/p/PSParseHTML.svg"></a>
   <a href="https://github.com/EvotecIT/PSParseHTML"><img src="https://img.shields.io/github/languages/top/evotecit/PSParseHTML.svg"></a>
   <a href="https://github.com/EvotecIT/PSParseHTML"><img src="https://img.shields.io/github/languages/code-size/evotecit/PSParseHTML.svg"></a>


### PR DESCRIPTION
## Summary
- expose a Codecov coverage badge in README
- push coverage files to Codecov from dotnet tests

## Testing
- `pwsh ./PSParseHTML.Tests.ps1`
- `dotnet test Sources/PSParseHTML.sln`


------
https://chatgpt.com/codex/tasks/task_e_684dce225624832eaa385dc9df8deef6