### PR TITLE
Add structured warnings for PreMailer

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -149,7 +149,7 @@ public sealed class CmdletOptimizeEmail : PSCmdlet {
         WriteObject(result.Html);
 
         foreach (var warning in result.Warnings) {
-            LoggingMessages.Logger.WriteWarning(warning);
+            LoggingMessages.Logger.WriteWarning(warning.Message);
         }
     }
 }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -120,13 +120,16 @@ public class PreMailerClient {
                 Options.CustomFormatter,
                 Options.PreserveMediaQueries);
 
+            List<PreMailerWarning> warnings = new();
             if (result.Warnings != null) {
                 foreach (string warning in result.Warnings) {
-                    LoggingMessages.Logger.WriteWarning(warning);
+                    var w = new PreMailerWarning(warning);
+                    warnings.Add(w);
+                    LoggingMessages.Logger.WriteWarning(w.Message);
                 }
             }
 
-            return new PreMailerResult(result.Html, result.Warnings ?? new List<string>());
+            return new PreMailerResult(result.Html, warnings);
         } catch (Exception ex) {
             LoggingMessages.Logger.WriteError("MoveCssInline failed with error: {0}", ex.Message);
             throw;

--- a/Sources/PSParseHTML/PreMailer/PreMailerResult.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerResult.cs
@@ -14,9 +14,9 @@ public class PreMailerResult {
     /// <summary>
     /// Any warnings returned by PreMailer.
     /// </summary>
-    public List<string> Warnings { get; }
+    public List<PreMailerWarning> Warnings { get; }
 
-    public PreMailerResult(string html, List<string> warnings) {
+    public PreMailerResult(string html, List<PreMailerWarning> warnings) {
         Html = html;
         Warnings = warnings;
     }

--- a/Sources/PSParseHTML/PreMailer/PreMailerWarning.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerWarning.cs
@@ -1,0 +1,19 @@
+namespace PSParseHTML;
+
+/// <summary>
+/// Represents a warning returned from PreMailer processing.
+/// </summary>
+public class PreMailerWarning
+{
+    /// <summary>Warning message.</summary>
+    public string Message { get; }
+
+    /// <summary>Warning severity or type.</summary>
+    public string Severity { get; }
+
+    public PreMailerWarning(string message, string severity = "Warning")
+    {
+        Message = message;
+        Severity = severity;
+    }
+}


### PR DESCRIPTION
## Summary
- add `PreMailerWarning` class
- return `PreMailerWarning` from `PreMailerClient` and `PreMailerResult`
- log warning messages from `Optimize-Email` using the new structure

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe79018ec832eacc839e2c9e73326