### PR TITLE
Add context options for browser sessions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -44,6 +44,7 @@
   - `Start-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
 - `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
+- `UserAgent`, `-ViewportWidth`, `-ViewportHeight` and `-DeviceScaleFactor` allow customizing the browser context
 - `Save-HTMLPdf` - generate a PDF of a rendered page
 - `Start-HTMLVideoRecording`/`Stop-HTMLVideoRecording` - record browser sessions to a `.webm` video file
   - supports the same authentication options as `Invoke-HTMLRendering` so you can capture the login process
@@ -131,6 +132,7 @@ Chromium 136.0.7103.25 (playwright build v1169) downloaded to C:\Users\USER\AppD
 Use `-Clean` to clear the `ms-playwright` cache and re-download the runtime if needed.
 Use `-Full` to capture the entire document, `-Open` to automatically view the image, specify `-Delay` or `-Selector` to wait for dynamic content, or supply `-X`, `-Y`, `-Width` and `-Height` to grab a specific region.
 Use `-Visible` to see the browser window and `-SlowMo` to slow down actions for easier debugging.
+Supply `-UserAgent`, `-ViewportWidth`, `-ViewportHeight` or `-DeviceScaleFactor` to emulate different devices.
 
 The expected input is a string literal or data read from a file.  The output can be PowerShell objects (classes are `HtmlNode` or `AngleSharp.Html.Dom.HtmlElement` depending on the selected engine) or strings written to `stdout`.
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -86,6 +86,20 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    [Parameter]
+    public string? UserAgent { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportWidth { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportHeight { get; set; }
+
+    [Parameter]
+    public double? DeviceScaleFactor { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
@@ -114,16 +128,20 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 form,
                 headless: !Visible.IsPresent,
                 slowMo: SlowMo,
-                storageStatePath: null).ConfigureAwait(false);
+                storageStatePath: null,
+                userAgent: UserAgent,
+                viewportWidth: ViewportWidth,
+                viewportHeight: ViewportHeight,
+                deviceScaleFactor: (float?)DeviceScaleFactor).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             string outPath = HtmlUtilities.ResolvePath(OutFile);
-            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
+            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo).ConfigureAwait(false);
+            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -75,6 +75,20 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
     public int Height { get; set; } = 600;
 
     [Parameter]
+    public string? UserAgent { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportWidth { get; set; }
+
+    [Parameter]
+    [ValidateRange(1,int.MaxValue)]
+    public int? ViewportHeight { get; set; }
+
+    [Parameter]
+    public double? DeviceScaleFactor { get; set; }
+
+    [Parameter]
     public SwitchParameter NoDefault { get; set; }
 
     protected override async Task ProcessRecordAsync() {
@@ -131,7 +145,11 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 headless,
                 SlowMo,
                 Width,
-                Height).ConfigureAwait(false)
+                Height,
+                UserAgent,
+                ViewportWidth,
+                ViewportHeight,
+                (float?)DeviceScaleFactor).ConfigureAwait(false)
             : await HtmlBrowser.StartVideoRecordingAsync(
                 target,
                 OutFile,
@@ -143,7 +161,11 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 headless,
                 SlowMo,
                 Width,
-                Height).ConfigureAwait(false);
+                Height,
+                UserAgent,
+                ViewportWidth,
+                ViewportHeight,
+                (float?)DeviceScaleFactor).ConfigureAwait(false);
 
         if (!NoDefault.IsPresent) {
             SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -19,8 +19,12 @@ public static partial class HtmlBrowser {
         bool headless = true,
         int slowMo = 0,
         int width = 800,
-        int height = 600)
-        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null);
+        int height = 600,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null)
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, userAgent, viewportWidth, viewportHeight, deviceScaleFactor);
 
     /// <summary>
     /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
@@ -31,7 +35,11 @@ public static partial class HtmlBrowser {
         bool headless = true,
         int slowMo = 0,
         int width = 800,
-        int height = 600) {
+        int height = 600,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null) {
         string temp = Path.GetTempFileName();
         await session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = temp }).ConfigureAwait(false);
         string url = session.Page.Url;
