### PR TITLE
Enable remote CSS inlining

### DIFF
--- a/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
+++ b/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
@@ -409,6 +409,16 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <!-- Parameter: DownloadRemoteCss -->
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>DownloadRemoteCss</maml:name>
+          <command:parameterValue required="true">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <!-- Parameter set: File -->
       <command:syntaxItem>
@@ -564,6 +574,16 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <!-- Parameter: DownloadRemoteCss -->
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>DownloadRemoteCss</maml:name>
+          <command:parameterValue required="true">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -698,6 +718,19 @@
         <maml:name>UseEmailFormatter</maml:name>
         <maml:description>
           <maml:para>Use the email formatter when generating HTML.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <!-- Parameter: DownloadRemoteCss -->
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>DownloadRemoteCss</maml:name>
+        <maml:description>
+          <maml:para>Download CSS from &lt;link&gt; elements.</maml:para>
         </maml:description>
         <command:parameterValue required="true">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/README.MD
+++ b/README.MD
@@ -34,7 +34,7 @@
 - `Format-HTML` - tidy up HTML markup
 - `Format-JavaScript` - beautify JavaScript (`Format-JS` alias)
 - `Optimize-CSS` - minify style sheets
-- `Optimize-Email` - inline CSS for email bodies
+- `Optimize-Email` - inline CSS for email bodies (can download linked stylesheets)
 - `Optimize-HTML` - minify HTML
 - `Optimize-JavaScript` - minify JavaScript
 
@@ -85,8 +85,8 @@ Format-JavaScript -Path '.\script.js'
 # Minify a CSS file
 Optimize-CSS -Path '.\style.css'
 
