### PR TITLE
Add Playwright cookie helpers

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Get-HTMLCookie', 'Set-HTMLCookie')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -52,6 +52,8 @@
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file
+- `Get-HTMLCookie` - retrieve cookies from the active session
+- `Set-HTMLCookie` - add cookies to the active session
 - `Close-HTMLSession` - dispose an active browser session (`Stop-HTMLSession` alias)
 
 All cmdlets that work with files accept a `-Path` parameter (or alias) in addition to `-File`. Relative, absolute and UNC paths are resolved to full paths automatically.

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that retrieves cookies from an active browser session.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "HTMLCookie")]
+[OutputType(typeof(HtmlCookie))]
+public sealed class CmdletGetHtmlCookie : AsyncPSCmdlet {
+    /// <summary>Browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        List<HtmlCookie> cookies = await HtmlBrowser.GetCookiesAsync(session).ConfigureAwait(false);
+        WriteObject(cookies, true);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that adds cookies to an active browser session.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "HTMLCookie")]
+public sealed class CmdletSetHtmlCookie : AsyncPSCmdlet {
+    /// <summary>Browser session.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>Cookies to add.</summary>
+    [Parameter(Mandatory = true)]
+    public HtmlCookie[]? Cookie { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        IEnumerable<HtmlCookie> cookies = Cookie ?? System.Array.Empty<HtmlCookie>();
+        await HtmlBrowser.SetCookiesAsync(session, cookies).ConfigureAwait(false);
+    }
+}

--- a/Sources/PSParseHTML/Models/HtmlCookie.cs
+++ b/Sources/PSParseHTML/Models/HtmlCookie.cs
@@ -1,0 +1,35 @@
+using Microsoft.Playwright;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Represents a browser cookie.
+/// </summary>
+public sealed class HtmlCookie {
+    /// <summary>Name of the cookie.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Cookie value.</summary>
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>Optional URL for the cookie.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>Cookie domain.</summary>
+    public string? Domain { get; set; }
+
+    /// <summary>Cookie path.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Expiration time as UNIX timestamp.</summary>
+    public float? Expires { get; set; }
+
+    /// <summary>True when the cookie is HTTP only.</summary>
+    public bool? HttpOnly { get; set; }
+
+    /// <summary>True when the cookie requires HTTPS.</summary>
+    public bool? Secure { get; set; }
+
+    /// <summary>SameSite policy.</summary>
+    public SameSiteAttribute? SameSite { get; set; }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
@@ -1,0 +1,50 @@
+using Microsoft.Playwright;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PSParseHTML;
+
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Retrieves cookies from the browser context.
+    /// </summary>
+    public static async Task<List<HtmlCookie>> GetCookiesAsync(HtmlBrowserSession session) {
+        IReadOnlyList<BrowserContextCookiesResult> cookies = await session.Context.CookiesAsync();
+        List<HtmlCookie> result = new();
+        foreach (BrowserContextCookiesResult c in cookies) {
+            result.Add(new HtmlCookie {
+                Name = c.Name,
+                Value = c.Value,
+                Domain = c.Domain,
+                Path = c.Path,
+                Expires = c.Expires,
+                HttpOnly = c.HttpOnly,
+                Secure = c.Secure,
+                SameSite = c.SameSite
+            });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Adds cookies to the browser context.
+    /// </summary>
+    public static Task SetCookiesAsync(HtmlBrowserSession session, IEnumerable<HtmlCookie> cookies) {
+        List<Cookie> list = new();
+        foreach (HtmlCookie c in cookies) {
+            Cookie nc = new() {
+                Name = c.Name,
+                Value = c.Value,
+                Url = c.Url,
+                Domain = c.Domain,
+                Path = c.Path,
+                Expires = c.Expires,
+                HttpOnly = c.HttpOnly,
+                Secure = c.Secure,
+                SameSite = c.SameSite
+            };
+            list.Add(nc);
+        }
+        return session.Context.AddCookiesAsync(list);
+    }
+}

--- a/Tests/GetSet-HTMLCookie.Tests.ps1
+++ b/Tests/GetSet-HTMLCookie.Tests.ps1
@@ -1,0 +1,28 @@
+Describe 'HTML Cookie cmdlets' {
+    It 'Persists cookies between sessions' {
+        $url = 'about:blank'
+
+        $cookie = [PSParseHTML.HtmlCookie]::new()
+        $cookie.Name = 'mycookie'
+        $cookie.Value = 'choco'
+        $cookie.Domain = 'example.com'
+        $cookie.Path = '/'
+
+        $session1 = Invoke-HTMLRendering -Url $url -Session
+        Set-HTMLCookie -Session $session1 -Cookie ([PSParseHTML.HtmlCookie[]]@($cookie))
+        $cookies1 = Get-HTMLCookie -Session $session1
+        Close-HTMLSession -Session $session1
+
+        ($cookies1 | Where-Object Name -eq 'mycookie').Value | Should -Be 'choco'
+
+        $session2 = Invoke-HTMLRendering -Url $url -Session
+        $cookies2 = Get-HTMLCookie -Session $session2
+        ($cookies2 | Where-Object Name -eq 'mycookie') | Should -Be $null
+
+        Set-HTMLCookie -Session $session2 -Cookie $cookies1
+        $after = Get-HTMLCookie -Session $session2
+        Close-HTMLSession -Session $session2
+
+        ($after | Where-Object Name -eq 'mycookie').Value | Should -Be 'choco'
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GetCookiesAsync` and `SetCookiesAsync`
- expose new `Get-HTMLCookie` and `Set-HTMLCookie` cmdlets
- document new commands
- test cookie persistence

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684dd563d750832e9f0d71ae99755b01