### PR TITLE
Add proxy support to Playwright operations

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -40,6 +40,16 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetFile)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Proxy server address used when launching the browser.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public string? Proxy { get; set; }
+
+    /// <summary>Credentials used for the <see cref="Proxy"/> server.</summary>
+    [Parameter(ParameterSetName = ParameterSetUrl)]
+    [Parameter(ParameterSetName = ParameterSetFile)]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Show the browser instead of running headless.</summary>
     [Parameter(ParameterSetName = ParameterSetUrl)]
     [Parameter(ParameterSetName = ParameterSetFile)]
@@ -94,6 +104,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         List<HtmlInteractableInfo> list;
+        string? pUser = ProxyCredential?.UserName;
+        string? pPass = ProxyCredential?.GetNetworkCredential().Password;
         switch (ParameterSetName) {
             case ParameterSetUrl:
                 string? user = Credential?.UserName ?? Username;
@@ -120,7 +132,10 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     form,
                     headless: !Visible.IsPresent,
                     slowMo: SlowMo,
-                    storageStatePath: null).ConfigureAwait(false)) {
+                    storageStatePath: null,
+                    proxy: Proxy,
+                    proxyUsername: pUser,
+                    proxyPassword: pPass).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;
@@ -135,7 +150,10 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     null,
                     headless: !Visible.IsPresent,
                     slowMo: SlowMo,
-                    storageStatePath: null).ConfigureAwait(false)) {
+                    storageStatePath: null,
+                    proxy: Proxy,
+                    proxyUsername: pUser,
+                    proxyPassword: pPass).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -41,6 +41,14 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetFile)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Proxy server address used when launching the browser.</summary>
+    [Parameter]
+    public string? Proxy { get; set; }
+
+    /// <summary>Credentials used for the <see cref="Proxy"/> server.</summary>
+    [Parameter]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Credentials used when accessing authenticated pages.</summary>
     [Parameter]
     public PSCredential? Credential { get; set; }
@@ -104,6 +112,8 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         string? user = Credential?.UserName ?? Username;
         string? pass = Credential?.GetNetworkCredential().Password ?? Password;
+        string? pUser = ProxyCredential?.UserName;
+        string? pPass = ProxyCredential?.GetNetworkCredential().Password;
         HtmlFormLogin? form = null;
         if (!string.IsNullOrEmpty(LoginUrl) && !string.IsNullOrEmpty(UsernameSelector) && !string.IsNullOrEmpty(PasswordSelector) && !string.IsNullOrEmpty(SubmitSelector)) {
             form = new HtmlFormLogin {
@@ -132,16 +142,19 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 userAgent: UserAgent,
                 viewportWidth: ViewportWidth,
                 viewportHeight: ViewportHeight,
-                deviceScaleFactor: (float?)DeviceScaleFactor).ConfigureAwait(false);
+                deviceScaleFactor: (float?)DeviceScaleFactor,
+                proxy: Proxy,
+                proxyUsername: pUser,
+                proxyPassword: pPass).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             string outPath = HtmlUtilities.ResolvePath(OutFile!);
-            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor).ConfigureAwait(false);
+            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor).ConfigureAwait(false);
+            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -55,6 +55,14 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetFileClip)]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Proxy server address used when launching the browser.</summary>
+    [Parameter]
+    public string? Proxy { get; set; }
+
+    /// <summary>Credentials used for the <see cref="Proxy"/> server.</summary>
+    [Parameter]
+    public PSCredential? ProxyCredential { get; set; }
+
     /// <summary>Show the browser instead of running headless.</summary>
     [Parameter]
     public SwitchParameter Visible { get; set; }
@@ -110,6 +118,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        string? pUser = ProxyCredential?.UserName;
+        string? pPass = ProxyCredential?.GetNetworkCredential().Password;
 
         if (string.IsNullOrWhiteSpace(OutFile)) {
             if (Open.IsPresent) {
@@ -139,7 +149,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Width,
                     Height,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: pUser,
+                    proxyPassword: pPass).ConfigureAwait(false);
                 break;
             case ParameterSetFileClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
@@ -155,7 +168,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Width,
                     Height,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: pUser,
+                    proxyPassword: pPass).ConfigureAwait(false);
                 break;
             case ParameterSetSessionClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
@@ -190,7 +206,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Delay,
                     Selector,
                     headless: !Visible.IsPresent,