@@ -53,7 +61,11 @@ public static partial class HtmlBrowser {
             videoPath: videoPath,
             videoWidth: width,
             videoHeight: height,
-            storageStatePath: temp).ConfigureAwait(false);
+            storageStatePath: temp,
+            userAgent: userAgent,
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight,
+            deviceScaleFactor: deviceScaleFactor).ConfigureAwait(false);
 
         File.Delete(temp);
         return newSession;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -26,7 +26,11 @@ public static partial class HtmlBrowser {
         string? videoPath = null,
         int videoWidth = 800,
         int videoHeight = 600,
-        string? storageStatePath = null) {
+        string? storageStatePath = null,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -66,6 +70,15 @@ public static partial class HtmlBrowser {
             Directory.CreateDirectory(dir);
             contextOptions.RecordVideoDir = dir;
             contextOptions.RecordVideoSize = new RecordVideoSize { Width = videoWidth, Height = videoHeight };
+        }
+        if (!string.IsNullOrEmpty(userAgent)) {
+            contextOptions.UserAgent = userAgent;
+        }
+        if (viewportWidth.HasValue && viewportHeight.HasValue) {
+            contextOptions.ViewportSize = new ViewportSize { Width = viewportWidth.Value, Height = viewportHeight.Value };
+        }
+        if (deviceScaleFactor.HasValue) {
+            contextOptions.DeviceScaleFactor = deviceScaleFactor.Value;
         }
 
         var context = await browserInstance.NewContextAsync(contextOptions);
@@ -110,8 +123,12 @@ public static partial class HtmlBrowser {
         string? videoPath = null,
         int videoWidth = 800,
         int videoHeight = 600,
-        string? storageStatePath = null)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath);
+        string? storageStatePath = null,
+        string? userAgent = null,
+        int? viewportWidth = null,
+        int? viewportHeight = null,
+        float? deviceScaleFactor = null)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -126,7 +143,7 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0) {
+    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -136,7 +153,14 @@ public static partial class HtmlBrowser {
             formLogin,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            videoPath: null,
+            videoWidth: 800,
+            videoHeight: 600,
+            storageStatePath: null,
+            userAgent: userAgent,
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight,
+            deviceScaleFactor: deviceScaleFactor).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -146,9 +170,9 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0) {
+    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null) {
         string fullPath = HtmlUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo).ConfigureAwait(false);
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 

--- a/Tests/Invoke-HTMLRendering.Tests.ps1
+++ b/Tests/Invoke-HTMLRendering.Tests.ps1
@@ -12,4 +12,17 @@ Describe 'Invoke-HTMLRendering' {
         $html = Invoke-HTMLRendering -Url $uri -Browser Firefox
         $html | Should -Match 'Dynamic Content'
     }
+
+    It 'Applies custom browser context options' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session -UserAgent 'MyAgent' -ViewportWidth 123 -ViewportHeight 77 -DeviceScaleFactor 1.5
+        $ua = $session.Page.EvaluateAsync('navigator.userAgent',$null).GetAwaiter().GetResult()
+        $w = [int]($session.Page.EvaluateAsync('window.innerWidth',$null).GetAwaiter().GetResult().ToString())
+        $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
+        Close-HTMLSession -Session $session
+        $ua | Should -Be 'MyAgent'
+        $w | Should -Be 123
+        [double]$d | Should -Be 1.5
+    }
 }

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -29,4 +29,18 @@ describe 'HTML Video Recording' {
         Stop-HTMLVideoRecording -Session $record
         (Test-Path $out) | Should -BeTrue
     }
+
+    it 'Applies custom options' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $out = Join-Path $TestDrive 'opts.webm'
+        $session = Start-HTMLVideoRecording -Url $uri -OutFile $out -Width 320 -Height 240 -UserAgent 'VideoUA' -ViewportWidth 200 -ViewportHeight 150 -DeviceScaleFactor 2
+        $ua = $session.Page.EvaluateAsync('navigator.userAgent',$null).GetAwaiter().GetResult()
+        $w = [int]($session.Page.EvaluateAsync('window.innerWidth',$null).GetAwaiter().GetResult().ToString())
+        $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
+        Stop-HTMLVideoRecording -Session $session
+        $ua | Should -Be 'VideoUA'
+        $w | Should -Be 200
+        [double]$d | Should -Be 2
+    }
 }


### PR DESCRIPTION
## Summary
- allow customizing Playwright context in `CreatePageAsync`
- add parameters to `Invoke-HTMLRendering` and `Start-HTMLVideoRecording`
- document new options in README
- test that the options take effect

## Testing
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684dd59fe084832eab3b4cbdb52ec231