### PR TITLE
Use shared HttpClient for list parsing

### DIFF
--- a/Sources/PSParseHTML/HtmlParserFromList.cs
+++ b/Sources/PSParseHTML/HtmlParserFromList.cs
@@ -3,6 +3,7 @@ using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -11,6 +12,7 @@ namespace PSParseHTML;
 /// Provides functionality for parsing HTML lists.
 /// </summary>
 public static class HtmlParserFromList {
+    private static readonly HttpClient _sharedClient = new();
     /// <summary>
     /// Extracts list items from HTML using AngleSharp with metadata.
     /// </summary>
@@ -97,7 +99,7 @@ public static class HtmlParserFromList {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
-        HttpClient http = client ?? new HttpClient();
+        HttpClient http = client ?? _sharedClient;
         string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
         return ParseListsWithAngleSharpDetailed(content, tagPlaceholder);
     }
@@ -211,7 +213,7 @@ public static class HtmlParserFromList {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
-        HttpClient http = client ?? new HttpClient();
+        HttpClient http = client ?? _sharedClient;
         string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
         return ParseListsWithHtmlAgilityPackDetailed(content, tagPlaceholder);
     }


### PR DESCRIPTION
## Summary
- fix HttpClient usage in HtmlParserFromList

## Testing
- `dotnet test Sources/PSParseHTML.sln --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684dd52c220c832ea71b671fba2e60ac