-# Inline CSS in an email body
-Optimize-Email -Body $html -UseEmailFormatter
+# Inline CSS in an email body (fetch linked stylesheets)
+Optimize-Email -Body $html -UseEmailFormatter -DownloadRemoteCss
 
 # Minify an HTML file
 Optimize-HTML -Path '.\page.html'

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -65,6 +65,10 @@ public sealed class CmdletOptimizeEmail : PSCmdlet {
     [Parameter]
     public SwitchParameter UseEmailFormatter { get; set; }
 
+    /// <summary>Download CSS from &lt;link&gt; elements.</summary>
+    [Parameter]
+    public SwitchParameter DownloadRemoteCss { get; set; }
+
     /// <summary>Add Google Analytics tags.</summary>
     [Parameter]
     public SwitchParameter AddAnalyticsTags { get; set; }
@@ -129,6 +133,7 @@ public sealed class CmdletOptimizeEmail : PSCmdlet {
             RemoveComments = RemoveComments,
             PreserveMediaQueries = PreserveMediaQueries,
             UseEmailFormatter = UseEmailFormatter,
+            DownloadRemoteCss = DownloadRemoteCss,
             AddAnalyticsTags = AddAnalyticsTags,
             AnalyticsSource = AnalyticsSource,
             AnalyticsMedium = AnalyticsMedium,

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -67,7 +67,12 @@ public class PreMailerClient {
 
                             if (uri.IsFile)
                             {
-                                cssContent += File.ReadAllText(uri.LocalPath);
+                                string localPath = uri.LocalPath;
+                                if (uri.IsUnc && Path.DirectorySeparatorChar == '/')
+                                {
+                                    localPath = "/" + localPath.TrimStart('\\');
+                                }
+                                cssContent += File.ReadAllText(localPath);
                             }
                             else if (uri.IsAbsoluteUri)
                             {

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Net.Http;
+using AngleSharp.Dom;
 using PreMailer.Net;
 
 namespace PSParseHTML;
@@ -43,6 +45,46 @@ public class PreMailerClient {
     public PreMailerResult MoveCssInline() {
         try {
             string cssContent = Options.Css ?? string.Empty;
+            string htmlToProcess = _html;
+
+            var document = HtmlParser.ParseWithAngleSharp(_html);
+                foreach (var link in document.QuerySelectorAll("link")) {
+                    string? href = link.GetAttribute("href");
+                    string? rel = link.GetAttribute("rel");
+                    bool isCss = !string.IsNullOrEmpty(href) &&
+                        (href.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
+                         (rel != null && rel.Equals("stylesheet", StringComparison.OrdinalIgnoreCase)));
+                    if (!isCss) {
+                        continue;
+                    }
+
+                    if (Options.DownloadRemoteCss && href != null) {
+                        try {
+                            Uri uri = new Uri(href, UriKind.RelativeOrAbsolute);
+                            if (!uri.IsAbsoluteUri && Options.BaseUri != null) {
+                                uri = new Uri(Options.BaseUri, uri);
+                            }
+
+                            if (uri.IsFile)
+                            {
+                                cssContent += File.ReadAllText(uri.LocalPath);
+                            }
+                            else if (uri.IsAbsoluteUri)
+                            {
+                                using HttpClient client = new();
+                                cssContent += HtmlUtilities
+                                    .GetStringWithProperEncodingAsync(client, uri.ToString())
+                                    .GetAwaiter().GetResult();
+                            }
+                        } catch (Exception ex) {
+                            LoggingMessages.Logger.WriteError("Failed to download CSS from {0}: {1}", href, ex.Message);
+                        }
+                    }
+
+                    link.Remove();
+                }
+
+            htmlToProcess = document.DocumentElement.OuterHtml;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
                 string cssPath = HtmlUtilities.ResolvePath(Options.CssFilePath!);
                 if (!File.Exists(cssPath)) {
@@ -52,8 +94,8 @@ public class PreMailerClient {
             }
 
             PreMailer.Net.PreMailer preMailer = Options.BaseUri != null
-                ? new PreMailer.Net.PreMailer(_html, Options.BaseUri)
-                : new PreMailer.Net.PreMailer(_html);
+                ? new PreMailer.Net.PreMailer(htmlToProcess, Options.BaseUri)
+                : new PreMailer.Net.PreMailer(htmlToProcess);
 
             if (Options.AddAnalyticsTags && !string.IsNullOrEmpty(Options.AnalyticsSource)) {
                 preMailer.AddAnalyticsTags(
@@ -115,6 +157,7 @@ public class PreMailerClient {
         global::AngleSharp.IMarkupFormatter? customFormatter = null,
         bool preserveMediaQueries = false,
         bool useEmailFormatter = false,
+        bool downloadRemoteCss = false,
         bool addAnalyticsTags = false,
         string? analyticsSource = null,
         string? analyticsMedium = null,
@@ -133,6 +176,7 @@ public class PreMailerClient {
             CustomFormatter = customFormatter,
             PreserveMediaQueries = preserveMediaQueries,
             UseEmailFormatter = useEmailFormatter,
+            DownloadRemoteCss = downloadRemoteCss,
             AddAnalyticsTags = addAnalyticsTags,
             AnalyticsSource = analyticsSource,
             AnalyticsMedium = analyticsMedium,
@@ -159,6 +203,7 @@ public class PreMailerClient {
         global::AngleSharp.IMarkupFormatter? customFormatter = null,
         bool preserveMediaQueries = false,
         bool useEmailFormatter = false,
+        bool downloadRemoteCss = false,
         bool addAnalyticsTags = false,
         string? analyticsSource = null,
         string? analyticsMedium = null,
@@ -177,6 +222,7 @@ public class PreMailerClient {
             CustomFormatter = customFormatter,
             PreserveMediaQueries = preserveMediaQueries,
             UseEmailFormatter = useEmailFormatter,
+            DownloadRemoteCss = downloadRemoteCss,
             AddAnalyticsTags = addAnalyticsTags,
             AnalyticsSource = analyticsSource,
             AnalyticsMedium = analyticsMedium,

--- a/Sources/PSParseHTML/PreMailer/PreMailerOptions.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerOptions.cs
@@ -37,6 +37,11 @@ public class PreMailerOptions {
     /// <summary>Use email formatter when generating HTML.</summary>
     public bool UseEmailFormatter { get; set; }
 
+    /// <summary>
+    /// When enabled, CSS from <link> tags will be downloaded and inlined.
+    /// </summary>
+    public bool DownloadRemoteCss { get; set; }
+
     // Analytics configuration
     /// <summary>Add Google Analytics tags.</summary>
     public bool AddAnalyticsTags { get; set; }

--- a/Tests/Optimize-Email.Tests.ps1
+++ b/Tests/Optimize-Email.Tests.ps1
@@ -27,4 +27,16 @@ Describe 'Optimize-Email' {    It 'Given HTML content - Should inline CSS and re
         $normalizedExpected = $expected -replace '\r\n', "`n" -replace '\r', "`n"
         Should -Actual $normalizedResult -Be $normalizedExpected
     }
+
+    It 'Given linked stylesheet - Should inline when DownloadRemoteCss is enabled' {
+        $cssPath = Join-Path $TestDrive 'styles.css'
+        'p{color:green}' | Set-Content -Path $cssPath
+        $uri = [System.IO.Path]::GetFullPath($cssPath) -replace '\\','/'
+        $html = "<html><head><link rel='stylesheet' href='file:///$uri'></head><body><p>Link</p></body></html>"
+        $expected = '<html><head></head><body><p style="color: green">Link</p></body></html>'
+        $result = Optimize-Email -Body $html -RemoveStyleElements -DownloadRemoteCss
+        $normalizedResult = $result -replace '\r\n', "`n" -replace '\r', "`n"
+        $normalizedExpected = $expected -replace '\r\n', "`n" -replace '\r', "`n"
+        $normalizedResult | Should -Be $normalizedExpected
+    }
 }

--- a/Tests/Optimize-Email.Tests.ps1
+++ b/Tests/Optimize-Email.Tests.ps1
@@ -31,8 +31,8 @@ Describe 'Optimize-Email' {    It 'Given HTML content - Should inline CSS and re
     It 'Given linked stylesheet - Should inline when DownloadRemoteCss is enabled' {
         $cssPath = Join-Path $TestDrive 'styles.css'
         'p{color:green}' | Set-Content -Path $cssPath
-        $uri = [System.IO.Path]::GetFullPath($cssPath) -replace '\\','/'
-        $html = "<html><head><link rel='stylesheet' href='file:///$uri'></head><body><p>Link</p></body></html>"
+        $uri = [System.Uri]::new([System.IO.Path]::GetFullPath($cssPath)).AbsoluteUri
+        $html = "<html><head><link rel='stylesheet' href='$uri'></head><body><p>Link</p></body></html>"
         $expected = '<html><head></head><body><p style="color: green">Link</p></body></html>'
         $result = Optimize-Email -Body $html -RemoveStyleElements -DownloadRemoteCss
         $normalizedResult = $result -replace '\r\n', "`n" -replace '\r', "`n"


### PR DESCRIPTION
## Summary
- allow downloading CSS from linked files
- add `DownloadRemoteCss` option to options and cmdlet
- test linked stylesheet inlining

## Testing
- `dotnet build Sources/PSParseHTML/PSParseHTML.csproj -c Release`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File PSParseHTML.Tests.ps1` *(fails: Convert-HTMLToText cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdcfa63b8832eb6cd9bdf3303e8cc