### PR TITLE
Add element selector screenshot option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -42,7 +42,7 @@
 - `Invoke-HTMLRendering` - render pages with a headless browser (supports basic and form authentication)
   - `Open-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
   - `Start-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
-- `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, clipping parameters, `-Delay` and `-Selector`)
+- `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, `-ElementSelector`, clipping parameters, `-Delay` and `-Selector`)
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
 - `UserAgent`, `-ViewportWidth`, `-ViewportHeight` and `-DeviceScaleFactor` allow customizing the browser context
 - `Save-HTMLPdf` - generate a PDF of a rendered page
@@ -108,6 +108,7 @@ Invoke-HTMLRendering -Url 'https://example.com/protected' `
     -PasswordSelector 'input[name=pwd]' `
     -SubmitSelector '#wp-submit'
 Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\page.png -Full -Open -Delay 1000 -Selector '#content'
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\header.png -ElementSelector 'header'
 Save-HTMLPdf -Url 'https://example.com' -OutFile .\page.pdf -PrintBackground
 Save-HTMLAttachment -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads'
 Save-HTMLAttachment -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads' -Filter '.zip'

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -91,6 +91,10 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [Parameter]
     public string? Selector { get; set; }
 
+    /// <summary>CSS selector of an element to capture.</summary>
+    [Parameter]
+    public string? ElementSelector { get; set; }
+
     /// <summary>X coordinate for a clip region.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetSessionClip)]
@@ -144,6 +148,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     false,
                     Delay,
                     Selector,
+                    ElementSelector,
                     X,
                     Y,
                     Width,
@@ -163,6 +168,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     false,
                     Delay,
                     Selector,
+                    ElementSelector,
                     X,
                     Y,
                     Width,
@@ -180,6 +186,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     false,
                     Delay,
                     Selector,
+                    ElementSelector,
                     X,
                     Y,
                     Width,
@@ -191,7 +198,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     HtmlUtilities.ResolvePath(OutFile!),
                     Full.IsPresent,
                     Delay,
-                    Selector).ConfigureAwait(false);
+                    Selector,
+                    ElementSelector).ConfigureAwait(false);
                 break;
             default:
                 string target = ParameterSetName == ParameterSetFileDefault
@@ -205,6 +213,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Full.IsPresent,
                     Delay,
                     Selector,
+                    ElementSelector,
                     headless: !Visible.IsPresent,
                     slowMo: SlowMo,
                     proxy: Proxy,

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -22,6 +22,7 @@ public static partial class HtmlBrowser {
     /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
     /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
     /// <param name="selector">Optional CSS selector to wait for before capturing.</param>
+    /// <param name="elementSelector">CSS selector of an element to capture.</param>
     /// <param name="clipX">Optional clip region X coordinate.</param>
     /// <param name="clipY">Optional clip region Y coordinate.</param>
     /// <param name="clipWidth">Optional clip region width.</param>
@@ -34,6 +35,7 @@ public static partial class HtmlBrowser {
         bool fullPage = false,
         int delayMs = 0,
         string? selector = null,
+        string? elementSelector = null,
         int? clipX = null,
         int? clipY = null,
         int? clipWidth = null,
@@ -67,6 +69,7 @@ public static partial class HtmlBrowser {
             fullPage,
             delayMs,
             selector,
+            elementSelector,
             clipX,
             clipY,
             clipWidth,
@@ -76,12 +79,23 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Captures a screenshot of an already loaded page.
     /// </summary>
+    /// <param name="page">Playwright page instance.</param>
+    /// <param name="path">File path for the screenshot.</param>
+    /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
+    /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
+    /// <param name="selector">Optional CSS selector to wait for before capturing.</param>
+    /// <param name="elementSelector">CSS selector of an element to capture.</param>
+    /// <param name="clipX">Optional clip region X coordinate.</param>
+    /// <param name="clipY">Optional clip region Y coordinate.</param>
+    /// <param name="clipWidth">Optional clip region width.</param>
+    /// <param name="clipHeight">Optional clip region height.</param>
     public static async Task CaptureScreenshotAsync(
         IPage page,
         string path,
         bool fullPage = false,
         int delayMs = 0,
         string? selector = null,
+        string? elementSelector = null,
         int? clipX = null,
         int? clipY = null,
         int? clipWidth = null,
@@ -91,6 +105,17 @@ public static partial class HtmlBrowser {
         }
         if (delayMs > 0) {
             await page.WaitForTimeoutAsync(delayMs);
+        }
+
+        if (!string.IsNullOrEmpty(elementSelector)) {
+            var locator = page.Locator(elementSelector);
+            var box = await locator.BoundingBoxAsync();
+            if (box != null) {
+                clipX = (int)Math.Floor(box.X);
+                clipY = (int)Math.Floor(box.Y);
+                clipWidth = (int)Math.Ceiling(box.Width);
+                clipHeight = (int)Math.Ceiling(box.Height);
+            }
         }
 
         string fullPath = HtmlUtilities.ResolvePath(path);

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -31,6 +31,14 @@ Describe 'Save-HTMLScreenshot' {
         (Test-Path $outfile) | Should -BeTrue
     }
 
+    It 'Captures a single element screenshot' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'element.png'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -ElementSelector '#loaded'
+        (Test-Path $outfile) | Should -BeTrue
+    }
+
     It 'Defaults to temp file when using -Open without OutFile' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri


### PR DESCRIPTION
## Summary
- add `ElementSelector` parameter to screenshot helpers and cmdlet
- compute screenshot clip from bounding box via Playwright
- document new option
- test capturing a single element

## Testing
- `dotnet build Sources/PSParseHTML.sln --configuration Debug`
- `pwsh -NoLogo -File ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684fdc86ecec832e8d4ea4f9c3ccb5db