### PR TITLE
Fix null reference paths

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -78,7 +78,7 @@ public sealed class CmdletConvertHtmlToText : PSCmdlet {
         };
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, text);
         } else {
             WriteObject(text);

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
@@ -37,7 +37,7 @@ public sealed class CmdletFormatCss : PSCmdlet {
             : HtmlFormatter.FormatCss(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, formatted);
         } else {
             WriteObject(formatted);

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
@@ -85,7 +85,7 @@ public sealed class CmdletFormatHtml : PSCmdlet {
             RemoveEmptyBlocks.IsPresent);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -40,7 +40,7 @@ public sealed class CmdletFormatJavaScript : PSCmdlet {
             : HtmlFormatter.FormatJavaScript(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, formatted);
         } else {
             WriteObject(formatted);

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -120,7 +120,7 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutFile);
+            string outPath = HtmlUtilities.ResolvePath(OutFile!);
             await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
         } else {
             string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
@@ -36,7 +36,7 @@ public sealed class CmdletOptimizeCss : PSCmdlet {
             : HtmlOptimizer.OptimizeCss(Css);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -108,7 +108,7 @@ public sealed class CmdletOptimizeEmail : PSCmdlet {
 
         errorAction = (ActionPreference)SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = MyInvocation.BoundParameters["ErrorAction"].ToString();
+            string errorActionString = MyInvocation.BoundParameters["ErrorAction"]?.ToString() ?? string.Empty;
             if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
                 errorAction = actionPreference;
             }

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -39,7 +39,7 @@ public sealed class CmdletOptimizeHtml : PSCmdlet {
             ? HtmlOptimizer.OptimizeHtmlFile(HtmlUtilities.ResolvePath(Path), CSSDecodeEscapes.IsPresent)
             : HtmlOptimizer.OptimizeHtml(Content, CSSDecodeEscapes.IsPresent);
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
@@ -36,7 +36,7 @@ public sealed class CmdletOptimizeJavaScript : PSCmdlet {
             : HtmlOptimizer.OptimizeJavaScript(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             File.WriteAllText(outPath, optimized);
         } else {
             WriteObject(optimized);

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -128,7 +128,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     Url,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Browser,
                     Clean.IsPresent,
                     false,
@@ -144,7 +144,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetFileClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Browser,
                     Clean.IsPresent,
                     false,
@@ -160,7 +160,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     false,
                     Delay,
                     Selector,
@@ -172,7 +172,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionDefault:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Full.IsPresent,
                     Delay,
                     Selector).ConfigureAwait(false);
@@ -183,7 +183,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     : Url;
                 await HtmlBrowser.CaptureScreenshotAsync(
                     target,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Browser,
                     Clean.IsPresent,
                     Full.IsPresent,
@@ -197,7 +197,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
         if (Open.IsPresent) {
             try {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
-                    FileName = HtmlUtilities.ResolvePath(OutFile),
+                    FileName = HtmlUtilities.ResolvePath(OutFile!),
                     UseShellExecute = true,
                 });
             } catch (System.Exception ex) {

--- a/Sources/PSParseHTML.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/Sources/PSParseHTML.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -62,16 +62,16 @@ public class InternalLoggerPowerShell {
     /// <param name="e"></param>
     private void Logger_OnVerboseMessage(object? sender, LogEventArgs e) {
         if (e.Args != null && e.Args.Length > 0) {
-            WriteVerbose(e.Message, e.Args);
+            WriteVerbose(e.Message ?? string.Empty, e.Args);
         } else {
-            WriteVerbose(e.Message);
+            WriteVerbose(e.Message ?? string.Empty);
         }
     }
     private void Logger_OnDebugMessage(object? sender, LogEventArgs e) {
-        WriteDebug(e.Message);
+        WriteDebug(e.Message ?? string.Empty);
     }
     private void Logger_OnWarningMessage(object? sender, LogEventArgs e) {
-        WriteWarning(e.Message);
+        WriteWarning(e.Message ?? string.Empty);
     }
     private void Logger_OnErrorMessage(object? sender, LogEventArgs e) {
         ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), "1", ErrorCategory.NotSpecified, null);
@@ -108,7 +108,7 @@ public class InternalLoggerPowerShell {
         WriteProgress(progressRecord);
     }
     private void Logger_OnInformationMessage(object? sender, LogEventArgs e) {
-        WriteInformation(e.Message);
+        WriteInformation(e.Message ?? string.Empty);
     }
 
     private void WriteVerbose(string message) {

--- a/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
+++ b/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
@@ -33,10 +33,13 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
     /// <returns></returns>
     private static Assembly? MyResolveEventHandler(object? sender, ResolveEventArgs args) {
         var libDirectory = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
-        var directoriesToSearch = new List<string> { libDirectory };
+        var directoriesToSearch = new List<string>();
 
-        if (Directory.Exists(libDirectory)) {
-            directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+        if (!string.IsNullOrEmpty(libDirectory)) {
+            directoriesToSearch.Add(libDirectory);
+            if (Directory.Exists(libDirectory)) {
+                directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+            }
         }
 
         var requestedAssemblyName = new AssemblyName(args.Name).Name + ".dll";

--- a/Sources/PSParseHTML/HtmlParserFromList.cs
+++ b/Sources/PSParseHTML/HtmlParserFromList.cs
@@ -147,7 +147,7 @@ public static class HtmlParserFromList {
             var metadata = result.Metadata;
             metadata.ListIndex = index++;
             metadata.Id = list.Id;
-            metadata.Classes = list.GetAttributeValue("class", null);
+            metadata.Classes = list.GetAttributeValue("class", string.Empty);
             metadata.IsOrdered = list.Name.Equals("ol", StringComparison.OrdinalIgnoreCase);
             foreach (var attr in list.Attributes) {
                 metadata.Attributes[attr.Name] = attr.Value ?? string.Empty;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -105,7 +105,7 @@ public static partial class HtmlBrowser {
         bool outline = false,
         bool tagged = false) {
         if (!string.IsNullOrEmpty(selector)) {
-            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+            await page.WaitForSelectorAsync(selector!, new PageWaitForSelectorOptions { Timeout = 10000 });
         }
         if (delayMs > 0) {
             await page.WaitForTimeoutAsync(delayMs);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -81,7 +81,7 @@ public static partial class HtmlBrowser {
         int? clipWidth = null,
         int? clipHeight = null) {
         if (!string.IsNullOrEmpty(selector)) {
-            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+            await page.WaitForSelectorAsync(selector!, new PageWaitForSelectorOptions { Timeout = 10000 });
         }
         if (delayMs > 0) {
             await page.WaitForTimeoutAsync(delayMs);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -62,7 +62,8 @@ public static partial class HtmlBrowser {
             contextOptions.StorageStatePath = storageStatePath;
         }
         if (!string.IsNullOrEmpty(videoPath)) {
-            string dir = Path.GetDirectoryName(HtmlUtilities.ResolvePath(videoPath))!;
+            string resolved = HtmlUtilities.ResolvePath(videoPath);
+            string dir = Path.GetDirectoryName(resolved) ?? resolved;
             Directory.CreateDirectory(dir);
             contextOptions.RecordVideoDir = dir;
             contextOptions.RecordVideoSize = new RecordVideoSize { Width = videoWidth, Height = videoHeight };

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -51,8 +51,8 @@ public static partial class HtmlBrowser {
         if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
             contextOptions = new BrowserNewContextOptions {
                 HttpCredentials = new HttpCredentials {
-                    Username = username,
-                    Password = password
+                    Username = username!,
+                    Password = password!
                 }
             };
         }
@@ -62,7 +62,7 @@ public static partial class HtmlBrowser {
             contextOptions.StorageStatePath = storageStatePath;
         }
         if (!string.IsNullOrEmpty(videoPath)) {
-            string resolved = HtmlUtilities.ResolvePath(videoPath);
+            string resolved = HtmlUtilities.ResolvePath(videoPath!);
             string dir = Path.GetDirectoryName(resolved) ?? resolved;
             Directory.CreateDirectory(dir);
             contextOptions.RecordVideoDir = dir;
@@ -169,7 +169,7 @@ public static partial class HtmlBrowser {
             return await page.ContentAsync().ConfigureAwait(false);
         }
 
-        var locator = page.Locator(selector);
+        var locator = page.Locator(selector!);
         await locator.WaitForAsync();
 
         if (asText) {

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -44,7 +44,7 @@ public class PreMailerClient {
         try {
             string cssContent = Options.Css ?? string.Empty;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
-                string cssPath = HtmlUtilities.ResolvePath(Options.CssFilePath);
+                string cssPath = HtmlUtilities.ResolvePath(Options.CssFilePath!);
                 if (!File.Exists(cssPath)) {
                     throw new FileNotFoundException($"CSS file not found: {Options.CssFilePath}", cssPath);
                 }


### PR DESCRIPTION
## Summary
- avoid potential null path when saving video recording
- ensure CssFilePath resolved safely

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: write EPIPE)*

------
https://chatgpt.com/codex/tasks/task_e_684dcf6651b4832e9ceb1c6bea935e49