-                    slowMo: SlowMo).ConfigureAwait(false);
+                    slowMo: SlowMo,
+                    proxy: Proxy,
+                    proxyUsername: pUser,
+                    proxyPassword: pPass).ConfigureAwait(false);
                 break;
         }
 

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -38,12 +38,15 @@ public static partial class HtmlBrowser {
             string? footerTemplate = null,
             bool preferCssPageSize = false,
             bool outline = false,
-            bool tagged = false,
-            string? username = null,
-            string? password = null,
-            HtmlFormLogin? formLogin = null,
-            bool headless = true,
-            int slowMo = 0) {
+        bool tagged = false,
+        string? username = null,
+        string? password = null,
+        HtmlFormLogin? formLogin = null,
+        bool headless = true,
+        int slowMo = 0,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -53,7 +56,10 @@ public static partial class HtmlBrowser {
             formLogin,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            null,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
 
         await SavePagePdfAsync(
             session.Page,

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -42,7 +42,10 @@ public static partial class HtmlBrowser {
         string? password = null,
         HtmlFormLogin? formLogin = null,
         bool headless = true,
-        int slowMo = 0) {
+        int slowMo = 0,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -52,7 +55,10 @@ public static partial class HtmlBrowser {
             formLogin,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            null,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
 
         string fullPath = HtmlUtilities.ResolvePath(path);
         await CaptureScreenshotAsync(

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -24,7 +24,7 @@ public static partial class HtmlBrowser {
         int? viewportWidth = null,
         int? viewportHeight = null,
         float? deviceScaleFactor = null)
-        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, userAgent, viewportWidth, viewportHeight, deviceScaleFactor);
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy: null, proxyUsername: null, proxyPassword: null);
 
     /// <summary>
     /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
@@ -65,7 +65,10 @@ public static partial class HtmlBrowser {
             userAgent: userAgent,
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
-            deviceScaleFactor: deviceScaleFactor).ConfigureAwait(false);
+            deviceScaleFactor: deviceScaleFactor,
+            proxy: null,
+            proxyUsername: null,
+            proxyPassword: null).ConfigureAwait(false);
 
         File.Delete(temp);
         return newSession;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -30,7 +30,10 @@ public static partial class HtmlBrowser {
         string? userAgent = null,
         int? viewportWidth = null,
         int? viewportHeight = null,
-        float? deviceScaleFactor = null) {
+        float? deviceScaleFactor = null,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null) {
         if (clean) {
             CleanInstallDir();
         }
@@ -47,10 +50,18 @@ public static partial class HtmlBrowser {
             _ => playwright.Chromium,
         };
 
-        var browserInstance = await type.LaunchAsync(new BrowserTypeLaunchOptions {
+        var launchOptions = new BrowserTypeLaunchOptions {
             Headless = headless,
             SlowMo = slowMo
-        });
+        };
+        if (!string.IsNullOrEmpty(proxy)) {
+            launchOptions.Proxy = new Proxy {
+                Server = proxy,
+                Username = proxyUsername,
+                Password = proxyPassword
+            };
+        }
+        var browserInstance = await type.LaunchAsync(launchOptions);
         BrowserNewContextOptions? contextOptions = null;
         if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
             contextOptions = new BrowserNewContextOptions {
@@ -128,8 +139,11 @@ public static partial class HtmlBrowser {
         string? userAgent = null,
         int? viewportWidth = null,
         int? viewportHeight = null,
-        float? deviceScaleFactor = null)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor);
+        float? deviceScaleFactor = null,
+        string? proxy = null,
+        string? proxyUsername = null,
+        string? proxyPassword = null)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -144,7 +158,7 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null) {
+    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -161,7 +175,10 @@ public static partial class HtmlBrowser {
             userAgent: userAgent,
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
-            deviceScaleFactor: deviceScaleFactor).ConfigureAwait(false);
+            deviceScaleFactor: deviceScaleFactor,
+            proxy: proxy,
+            proxyUsername: proxyUsername,
+            proxyPassword: proxyPassword).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -171,9 +188,9 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null) {
+    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null) {
         string fullPath = HtmlUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor).ConfigureAwait(false);
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 

--- a/Tests/Invoke-HTMLRendering.Tests.ps1
+++ b/Tests/Invoke-HTMLRendering.Tests.ps1
@@ -25,4 +25,11 @@ Describe 'Invoke-HTMLRendering' {
         $w | Should -Be 123
         [double]$d | Should -Be 1.5
     }
+
+    It 'Supports proxy parameters' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $html = Invoke-HTMLRendering -Url $uri -Proxy 'http://localhost:8080'
+        $html | Should -Match 'Dynamic Content'
+    }
 }

--- a/Tests/Proxy.Tests.ps1
+++ b/Tests/Proxy.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Proxy parameters' {
     It 'Cmdlets expose proxy parameters' {
-        $cmdlets = 'ConvertFrom-HTML','ConvertFrom-HtmlTable','ConvertFrom-HtmlAttributes','ConvertFrom-HtmlList','Convert-HTMLToText'
+        $cmdlets = 'ConvertFrom-HTML','ConvertFrom-HtmlTable','ConvertFrom-HtmlAttributes','ConvertFrom-HtmlList','Convert-HTMLToText','Invoke-HTMLRendering','Save-HTMLScreenshot'
         foreach($cmd in $cmdlets){
             $params = (Get-Command $cmd).Parameters.Keys
             $params | Should -Contain 'Proxy'

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -7,6 +7,14 @@ Describe 'Save-HTMLScreenshot' {
         (Test-Path $outfile) | Should -BeTrue
     }
 
+    It 'Supports proxy parameters' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'proxy.png'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -Proxy 'http://localhost:8080'
+        (Test-Path $outfile) | Should -BeTrue
+    }
+
     It 'Creates a full page screenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri


### PR DESCRIPTION
## Summary
- allow `HtmlBrowser.CreatePageAsync` to use a proxy
- plumb proxy settings through Playwright helper methods
- expose `-Proxy` and `-ProxyCredential` in Playwright cmdlets
- test proxy options for `Invoke-HTMLRendering` and `Save-HTMLScreenshot`
- verify proxy parameters are exposed on public cmdlets

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684e8a25af6c832e909525c01581f583