### PR TITLE
Add proxy support to Playwright cmdlets

### DIFF
--- a/Docs/Examples/04-InterceptRequests/README.MD
+++ b/Docs/Examples/04-InterceptRequests/README.MD
@@ -1,0 +1,38 @@
+# `Register-HTMLRoute`
+
+## 📖 Summary
+
+`Register-HTMLRoute` lets you intercept network requests inside a browser session. Use it to block calls or return custom responses when testing pages.
+
+---
+
+## 💡 Example
+
+```powershell
+$page = Join-Path $PSScriptRoot 'route_page.html'
+$uri = [System.Uri]::new($page).AbsoluteUri
+$session = Start-HTMLSession -Url $uri
+
+# Return custom JSON instead of the real file
+$handler = Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock {
+    param($route)
+    $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
+        Status = 200
+        ContentType = 'application/json'
+        Body = '{"message":"mock"}'
+    }) | Out-Null
+}
+
+Invoke-HTMLNavigation -Session $session -Url $uri
+Get-HTMLContent -Session $session -Selector '#result' -AsText
+# -> 'mock'
+
+Unregister-HTMLRoute -Session $session -Pattern '**/data.json' -Handler $handler
+Close-HTMLSession -Session $session
+```
+
+To simply block a request:
+
+```powershell
+Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
+```

--- a/Examples/Example-InvokeHtmlScript.ps1
+++ b/Examples/Example-InvokeHtmlScript.ps1
@@ -1,0 +1,14 @@
+Import-Module ../PSParseHTML.psd1 -Force
+
+$path = Join-Path $PSScriptRoot '../Tests/Documents/dynamic.html'
+$uri = [System.Uri]::new($path).AbsoluteUri
+$session = Invoke-HTMLRendering -Url $uri -Session
+
+# Add a new paragraph element
+$addScript = 'document.body.insertAdjacentHTML("beforeend", "<p id=\"demo\">Hello</p>");'
+Invoke-HTMLScript -Session $session -Script $addScript | Out-Null
+
+# Retrieve the text we just added
+$getScript = 'document.getElementById("demo").textContent'
+$text = Invoke-HTMLScript -Session $session -Script $getScript
+$text

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Invoke-HTMLScript', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Unregister-HTMLRoute')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -44,6 +44,7 @@
   - `Start-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
+- `UserAgent`, `-ViewportWidth`, `-ViewportHeight` and `-DeviceScaleFactor` allow customizing the browser context
 - `Save-HTMLPdf` - generate a PDF of a rendered page
 - `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a `.webm` video file
   - supports the same authentication options as `Invoke-HTMLRendering` so you can capture the login process
@@ -51,7 +52,11 @@
   - the temporary Playwright video file is cleaned up automatically when stopping
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
+- `Invoke-HTMLScript` - run custom JavaScript against a session
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file
+- `Register-HTMLRoute`/`Unregister-HTMLRoute` - intercept requests to block or mock responses
+- `Get-HTMLCookie` - retrieve cookies from the active session
+- `Set-HTMLCookie` - add cookies to the active session
 - `Close-HTMLSession` - dispose an active browser session (`Stop-HTMLSession` alias)
 
 All cmdlets that work with files accept a `-Path` parameter (or alias) in addition to `-File`. Relative, absolute and UNC paths are resolved to full paths automatically.
@@ -90,8 +95,8 @@ Optimize-HTML -Path '.\page.html'
 Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
-Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
-
+$handler = Register-HTMLRoute -Session $session -Pattern '**/api/data' -ScriptBlock {
+Unregister-HTMLRoute -Session $session -Pattern '**/api/data' -Handler $handler
 # Render a protected page using credentials
 $cred = Get-Credential
 Invoke-HTMLRendering -Url 'https://example.com' -Credential $cred
@@ -117,6 +122,13 @@ Save-HTMLScreenshot -Session $session -OutFile '.\secure.png' -Selector '#conten
 Invoke-HTMLNavigation -Session $session -Url 'https://example.com/downloads' |
     Save-HTMLScreenshot -OutFile '.\downloads.png'
 Save-HTMLAttachment -Session $session -Path '.\Downloads'
+# Mock an API response
+$handler = Register-HTMLRoute -Session $session -Pattern '*api/data' -ScriptBlock {
+    param($route)
+    $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{ Status = 200; ContentType = 'application/json'; Body = '{"ok":true}' }) | Out-Null
+}
+Invoke-HTMLNavigation -Session $session -Url 'https://example.com/api/data'
+Unregister-HTMLRoute -Session $session -Pattern '*api/data' -Handler $handler
 Close-HTMLSession -Session $session
 ```
 
@@ -131,6 +143,7 @@ Chromium 136.0.7103.25 (playwright build v1169) downloaded to C:\Users\USER\AppD
 Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if needed.
 Use `-Full` to capture the entire document, `-Open` to automatically view the image, specify `-Delay` or `-Selector` to wait for dynamic content, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
 Use `-Visible` to see the browser window and `-SlowMo` to slow down actions for easier debugging.
+Supply `-UserAgent`, `-ViewportWidth`, `-ViewportHeight` or `-DeviceScaleFactor` to emulate different devices.
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -78,7 +78,7 @@ public sealed class CmdletConvertHtmlToText : PSCmdlet {
         };
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, text);
         } else {
             WriteObject(text);

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
@@ -37,7 +37,7 @@ public sealed class CmdletFormatCss : PSCmdlet {
             : HtmlFormatter.FormatCss(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, formatted);
         } else {
             WriteObject(formatted);

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
@@ -85,7 +85,7 @@ public sealed class CmdletFormatHtml : PSCmdlet {
             RemoveEmptyBlocks.IsPresent);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -40,7 +40,7 @@ public sealed class CmdletFormatJavaScript : PSCmdlet {
             : HtmlFormatter.FormatJavaScript(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, formatted);
         } else {
             WriteObject(formatted);

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that retrieves cookies from an active browser session.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "HTMLCookie")]
+[OutputType(typeof(HtmlCookie))]
+public sealed class CmdletGetHtmlCookie : AsyncPSCmdlet {
+    /// <summary>Browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        List<HtmlCookie> cookies = await HtmlBrowser.GetCookiesAsync(session).ConfigureAwait(false);
+        WriteObject(cookies, true);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -50,6 +50,21 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>
+    /// Proxy server address used for browser traffic.
+    /// Include protocol and port if required.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? Proxy { get; set; }
+
+    /// <summary>
+    /// Credentials used for the specified <see cref="Proxy"/> server.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Include elements hidden from view.</summary>
     [Parameter]
     public SwitchParameter IncludeHidden { get; set; }
@@ -98,6 +113,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
             case ParameterSetUrl:
                 string? user = Credential?.UserName ?? Username;
                 string? pass = Credential?.GetNetworkCredential().Password ?? Password;
+                string? proxyUser = ProxyCredential?.UserName;
+                string? proxyPass = ProxyCredential?.GetNetworkCredential().Password;
                 HtmlFormLogin? form = null;
                 if (!string.IsNullOrEmpty(LoginUrl) &&
                     !string.IsNullOrEmpty(UsernameSelector) &&
@@ -120,7 +137,10 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     form,
                     headless: !Visible.IsPresent,
                     slowMo: SlowMo,
-                    storageStatePath: null).ConfigureAwait(false)) {
+                    storageStatePath: null,
+                    proxy: Proxy,
+                    proxyUsername: proxyUser,
+                    proxyPassword: proxyPass).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;
@@ -135,7 +155,10 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     null,
                     headless: !Visible.IsPresent,
                     slowMo: SlowMo,
-                    storageStatePath: null).ConfigureAwait(false)) {
+                    storageStatePath: null,
+                    proxy: Proxy,
+                    proxyUsername: null,
+                    proxyPassword: null).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -99,6 +99,20 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [Parameter]
     public PSCredential? ProxyCredential { get; set; }
 
+    [Parameter]
+    public string? UserAgent { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportWidth { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportHeight { get; set; }
+
+    [Parameter]
+    public double? DeviceScaleFactor { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
@@ -132,13 +146,17 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 storageStatePath: null,
                 proxy: Proxy,
                 proxyUsername: proxyUser,
-                proxyPassword: proxyPass).ConfigureAwait(false);
+                proxyPassword: proxyPass,
+                userAgent: UserAgent,
+                viewportWidth: ViewportWidth,
+                viewportHeight: ViewportHeight,
+                deviceScaleFactor: (float?)DeviceScaleFactor).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutFile);
+            string outPath = HtmlUtilities.ResolvePath(OutFile!);
             await HtmlBrowser.SavePageContentAsync(
                 target,
                 outPath,
@@ -151,7 +169,11 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 SlowMo,
                 Proxy,
                 proxyUser,
-                proxyPass).ConfigureAwait(false);
+                proxyPass,
+                UserAgent,
+                ViewportWidth,
+                ViewportHeight,
+                (float?)DeviceScaleFactor).ConfigureAwait(false);
         } else {
             string html = await HtmlBrowser.GetPageContentAsync(
                 target,
@@ -164,7 +186,11 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 SlowMo,
                 Proxy,
                 proxyUser,
-                proxyPass).ConfigureAwait(false);
+                proxyPass,
+                UserAgent,
+                ViewportWidth,
+                ViewportHeight,
+                (float?)DeviceScaleFactor).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -86,10 +86,25 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>
+    /// Proxy server address used for browser traffic.
+    /// Include protocol and port if required.
+    /// </summary>
+    [Parameter]
+    public string? Proxy { get; set; }
+
+    /// <summary>
+    /// Credentials used for authenticating with the specified <see cref="Proxy"/> server.
+    /// </summary>
+    [Parameter]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
         string? pass = Credential?.GetNetworkCredential().Password ?? Password;
+        string? proxyUser = ProxyCredential?.UserName;
+        string? proxyPass = ProxyCredential?.GetNetworkCredential().Password;
         HtmlFormLogin? form = null;
         if (!string.IsNullOrEmpty(LoginUrl) && !string.IsNullOrEmpty(UsernameSelector) && !string.IsNullOrEmpty(PasswordSelector) && !string.IsNullOrEmpty(SubmitSelector)) {
             form = new HtmlFormLogin {
@@ -114,16 +129,42 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 form,
                 headless: !Visible.IsPresent,
                 slowMo: SlowMo,
-                storageStatePath: null).ConfigureAwait(false);
+                storageStatePath: null,
+                proxy: Proxy,
+                proxyUsername: proxyUser,
+                proxyPassword: proxyPass).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             string outPath = HtmlUtilities.ResolvePath(OutFile);
-            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
+            await HtmlBrowser.SavePageContentAsync(
+                target,
+                outPath,
+                Browser,
+                Clean.IsPresent,
+                user,
+                pass,
+                form,
+                !Visible.IsPresent,
+                SlowMo,
+                Proxy,
+                proxyUser,
+                proxyPass).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
+            string html = await HtmlBrowser.GetPageContentAsync(
+                target,
+                Browser,
+                Clean.IsPresent,
+                user,
+                pass,
+                form,
+                !Visible.IsPresent,
+                SlowMo,
+                Proxy,
+                proxyUser,
+                proxyPass).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlScript.cs
@@ -1,0 +1,28 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that runs arbitrary JavaScript in an existing browser session.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Invoke, "HTMLScript")]
+[OutputType(typeof(object))]
+public sealed class CmdletInvokeHtmlScript : AsyncPSCmdlet {
+    /// <summary>Browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>JavaScript code to execute.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Script { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        object? result = await HtmlBrowser.EvaluateAsync<object>(session, Script).ConfigureAwait(false);
+        WriteObject(result);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
@@ -36,7 +36,7 @@ public sealed class CmdletOptimizeCss : PSCmdlet {
             : HtmlOptimizer.OptimizeCss(Css);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -108,7 +108,7 @@ public sealed class CmdletOptimizeEmail : PSCmdlet {
 
         errorAction = (ActionPreference)SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = MyInvocation.BoundParameters["ErrorAction"].ToString();
+            string errorActionString = MyInvocation.BoundParameters["ErrorAction"]?.ToString() ?? string.Empty;
             if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
                 errorAction = actionPreference;
             }

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -39,7 +39,7 @@ public sealed class CmdletOptimizeHtml : PSCmdlet {
             ? HtmlOptimizer.OptimizeHtmlFile(HtmlUtilities.ResolvePath(Path), CSSDecodeEscapes.IsPresent)
             : HtmlOptimizer.OptimizeHtml(Content, CSSDecodeEscapes.IsPresent);
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             System.IO.File.WriteAllText(outPath, result);
         } else {
             WriteObject(result);

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
@@ -36,7 +36,7 @@ public sealed class CmdletOptimizeJavaScript : PSCmdlet {
             : HtmlOptimizer.OptimizeJavaScript(Content);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile);
+            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
             File.WriteAllText(outPath, optimized);
         } else {
             WriteObject(optimized);

--- a/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that registers a Playwright route handler for an active session.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Register, "HTMLRoute")]
+public sealed class CmdletRegisterHtmlRoute : AsyncPSCmdlet {
+    /// <summary>Browser session in use.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>URL pattern for the route.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>Script block executed for each matching request.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public ScriptBlock? ScriptBlock { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        ScriptBlock block = ScriptBlock ?? throw new PSArgumentNullException(nameof(ScriptBlock));
+        Func<IRoute, Task> handler = route => {
+            object? result = block.InvokeReturnAsIs(route);
+            return result is Task t ? t : Task.CompletedTask;
+        };
+
+        await HtmlBrowser.RegisterRouteAsync(session, Pattern, handler).ConfigureAwait(false);
+        WriteObject(handler);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -49,6 +49,19 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>
+    /// Proxy server address used for browser traffic.
+    /// Include protocol and port if required.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    public string? Proxy { get; set; }
+
+    /// <summary>
+    /// Credentials used for the specified <see cref="Proxy"/> server.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetDefault)]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Optional filter applied to download URLs or file names.</summary>
     [Parameter]
     public string? Filter { get; set; }
@@ -56,6 +69,8 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        string? proxyUser = ProxyCredential?.UserName;
+        string? proxyPass = ProxyCredential?.GetNetworkCredential().Password;
 
         List<string> files = ParameterSetName switch {
             ParameterSetSession => await HtmlBrowser.SavePageDownloadsAsync(
@@ -69,7 +84,10 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
                 Clean.IsPresent,
                 Filter,
                 headless: !Visible.IsPresent,
-                slowMo: SlowMo).ConfigureAwait(false)
+                slowMo: SlowMo,
+                proxy: Proxy,
+                proxyUsername: proxyUser,
+                proxyPassword: proxyPass).ConfigureAwait(false)
         };
 
         WriteObject(files.ToArray(), true);

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
@@ -53,6 +53,19 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>
+    /// Proxy server address used for browser traffic.
+    /// Include protocol and port if required.
+    /// </summary>
+    [Parameter]
+    public string? Proxy { get; set; }
+
+    /// <summary>
+    /// Credentials used for the specified <see cref="Proxy"/> server.
+    /// </summary>
+    [Parameter]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Open the PDF after saving.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
@@ -130,6 +143,8 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        string? proxyUser = ProxyCredential?.UserName;
+        string? proxyPass = ProxyCredential?.GetNetworkCredential().Password;
         switch (ParameterSetName) {
             case ParameterSetSession:
                 await HtmlBrowser.SavePagePdfAsync(
@@ -181,7 +196,10 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
                     outline: false,
                     tagged: false,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: proxyUser,
+                    proxyPassword: proxyPass).ConfigureAwait(false);
                 break;
             default:
                 await HtmlBrowser.SavePagePdfAsync(
@@ -209,7 +227,10 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
                     outline: false,
                     tagged: false,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: proxyUser,
+                    proxyPassword: proxyPass).ConfigureAwait(false);
                 break;
         }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -64,6 +64,19 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>
+    /// Proxy server address used for browser traffic.
+    /// Include protocol and port if required.
+    /// </summary>
+    [Parameter]
+    public string? Proxy { get; set; }
+
+    /// <summary>
+    /// Credentials used for the specified <see cref="Proxy"/> server.
+    /// </summary>
+    [Parameter]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Open the screenshot after saving.</summary>
     [Parameter]
     public SwitchParameter Open { get; set; }
@@ -110,6 +123,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        string? proxyUser = ProxyCredential?.UserName;
+        string? proxyPass = ProxyCredential?.GetNetworkCredential().Password;
 
         if (string.IsNullOrWhiteSpace(OutFile)) {
             if (Open.IsPresent) {
@@ -139,7 +154,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Width,
                     Height,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: proxyUser,
+                    proxyPassword: proxyPass).ConfigureAwait(false);
                 break;
             case ParameterSetFileClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
@@ -155,7 +173,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Width,
                     Height,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: proxyUser,
+                    proxyPassword: proxyPass).ConfigureAwait(false);
                 break;
             case ParameterSetSessionClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
@@ -190,7 +211,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Delay,
                     Selector,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: proxyUser,
+                    proxyPassword: proxyPass).ConfigureAwait(false);
                 break;
         }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -143,7 +143,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     Url,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Browser,
                     Clean.IsPresent,
                     false,
@@ -162,7 +162,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetFileClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Browser,
                     Clean.IsPresent,
                     false,
@@ -181,7 +181,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     false,
                     Delay,
                     Selector,
@@ -193,7 +193,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionDefault:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Full.IsPresent,
                     Delay,
                     Selector).ConfigureAwait(false);
@@ -204,7 +204,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     : Url;
                 await HtmlBrowser.CaptureScreenshotAsync(
                     target,
-                    HtmlUtilities.ResolvePath(OutFile),
+                    HtmlUtilities.ResolvePath(OutFile!),
                     Browser,
                     Clean.IsPresent,
                     Full.IsPresent,
@@ -221,7 +221,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
         if (Open.IsPresent) {
             try {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
-                    FileName = HtmlUtilities.ResolvePath(OutFile),
+                    FileName = HtmlUtilities.ResolvePath(OutFile!),
                     UseShellExecute = true,
                 });
             } catch (System.Exception ex) {

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that adds cookies to an active browser session.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "HTMLCookie")]
+public sealed class CmdletSetHtmlCookie : AsyncPSCmdlet {
+    /// <summary>Browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>Cookies to add.</summary>
+    [Parameter(Mandatory = true)]
+    public HtmlCookie[]? Cookie { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        IEnumerable<HtmlCookie> cookies = Cookie ?? System.Array.Empty<HtmlCookie>();
+        await HtmlBrowser.SetCookiesAsync(session, cookies).ConfigureAwait(false);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -66,6 +66,21 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     [ValidateRange(0,int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>
+    /// Proxy server address used for browser traffic.
+    /// Include protocol and port if required.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? Proxy { get; set; }
+
+    /// <summary>
+    /// Credentials used for the specified <see cref="Proxy"/> server.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public PSCredential? ProxyCredential { get; set; }
+
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int Width { get; set; } = 800;
@@ -87,6 +102,8 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
         bool headless = !Visible.IsPresent;
         string? user = null;
         string? pass = null;
+        string? proxyUser = ProxyCredential?.UserName;
+        string? proxyPass = ProxyCredential?.GetNetworkCredential().Password;
         HtmlFormLogin? form = null;
 
         switch (ParameterSetName) {
@@ -143,7 +160,10 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 headless,
                 SlowMo,
                 Width,
-                Height).ConfigureAwait(false);
+                Height,
+                proxy: Proxy,
+                proxyUsername: proxyUser,
+                proxyPassword: proxyPass).ConfigureAwait(false);
 
         if (!NoDefault.IsPresent) {
             SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -90,6 +90,20 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     public int Height { get; set; } = 600;
 
     [Parameter]
+    public string? UserAgent { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportWidth { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportHeight { get; set; }
+
+    [Parameter]
+    public double? DeviceScaleFactor { get; set; }
+
+    [Parameter]
     public SwitchParameter NoDefault { get; set; }
 
     protected override async Task ProcessRecordAsync() {
@@ -148,7 +162,11 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 headless,
                 SlowMo,
                 Width,
-                Height).ConfigureAwait(false)
+                Height,
+                UserAgent,
+                ViewportWidth,
+                ViewportHeight,
+                (float?)DeviceScaleFactor).ConfigureAwait(false)
             : await HtmlBrowser.StartVideoRecordingAsync(
                 target,
                 OutFile,
@@ -163,7 +181,11 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 Height,
                 proxy: Proxy,
                 proxyUsername: proxyUser,
-                proxyPassword: proxyPass).ConfigureAwait(false);
+                proxyPassword: proxyPass,
+                userAgent: UserAgent,
+                viewportWidth: ViewportWidth,
+                viewportHeight: ViewportHeight,
+                deviceScaleFactor: (float?)DeviceScaleFactor).ConfigureAwait(false);
 
         if (!NoDefault.IsPresent) {
             SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);

--- a/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that removes a previously registered Playwright route handler.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Unregister, "HTMLRoute")]
+public sealed class CmdletUnregisterHtmlRoute : AsyncPSCmdlet {
+    /// <summary>Browser session in use.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>URL pattern for the route.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>Handler returned by Register-HTMLRoute.</summary>
+    [Parameter(Position = 2)]
+    public Delegate? Handler { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.UnregisterRouteAsync(session, Pattern, Handler as Func<IRoute, Task>).ConfigureAwait(false);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/Sources/PSParseHTML.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -62,16 +62,16 @@ public class InternalLoggerPowerShell {
     /// <param name="e"></param>
     private void Logger_OnVerboseMessage(object? sender, LogEventArgs e) {
         if (e.Args != null && e.Args.Length > 0) {
-            WriteVerbose(e.Message, e.Args);
+            WriteVerbose(e.Message ?? string.Empty, e.Args);
         } else {
-            WriteVerbose(e.Message);
+            WriteVerbose(e.Message ?? string.Empty);
         }
     }
     private void Logger_OnDebugMessage(object? sender, LogEventArgs e) {
-        WriteDebug(e.Message);
+        WriteDebug(e.Message ?? string.Empty);
     }
     private void Logger_OnWarningMessage(object? sender, LogEventArgs e) {
-        WriteWarning(e.Message);
+        WriteWarning(e.Message ?? string.Empty);
     }
     private void Logger_OnErrorMessage(object? sender, LogEventArgs e) {
         ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), "1", ErrorCategory.NotSpecified, null);
@@ -108,7 +108,7 @@ public class InternalLoggerPowerShell {
         WriteProgress(progressRecord);
     }
     private void Logger_OnInformationMessage(object? sender, LogEventArgs e) {
-        WriteInformation(e.Message);
+        WriteInformation(e.Message ?? string.Empty);
     }
 
     private void WriteVerbose(string message) {

--- a/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
+++ b/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
@@ -33,10 +33,13 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
     /// <returns></returns>
     private static Assembly? MyResolveEventHandler(object? sender, ResolveEventArgs args) {
         var libDirectory = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
-        var directoriesToSearch = new List<string> { libDirectory };
+        var directoriesToSearch = new List<string>();
 
-        if (Directory.Exists(libDirectory)) {
-            directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+        if (!string.IsNullOrEmpty(libDirectory)) {
+            directoriesToSearch.Add(libDirectory);
+            if (Directory.Exists(libDirectory)) {
+                directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+            }
         }
 
         var requestedAssemblyName = new AssemblyName(args.Name).Name + ".dll";

--- a/Sources/PSParseHTML/HtmlParserFromList.cs
+++ b/Sources/PSParseHTML/HtmlParserFromList.cs
@@ -3,6 +3,7 @@ using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -11,6 +12,7 @@ namespace PSParseHTML;
 /// Provides functionality for parsing HTML lists.
 /// </summary>
 public static class HtmlParserFromList {
+    private static readonly HttpClient _sharedClient = new();
     /// <summary>
     /// Extracts list items from HTML using AngleSharp with metadata.
     /// </summary>
@@ -97,7 +99,7 @@ public static class HtmlParserFromList {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
-        HttpClient http = client ?? new HttpClient();
+        HttpClient http = client ?? _sharedClient;
         string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
         return ParseListsWithAngleSharpDetailed(content, tagPlaceholder);
     }
@@ -147,7 +149,7 @@ public static class HtmlParserFromList {
             var metadata = result.Metadata;
             metadata.ListIndex = index++;
             metadata.Id = list.Id;
-            metadata.Classes = list.GetAttributeValue("class", null);
+            metadata.Classes = list.GetAttributeValue("class", string.Empty);
             metadata.IsOrdered = list.Name.Equals("ol", StringComparison.OrdinalIgnoreCase);
             foreach (var attr in list.Attributes) {
                 metadata.Attributes[attr.Name] = attr.Value ?? string.Empty;
@@ -211,7 +213,7 @@ public static class HtmlParserFromList {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
-        HttpClient http = client ?? new HttpClient();
+        HttpClient http = client ?? _sharedClient;
         string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
         return ParseListsWithHtmlAgilityPackDetailed(content, tagPlaceholder);
     }

--- a/Sources/PSParseHTML/Models/HtmlCookie.cs
+++ b/Sources/PSParseHTML/Models/HtmlCookie.cs
@@ -1,0 +1,35 @@
+using Microsoft.Playwright;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Represents a browser cookie.
+/// </summary>
+public sealed class HtmlCookie {
+    /// <summary>Name of the cookie.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Cookie value.</summary>
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>Optional URL for the cookie.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>Cookie domain.</summary>
+    public string? Domain { get; set; }
+
+    /// <summary>Cookie path.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Expiration time as UNIX timestamp.</summary>
+    public float? Expires { get; set; }
+
+    /// <summary>True when the cookie is HTTP only.</summary>
+    public bool? HttpOnly { get; set; }
+
+    /// <summary>True when the cookie requires HTTPS.</summary>
+    public bool? Secure { get; set; }
+
+    /// <summary>SameSite policy.</summary>
+    public SameSiteAttribute? SameSite { get; set; }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
@@ -1,0 +1,50 @@
+using Microsoft.Playwright;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PSParseHTML;
+
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Retrieves cookies from the browser context.
+    /// </summary>
+    public static async Task<List<HtmlCookie>> GetCookiesAsync(HtmlBrowserSession session) {
+        IReadOnlyList<BrowserContextCookiesResult> cookies = await session.Context.CookiesAsync();
+        List<HtmlCookie> result = new();
+        foreach (BrowserContextCookiesResult c in cookies) {
+            result.Add(new HtmlCookie {
+                Name = c.Name,
+                Value = c.Value,
+                Domain = c.Domain,
+                Path = c.Path,
+                Expires = c.Expires,
+                HttpOnly = c.HttpOnly,
+                Secure = c.Secure,
+                SameSite = c.SameSite
+            });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Adds cookies to the browser context.
+    /// </summary>
+    public static Task SetCookiesAsync(HtmlBrowserSession session, IEnumerable<HtmlCookie> cookies) {
+        List<Cookie> list = new();
+        foreach (HtmlCookie c in cookies) {
+            Cookie nc = new() {
+                Name = c.Name,
+                Value = c.Value,
+                Url = c.Url,
+                Domain = c.Domain,
+                Path = c.Path,
+                Expires = c.Expires,
+                HttpOnly = c.HttpOnly,
+                Secure = c.Secure,
+                SameSite = c.SameSite
+            };
+            list.Add(nc);
+        }
+        return session.Context.AddCookiesAsync(list);
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Helper methods for running JavaScript in a browser session.
+/// </summary>
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Executes arbitrary JavaScript in the context of the current page.
+    /// </summary>
+    /// <typeparam name="T">Expected return type.</typeparam>
+    /// <param name="session">Browser session.</param>
+    /// <param name="script">JavaScript code to execute.</param>
+    /// <returns>Value returned by the script.</returns>
+    public static Task<T?> EvaluateAsync<T>(HtmlBrowserSession session, string script)
+        => session.Page.EvaluateAsync<T>(script);
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML;
+
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Registers a network route handler on the specified page.
+    /// </summary>
+    public static Task RegisterRouteAsync(IPage page, string pattern, Func<IRoute, Task> handler)
+        => page.RouteAsync(pattern, handler);
+
+    /// <summary>
+    /// Registers a network route handler on the session page.
+    /// </summary>
+    public static Task RegisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task> handler)
+        => RegisterRouteAsync(session.Page, pattern, handler);
+
+    /// <summary>
+    /// Removes a previously registered route handler from the page.
+    /// </summary>
+    public static Task UnregisterRouteAsync(IPage page, string pattern, Func<IRoute, Task>? handler = null)
+        => handler is null ? page.UnrouteAsync(pattern) : page.UnrouteAsync(pattern, handler);
+
+    /// <summary>
+    /// Removes a previously registered route handler from the session page.
+    /// </summary>
+    public static Task UnregisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task>? handler = null)
+        => UnregisterRouteAsync(session.Page, pattern, handler);
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -21,7 +21,17 @@ public static partial class HtmlBrowser {
     /// <param name="clean">Reinstall the browser runtime.</param>
     /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
     /// <returns>Paths of downloaded files.</returns>
-    public static async Task<List<string>> SavePageDownloadsAsync(string url, string directory, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? filter = null, bool headless = true, int slowMo = 0) {
+    public static async Task<List<string>> SavePageDownloadsAsync(
+        string url,
+        string directory,
+        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
+        bool clean = false,
+        string? filter = null,
+        bool headless = true,
+        int slowMo = 0,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -31,7 +41,10 @@ public static partial class HtmlBrowser {
             null,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            videoPath: null,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
         var page = session.Page;
         string dir = HtmlUtilities.ResolvePath(directory);
         return await SavePageDownloadsAsync(page, dir, filter).ConfigureAwait(false);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -43,7 +43,10 @@ public static partial class HtmlBrowser {
             string? password = null,
             HtmlFormLogin? formLogin = null,
             bool headless = true,
-            int slowMo = 0) {
+            int slowMo = 0,
+            string? proxy = null,
+            string? proxyUsername = null,
+            string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -53,7 +56,10 @@ public static partial class HtmlBrowser {
             formLogin,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            videoPath: null,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
 
         await SavePagePdfAsync(
             session.Page,

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -111,7 +111,7 @@ public static partial class HtmlBrowser {
         bool outline = false,
         bool tagged = false) {
         if (!string.IsNullOrEmpty(selector)) {
-            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+            await page.WaitForSelectorAsync(selector!, new PageWaitForSelectorOptions { Timeout = 10000 });
         }
         if (delayMs > 0) {
             await page.WaitForTimeoutAsync(delayMs);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -42,7 +42,10 @@ public static partial class HtmlBrowser {
         string? password = null,
         HtmlFormLogin? formLogin = null,
         bool headless = true,
-        int slowMo = 0) {
+        int slowMo = 0,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -52,7 +55,10 @@ public static partial class HtmlBrowser {
             formLogin,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            videoPath: null,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
 
         string fullPath = HtmlUtilities.ResolvePath(path);
         await CaptureScreenshotAsync(

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -87,7 +87,7 @@ public static partial class HtmlBrowser {
         int? clipWidth = null,
         int? clipHeight = null) {
         if (!string.IsNullOrEmpty(selector)) {
-            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
+            await page.WaitForSelectorAsync(selector!, new PageWaitForSelectorOptions { Timeout = 10000 });
         }
         if (delayMs > 0) {
             await page.WaitForTimeoutAsync(delayMs);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -19,8 +19,11 @@ public static partial class HtmlBrowser {
         bool headless = true,
         int slowMo = 0,
         int width = 800,
-        int height = 600)
-        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null);
+        int height = 600,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null)
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, proxy, proxyUsername, proxyPassword);
 
     /// <summary>
     /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
@@ -53,7 +56,10 @@ public static partial class HtmlBrowser {
             videoPath: videoPath,
             videoWidth: width,
             videoHeight: height,
-            storageStatePath: temp).ConfigureAwait(false);
+            storageStatePath: temp,
+            proxy: null,
+            proxyUsername: null,
+            proxyPassword: null).ConfigureAwait(false);
 
         File.Delete(temp);
         return newSession;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -22,8 +22,12 @@ public static partial class HtmlBrowser {
         int height = 600,
         string? proxy = null,
         string? proxyUsername = null,
-        string? proxyPassword = null)
-        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, proxy, proxyUsername, proxyPassword);
+        string? proxyPassword = null,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null)
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, proxy, proxyUsername, proxyPassword, userAgent, viewportWidth, viewportHeight, deviceScaleFactor);
 
     /// <summary>
     /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
@@ -34,7 +38,11 @@ public static partial class HtmlBrowser {
         bool headless = true,
         int slowMo = 0,
         int width = 800,
-        int height = 600) {
+        int height = 600,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null) {
         string temp = Path.GetTempFileName();
         await session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = temp }).ConfigureAwait(false);
         string url = session.Page.Url;
@@ -59,7 +67,11 @@ public static partial class HtmlBrowser {
             storageStatePath: temp,
             proxy: null,
             proxyUsername: null,
-            proxyPassword: null).ConfigureAwait(false);
+            proxyPassword: null,
+            userAgent: userAgent,
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight,
+            deviceScaleFactor: deviceScaleFactor).ConfigureAwait(false);
 
         File.Delete(temp);
         return newSession;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -29,7 +29,11 @@ public static partial class HtmlBrowser {
         string? storageStatePath = null,
         string? proxy = null,
         string? proxyUsername = null,
-        string? proxyPassword = null) {
+        string? proxyPassword = null,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -57,14 +61,13 @@ public static partial class HtmlBrowser {
                 Password = proxyPassword
             };
         }
-
         var browserInstance = await type.LaunchAsync(launchOptions);
         BrowserNewContextOptions? contextOptions = null;
         if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
             contextOptions = new BrowserNewContextOptions {
                 HttpCredentials = new HttpCredentials {
-                    Username = username,
-                    Password = password
+                    Username = username!,
+                    Password = password!
                 }
             };
         }
@@ -74,10 +77,20 @@ public static partial class HtmlBrowser {
             contextOptions.StorageStatePath = storageStatePath;
         }
         if (!string.IsNullOrEmpty(videoPath)) {
-            string dir = Path.GetDirectoryName(HtmlUtilities.ResolvePath(videoPath))!;
+            string resolved = HtmlUtilities.ResolvePath(videoPath!);
+            string dir = Path.GetDirectoryName(resolved) ?? resolved;
             Directory.CreateDirectory(dir);
             contextOptions.RecordVideoDir = dir;
             contextOptions.RecordVideoSize = new RecordVideoSize { Width = videoWidth, Height = videoHeight };
+        }
+        if (!string.IsNullOrEmpty(userAgent)) {
+            contextOptions.UserAgent = userAgent;
+        }
+        if (viewportWidth.HasValue && viewportHeight.HasValue) {
+            contextOptions.ViewportSize = new ViewportSize { Width = viewportWidth.Value, Height = viewportHeight.Value };
+        }
+        if (deviceScaleFactor.HasValue) {
+            contextOptions.DeviceScaleFactor = deviceScaleFactor.Value;
         }
 
         var context = await browserInstance.NewContextAsync(contextOptions);
@@ -125,8 +138,12 @@ public static partial class HtmlBrowser {
         string? storageStatePath = null,
         string? proxy = null,
         string? proxyUsername = null,
-        string? proxyPassword = null)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, proxy, proxyUsername, proxyPassword);
+        string? proxyPassword = null,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, proxy, proxyUsername, proxyPassword, userAgent, viewportWidth, viewportHeight, deviceScaleFactor);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -141,18 +158,7 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(
-        string url,
-        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
-        bool clean = false,
-        string? username = null,
-        string? password = null,
-        HtmlFormLogin? formLogin = null,
-        bool headless = true,
-        int slowMo = 0,
-        string? proxy = null,
-        string? proxyUsername = null,
-        string? proxyPassword = null) {
+    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -163,9 +169,16 @@ public static partial class HtmlBrowser {
             headless,
             slowMo,
             videoPath: null,
+            videoWidth: 800,
+            videoHeight: 600,
+            storageStatePath: null,
             proxy: proxy,
             proxyUsername: proxyUsername,
-            proxyPassword: proxyPassword).ConfigureAwait(false);
+            proxyPassword: proxyPassword,
+            userAgent: userAgent,
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight,
+            deviceScaleFactor: deviceScaleFactor).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -175,32 +188,9 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(
-        string url,
-        string path,
-        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
-        bool clean = false,
-        string? username = null,
-        string? password = null,
-        HtmlFormLogin? formLogin = null,
-        bool headless = true,
-        int slowMo = 0,
-        string? proxy = null,
-        string? proxyUsername = null,
-        string? proxyPassword = null) {
+    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null) {
         string fullPath = HtmlUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(
-            url,
-            browser,
-            clean,
-            username,
-            password,
-            formLogin,
-            headless,
-            slowMo,
-            proxy,
-            proxyUsername,
-            proxyPassword).ConfigureAwait(false);
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, proxy, proxyUsername, proxyPassword, userAgent, viewportWidth, viewportHeight, deviceScaleFactor).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 
@@ -220,7 +210,7 @@ public static partial class HtmlBrowser {
             return await page.ContentAsync().ConfigureAwait(false);
         }
 
-        var locator = page.Locator(selector);
+        var locator = page.Locator(selector!);
         await locator.WaitForAsync();
 
         if (asText) {

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -26,7 +26,10 @@ public static partial class HtmlBrowser {
         string? videoPath = null,
         int videoWidth = 800,
         int videoHeight = 600,
-        string? storageStatePath = null) {
+        string? storageStatePath = null,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -43,10 +46,19 @@ public static partial class HtmlBrowser {
             _ => playwright.Chromium,
         };
 
-        var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions {
+        var launchOptions = new BrowserTypeLaunchOptions {
             Headless = headless,
             SlowMo = slowMo
-        });
+        };
+        if (!string.IsNullOrEmpty(proxy)) {
+            launchOptions.Proxy = new Proxy {
+                Server = proxy,
+                Username = proxyUsername,
+                Password = proxyPassword
+            };
+        }
+
+        var browserInstance = await type.LaunchAsync(launchOptions);
         BrowserNewContextOptions? contextOptions = null;
         if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
             contextOptions = new BrowserNewContextOptions {
@@ -110,8 +122,11 @@ public static partial class HtmlBrowser {
         string? videoPath = null,
         int videoWidth = 800,
         int videoHeight = 600,
-        string? storageStatePath = null)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath);
+        string? storageStatePath = null,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, proxy, proxyUsername, proxyPassword);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -126,7 +141,18 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0) {
+    public static async Task<string> GetPageContentAsync(
+        string url,
+        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
+        bool clean = false,
+        string? username = null,
+        string? password = null,
+        HtmlFormLogin? formLogin = null,
+        bool headless = true,
+        int slowMo = 0,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -136,7 +162,10 @@ public static partial class HtmlBrowser {
             formLogin,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            videoPath: null,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -146,9 +175,32 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0) {
+    public static async Task SavePageContentAsync(
+        string url,
+        string path,
+        HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium,
+        bool clean = false,
+        string? username = null,
+        string? password = null,
+        HtmlFormLogin? formLogin = null,
+        bool headless = true,
+        int slowMo = 0,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         string fullPath = HtmlUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo).ConfigureAwait(false);
+        string content = await GetPageContentAsync(
+            url,
+            browser,
+            clean,
+            username,
+            password,
+            formLogin,
+            headless,
+            slowMo,
+            proxy,
+            proxyUsername,
+            proxyPassword).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -44,7 +44,7 @@ public class PreMailerClient {
         try {
             string cssContent = Options.Css ?? string.Empty;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
-                string cssPath = HtmlUtilities.ResolvePath(Options.CssFilePath);
+                string cssPath = HtmlUtilities.ResolvePath(Options.CssFilePath!);
                 if (!File.Exists(cssPath)) {
                     throw new FileNotFoundException($"CSS file not found: {Options.CssFilePath}", cssPath);
                 }

--- a/Tests/Documents/data.json
+++ b/Tests/Documents/data.json
@@ -1,0 +1,1 @@
+{"message":"original"}

--- a/Tests/Documents/route_page.html
+++ b/Tests/Documents/route_page.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<script>
+async function load(){
+  try {
+    const r = await fetch('https://example.com/data.json');
+    const j = await r.json();
+    document.getElementById('result').textContent = j.message;
+  } catch(e){
+    document.getElementById('result').textContent = 'error';
+  }
+}
+window.addEventListener('DOMContentLoaded', load);
+</script>
+</head>
+<body>
+<div id="result">loading</div>
+</body>
+</html>

--- a/Tests/GetSet-HTMLCookie.Tests.ps1
+++ b/Tests/GetSet-HTMLCookie.Tests.ps1
@@ -1,0 +1,28 @@
+Describe 'HTML Cookie cmdlets' {
+    It 'Persists cookies between sessions' {
+        $url = 'about:blank'
+
+        $cookie = [PSParseHTML.HtmlCookie]::new()
+        $cookie.Name = 'mycookie'
+        $cookie.Value = 'choco'
+        $cookie.Domain = 'example.com'
+        $cookie.Path = '/'
+
+        $session1 = Invoke-HTMLRendering -Url $url -Session
+        Set-HTMLCookie -Session $session1 -Cookie ([PSParseHTML.HtmlCookie[]]@($cookie))
+        $cookies1 = Get-HTMLCookie -Session $session1
+        Close-HTMLSession -Session $session1
+
+        ($cookies1 | Where-Object Name -eq 'mycookie').Value | Should -Be 'choco'
+
+        $session2 = Invoke-HTMLRendering -Url $url -Session
+        $cookies2 = Get-HTMLCookie -Session $session2
+        ($cookies2 | Where-Object Name -eq 'mycookie') | Should -Be $null
+
+        Set-HTMLCookie -Session $session2 -Cookie $cookies1
+        $after = Get-HTMLCookie -Session $session2
+        Close-HTMLSession -Session $session2
+
+        ($after | Where-Object Name -eq 'mycookie').Value | Should -Be 'choco'
+    }
+}

--- a/Tests/Invoke-HTMLRendering.Tests.ps1
+++ b/Tests/Invoke-HTMLRendering.Tests.ps1
@@ -12,4 +12,17 @@ Describe 'Invoke-HTMLRendering' {
         $html = Invoke-HTMLRendering -Url $uri -Browser Firefox
         $html | Should -Match 'Dynamic Content'
     }
+
+    It 'Applies custom browser context options' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session -UserAgent 'MyAgent' -ViewportWidth 123 -ViewportHeight 77 -DeviceScaleFactor 1.5
+        $ua = $session.Page.EvaluateAsync('navigator.userAgent',$null).GetAwaiter().GetResult()
+        $w = [int]($session.Page.EvaluateAsync('window.innerWidth',$null).GetAwaiter().GetResult().ToString())
+        $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
+        Close-HTMLSession -Session $session
+        $ua | Should -Be 'MyAgent'
+        $w | Should -Be 123
+        [double]$d | Should -Be 1.5
+    }
 }

--- a/Tests/Invoke-HTMLScript.Tests.ps1
+++ b/Tests/Invoke-HTMLScript.Tests.ps1
@@ -1,0 +1,20 @@
+describe 'Invoke-HTMLScript' {
+    it 'Manipulates the DOM and retrieves text' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        $add = 'document.body.insertAdjacentHTML("beforeend", "<p id=\"new\">Hi</p>");'
+        Invoke-HTMLScript -Session $session -Script $add | Out-Null
+        $get = 'document.getElementById("new").textContent'
+        $text = Invoke-HTMLScript -Session $session -Script $get
+        $text | Should -Be 'Hi'
+    }
+
+    it 'Returns expression result' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        $val = Invoke-HTMLScript -Session $session -Script '2 + 3'
+        $val | Should -Be 5
+    }
+}

--- a/Tests/Proxy.Tests.ps1
+++ b/Tests/Proxy.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Proxy parameters' {
     It 'Cmdlets expose proxy parameters' {
-        $cmdlets = 'ConvertFrom-HTML','ConvertFrom-HtmlTable','ConvertFrom-HtmlAttributes','ConvertFrom-HtmlList','Convert-HTMLToText'
+        $cmdlets = 'ConvertFrom-HTML','ConvertFrom-HtmlTable','ConvertFrom-HtmlAttributes','ConvertFrom-HtmlList','Convert-HTMLToText','Invoke-HTMLRendering','Save-HTMLScreenshot','Save-HTMLPdf','Save-HTMLAttachment','Get-HTMLInteractable','Start-HTMLVideoRecording'
         foreach($cmd in $cmdlets){
             $params = (Get-Command $cmd).Parameters.Keys
             $params | Should -Contain 'Proxy'

--- a/Tests/Register-HTMLRoute.Tests.ps1
+++ b/Tests/Register-HTMLRoute.Tests.ps1
@@ -1,0 +1,30 @@
+Describe 'Register-HTMLRoute' {
+    It 'Blocks a request to data.json' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        $text = Get-HTMLContent -Session $session -Selector '#result' -AsText
+        $text | Should -Be 'error'
+        Close-HTMLSession -Session $session
+    }
+
+    It 'Rewrites request to data.json' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock {
+            param($route)
+            $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
+                Status = 200
+                ContentType = 'application/json'
+                Body = '{"message":"mock"}'
+            }) | Out-Null
+        }
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        $text = Get-HTMLContent -Session $session -Selector '#result' -AsText
+        $text | Should -Be 'mock'
+        Close-HTMLSession -Session $session
+    }
+}

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -29,4 +29,18 @@ describe 'HTML Video Recording' {
         Stop-HTMLVideoRecording -Session $record
         (Test-Path $out) | Should -BeTrue
     }
+
+    it 'Applies custom options' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $out = Join-Path $TestDrive 'opts.webm'
+        $session = Start-HTMLVideoRecording -Url $uri -OutFile $out -Width 320 -Height 240 -UserAgent 'VideoUA' -ViewportWidth 200 -ViewportHeight 150 -DeviceScaleFactor 2
+        $ua = $session.Page.EvaluateAsync('navigator.userAgent',$null).GetAwaiter().GetResult()
+        $w = [int]($session.Page.EvaluateAsync('window.innerWidth',$null).GetAwaiter().GetResult().ToString())
+        $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
+        Stop-HTMLVideoRecording -Session $session
+        $ua | Should -Be 'VideoUA'
+        $w | Should -Be 200
+        [double]$d | Should -Be 2
+    }
 }


### PR DESCRIPTION
## Summary
- extend `HtmlBrowser.CreatePageAsync` with proxy support
- wire proxy configuration through Playwright launch options
- expose `-Proxy` and `-ProxyCredential` in Playwright-based cmdlets
- update tests for new parameters

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684dd57d4a1c832e9d1209a66a33fff0