### PR TITLE
Implement Register-HTMLRoute

### DIFF
--- a/Docs/Examples/04-InterceptRequests/README.MD
+++ b/Docs/Examples/04-InterceptRequests/README.MD
@@ -1,0 +1,38 @@
+# `Register-HTMLRoute`
+
+## 📖 Summary
+
+`Register-HTMLRoute` lets you intercept network requests inside a browser session. Use it to block calls or return custom responses when testing pages.
+
+---
+
+## 💡 Example
+
+```powershell
+$page = Join-Path $PSScriptRoot 'route_page.html'
+$uri = [System.Uri]::new($page).AbsoluteUri
+$session = Start-HTMLSession -Url $uri
+
+# Return custom JSON instead of the real file
+$handler = Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock {
+    param($route)
+    $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
+        Status = 200
+        ContentType = 'application/json'
+        Body = '{"message":"mock"}'
+    }) | Out-Null
+}
+
+Invoke-HTMLNavigation -Session $session -Url $uri
+Get-HTMLContent -Session $session -Selector '#result' -AsText
+# -> 'mock'
+
+Unregister-HTMLRoute -Session $session -Pattern '*data.json' -Handler $handler
+Close-HTMLSession -Session $session
+```
+
+To simply block a request:
+
+```powershell
+Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
+```

--- a/Docs/Examples/04-InterceptRequests/README.MD
+++ b/Docs/Examples/04-InterceptRequests/README.MD
@@ -14,7 +14,7 @@ $uri = [System.Uri]::new($page).AbsoluteUri
 $session = Start-HTMLSession -Url $uri
 
 # Return custom JSON instead of the real file
