### PR TITLE
Add Invoke-HTMLScript cmdlet

### DIFF
--- a/Examples/Example-InvokeHtmlScript.ps1
+++ b/Examples/Example-InvokeHtmlScript.ps1
@@ -1,0 +1,12 @@
+Import-Module ../PSParseHTML.psd1 -Force
+
+$path = Join-Path $PSScriptRoot '../Tests/Documents/dynamic.html'
+$uri = [System.Uri]::new($path).AbsoluteUri
+$session = Invoke-HTMLRendering -Url $uri -Session
+
+# Add a new paragraph element
+Invoke-HTMLScript -Session $session -Script "document.body.insertAdjacentHTML('beforeend','<p id=\"demo\">Hello</p>');" | Out-Null
+
+# Retrieve the text we just added
+$text = Invoke-HTMLScript -Session $session -Script "document.getElementById('demo').textContent"
+$text

--- a/Examples/Example-InvokeHtmlScript.ps1
+++ b/Examples/Example-InvokeHtmlScript.ps1
@@ -5,7 +5,7 @@ $uri = [System.Uri]::new($path).AbsoluteUri
 $session = Invoke-HTMLRendering -Url $uri -Session
 
 # Add a new paragraph element
-$addScript = 'document.body.insertAdjacentHTML("beforeend","<p id=""demo"">Hello</p>");'
+$addScript = 'document.body.insertAdjacentHTML("beforeend", "<p id=\"demo\">Hello</p>");'
 Invoke-HTMLScript -Session $session -Script $addScript | Out-Null
 
 # Retrieve the text we just added

--- a/Examples/Example-InvokeHtmlScript.ps1
+++ b/Examples/Example-InvokeHtmlScript.ps1
@@ -5,8 +5,10 @@ $uri = [System.Uri]::new($path).AbsoluteUri
 $session = Invoke-HTMLRendering -Url $uri -Session
 
 # Add a new paragraph element
-Invoke-HTMLScript -Session $session -Script "document.body.insertAdjacentHTML('beforeend','<p id=\"demo\">Hello</p>');" | Out-Null
+$addScript = 'document.body.insertAdjacentHTML("beforeend","<p id=""demo"">Hello</p>");'
+Invoke-HTMLScript -Session $session -Script $addScript | Out-Null
 
 # Retrieve the text we just added
-$text = Invoke-HTMLScript -Session $session -Script "document.getElementById('demo').textContent"
+$getScript = 'document.getElementById("demo").textContent'
+$text = Invoke-HTMLScript -Session $session -Script $getScript
 $text

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLScript', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Get-HTMLCookie', 'Set-HTMLCookie')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Invoke-HTMLScript', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Unregister-HTMLRoute')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Invoke-HTMLScript', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Unregister-HTMLRoute')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -51,6 +51,7 @@
   - the temporary Playwright video file is cleaned up automatically when stopping
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
+- `Invoke-HTMLScript` - run custom JavaScript against a session
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file
 - `Close-HTMLSession` - dispose an active browser session (`Stop-HTMLSession` alias)
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlScript.cs
@@ -1,0 +1,28 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that runs arbitrary JavaScript in an existing browser session.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Invoke, "HTMLScript")]
+[OutputType(typeof(object))]
+public sealed class CmdletInvokeHtmlScript : AsyncPSCmdlet {
+    /// <summary>Browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>JavaScript code to execute.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Script { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        object? result = await HtmlBrowser.EvaluateAsync<object>(session, Script).ConfigureAwait(false);
+        WriteObject(result);
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Helper methods for running JavaScript in a browser session.
+/// </summary>
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Executes arbitrary JavaScript in the context of the current page.
+    /// </summary>
+    /// <typeparam name="T">Expected return type.</typeparam>
+    /// <param name="session">Browser session.</param>
+    /// <param name="script">JavaScript code to execute.</param>
+    /// <returns>Value returned by the script.</returns>
+    public static Task<T?> EvaluateAsync<T>(HtmlBrowserSession session, string script)
+        => session.Page.EvaluateAsync<T>(script);
+}

--- a/Tests/Invoke-HTMLScript.Tests.ps1
+++ b/Tests/Invoke-HTMLScript.Tests.ps1
@@ -3,7 +3,7 @@ describe 'Invoke-HTMLScript' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $session = Invoke-HTMLRendering -Url $uri -Session
-        $add = 'document.body.insertAdjacentHTML("beforeend","<p id=""new"">Hi</p>");'
+        $add = 'document.body.insertAdjacentHTML("beforeend", "<p id=\"new\">Hi</p>");'
         Invoke-HTMLScript -Session $session -Script $add | Out-Null
         $get = 'document.getElementById("new").textContent'
         $text = Invoke-HTMLScript -Session $session -Script $get

--- a/Tests/Invoke-HTMLScript.Tests.ps1
+++ b/Tests/Invoke-HTMLScript.Tests.ps1
@@ -1,0 +1,18 @@
+describe 'Invoke-HTMLScript' {
+    it 'Manipulates the DOM and retrieves text' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        Invoke-HTMLScript -Session $session -Script "document.body.insertAdjacentHTML('beforeend','<p id=\"new\">Hi</p>');" | Out-Null
+        $text = Invoke-HTMLScript -Session $session -Script "document.getElementById('new').textContent"
+        $text | Should -Be 'Hi'
+    }
+
+    it 'Returns expression result' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        $val = Invoke-HTMLScript -Session $session -Script '2 + 3'
+        $val | Should -Be 5
+    }
+}

--- a/Tests/Invoke-HTMLScript.Tests.ps1
+++ b/Tests/Invoke-HTMLScript.Tests.ps1
@@ -3,8 +3,10 @@ describe 'Invoke-HTMLScript' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $session = Invoke-HTMLRendering -Url $uri -Session
-        Invoke-HTMLScript -Session $session -Script "document.body.insertAdjacentHTML('beforeend','<p id=\"new\">Hi</p>');" | Out-Null
-        $text = Invoke-HTMLScript -Session $session -Script "document.getElementById('new').textContent"
+        $add = 'document.body.insertAdjacentHTML("beforeend","<p id=""new"">Hi</p>");'
+        Invoke-HTMLScript -Session $session -Script $add | Out-Null
+        $get = 'document.getElementById("new").textContent'
+        $text = Invoke-HTMLScript -Session $session -Script $get
         $text | Should -Be 'Hi'
     }
 


### PR DESCRIPTION
## Summary
- expose `HtmlBrowser.EvaluateAsync<T>` for custom JavaScript execution
- create `Invoke-HTMLScript` cmdlet for running browser scripts
- document and export the new cmdlet
- add example usage
- test DOM manipulation and value return

## Testing
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_684dd58d8ba4832e8b5376604f783b44