-$handler = Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock {
+$handler = Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock {
     param($route)
     $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
         Status = 200
@@ -27,12 +27,12 @@ Invoke-HTMLNavigation -Session $session -Url $uri
 Get-HTMLContent -Session $session -Selector '#result' -AsText
 # -> 'mock'
 
-Unregister-HTMLRoute -Session $session -Pattern '*data.json' -Handler $handler
+Unregister-HTMLRoute -Session $session -Pattern '**/data.json' -Handler $handler
 Close-HTMLSession -Session $session
 ```
 
 To simply block a request:
 
 ```powershell
-Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
+Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
 ```

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Get-HTMLCookie', 'Set-HTMLCookie')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Unregister-HTMLRoute')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Unregister-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Unregister-HTMLRoute')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Unregister-HTMLRoute')
+    CmdletsToExport        = @('Close-HTMLSession', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLInteractable', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Unregister-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -52,6 +52,7 @@
 - `Save-HTMLAttachment` - download files discovered on a rendered page (optionally filter with `-Filter`, alias: `Save-HTMLDownload`)
 - `Invoke-HTMLNavigation` - navigate an existing session to another URL
 - `Get-HTMLInteractable` - list clickable elements from a session, URL or file
+- `Register-HTMLRoute`/`Unregister-HTMLRoute` - intercept requests to block or mock responses
 - `Close-HTMLSession` - dispose an active browser session (`Stop-HTMLSession` alias)
 
 All cmdlets that work with files accept a `-Path` parameter (or alias) in addition to `-File`. Relative, absolute and UNC paths are resolved to full paths automatically.
@@ -117,6 +118,13 @@ Save-HTMLScreenshot -Session $session -OutFile '.\secure.png' -Selector '#conten
 Invoke-HTMLNavigation -Session $session -Url 'https://example.com/downloads' |
     Save-HTMLScreenshot -OutFile '.\downloads.png'
 Save-HTMLAttachment -Session $session -Path '.\Downloads'
+# Mock an API response
+$handler = Register-HTMLRoute -Session $session -Pattern '*api/data' -ScriptBlock {
+    param($route)
+    $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{ Status = 200; ContentType = 'application/json'; Body = '{"ok":true}' }) | Out-Null
+}
+Invoke-HTMLNavigation -Session $session -Url 'https://example.com/api/data'
+Unregister-HTMLRoute -Session $session -Pattern '*api/data' -Handler $handler
 Close-HTMLSession -Session $session
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -94,8 +94,8 @@ Optimize-HTML -Path '.\page.html'
 Optimize-JavaScript -Path '.\app.js' -OutputFile '.\app.min.js'
 
 # Render a page after executing JavaScript
-Invoke-HTMLRendering -Url 'https://example.com' -Browser Chromium -Clean
-
+$handler = Register-HTMLRoute -Session $session -Pattern '**/api/data' -ScriptBlock {
+Unregister-HTMLRoute -Session $session -Pattern '**/api/data' -Handler $handler
 # Render a protected page using credentials
 $cred = Get-Credential
 Invoke-HTMLRendering -Url 'https://example.com' -Credential $cred

--- a/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that registers a Playwright route handler for an active session.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Register, "HTMLRoute")]
+public sealed class CmdletRegisterHtmlRoute : AsyncPSCmdlet {
+    /// <summary>Browser session in use.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>URL pattern for the route.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>Script block executed for each matching request.</summary>
+    [Parameter(Mandatory = true, Position = 2)]
+    public ScriptBlock? ScriptBlock { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        ScriptBlock block = ScriptBlock ?? throw new PSArgumentNullException(nameof(ScriptBlock));
+        Func<IRoute, Task> handler = route => {
+            object? result = block.InvokeReturnAsIs(route);
+            return result is Task t ? t : Task.CompletedTask;
+        };
+
+        await HtmlBrowser.RegisterRouteAsync(session, Pattern, handler).ConfigureAwait(false);
+        WriteObject(handler);
+    }
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML.PowerShell;
+
+/// <summary>
+/// Cmdlet that removes a previously registered Playwright route handler.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Unregister, "HTMLRoute")]
+public sealed class CmdletUnregisterHtmlRoute : AsyncPSCmdlet {
+    /// <summary>Browser session in use.</summary>
+    [Parameter(Position = 0, ValueFromPipeline = true)]
+    public HtmlBrowserSession? Session { get; set; }
+
+    /// <summary>URL pattern for the route.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>Handler returned by Register-HTMLRoute.</summary>
+    [Parameter(Position = 2)]
+    public Delegate? Handler { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync() {
+        HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
+            ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+
+        await HtmlBrowser.UnregisterRouteAsync(session, Pattern, Handler as Func<IRoute, Task>).ConfigureAwait(false);
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PSParseHTML;
+
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Registers a network route handler on the specified page.
+    /// </summary>
+    public static Task RegisterRouteAsync(IPage page, string pattern, Func<IRoute, Task> handler)
+        => page.RouteAsync(pattern, handler);
+
+    /// <summary>
+    /// Registers a network route handler on the session page.
+    /// </summary>
+    public static Task RegisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task> handler)
+        => RegisterRouteAsync(session.Page, pattern, handler);
+
+    /// <summary>
+    /// Removes a previously registered route handler from the page.
+    /// </summary>
+    public static Task UnregisterRouteAsync(IPage page, string pattern, Func<IRoute, Task>? handler = null)
+        => handler is null ? page.UnrouteAsync(pattern) : page.UnrouteAsync(pattern, handler);
+
+    /// <summary>
+    /// Removes a previously registered route handler from the session page.
+    /// </summary>
+    public static Task UnregisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task>? handler = null)
+        => UnregisterRouteAsync(session.Page, pattern, handler);
+}

--- a/Tests/Documents/data.json
+++ b/Tests/Documents/data.json
@@ -1,0 +1,1 @@
+{"message":"original"}

--- a/Tests/Documents/route_page.html
+++ b/Tests/Documents/route_page.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<script>
+async function load(){
+  try {
+    const r = await fetch('data.json');
+    const j = await r.json();
+    document.getElementById('result').textContent = j.message;
+  } catch(e){
+    document.getElementById('result').textContent = 'error';
+  }
+}
+window.addEventListener('DOMContentLoaded', load);
+</script>
+</head>
+<body>
+<div id="result">loading</div>
+</body>
+</html>

--- a/Tests/Documents/route_page.html
+++ b/Tests/Documents/route_page.html
@@ -5,7 +5,7 @@
 <script>
 async function load(){
   try {
-    const r = await fetch('data.json');
+    const r = await fetch('https://example.com/data.json');
     const j = await r.json();
     document.getElementById('result').textContent = j.message;
   } catch(e){

--- a/Tests/Register-HTMLRoute.Tests.ps1
+++ b/Tests/Register-HTMLRoute.Tests.ps1
@@ -3,7 +3,7 @@ Describe 'Register-HTMLRoute' {
         $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
         $uri = [System.Uri]::new($pagePath).AbsoluteUri
         $session = Invoke-HTMLRendering -Url $uri -Session
-        Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
+        Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
         Invoke-HTMLNavigation -Session $session -Url $uri
         $text = Get-HTMLContent -Session $session -Selector '#result' -AsText
         $text | Should -Be 'error'
@@ -14,7 +14,7 @@ Describe 'Register-HTMLRoute' {
         $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
         $uri = [System.Uri]::new($pagePath).AbsoluteUri
         $session = Invoke-HTMLRendering -Url $uri -Session
-        Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock {
+        Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock {
             param($route)
             $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
                 Status = 200

--- a/Tests/Register-HTMLRoute.Tests.ps1
+++ b/Tests/Register-HTMLRoute.Tests.ps1
@@ -1,0 +1,30 @@
+Describe 'Register-HTMLRoute' {
+    It 'Blocks a request to data.json' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        $text = Get-HTMLContent -Session $session -Selector '#result' -AsText
+        $text | Should -Be 'error'
+        Close-HTMLSession -Session $session
+    }
+
+    It 'Rewrites request to data.json' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $session = Invoke-HTMLRendering -Url $uri -Session
+        Register-HTMLRoute -Session $session -Pattern '*data.json' -ScriptBlock {
+            param($route)
+            $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
+                Status = 200
+                ContentType = 'application/json'
+                Body = '{"message":"mock"}'
+            }) | Out-Null
+        }
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        $text = Get-HTMLContent -Session $session -Selector '#result' -AsText
+        $text | Should -Be 'mock'
+        Close-HTMLSession -Session $session
+    }
+}


### PR DESCRIPTION
## Summary
- add HtmlBrowser route helpers
- expose via Register-HTMLRoute and Unregister-HTMLRoute cmdlets
- document route interception and add example
- add tests for blocking and rewriting requests

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_684dd857b0ec832ebb6ef249b4b4a3a5