### PR TITLE
Add PSD1 refresh step for tests

### DIFF
--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -25,12 +25,44 @@ env:
   BUILD_CONFIGURATION: 'Debug'
 
 jobs:
+  refresh-psd1:
+    name: 'Refresh PSD1'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PowerShell modules
+        shell: pwsh
+        run: |
+          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
+
+      - name: Refresh module manifest
+        shell: pwsh
+        env:
+          RefreshPSD1Only: 'true'
+        run: |
+          .\Build\Build-Module.ps1
+
+      - name: Upload refreshed manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: psd1
+          path: PSParseHTML.psd1
+
   test-windows-ps7:
+    needs: refresh-psd1
     name: 'Windows PowerShell 7'
     runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -54,11 +86,18 @@ jobs:
         run: .\PSParseHTML.Tests.ps1
 
   test-ubuntu:
+    needs: refresh-psd1
     name: 'Ubuntu PowerShell 7'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -89,11 +128,18 @@ jobs:
         run: ./PSParseHTML.Tests.ps1
 
   test-macos:
+    needs: refresh-psd1
     name: 'macOS PowerShell 7'
     runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,3 +1,5 @@
+$RefreshPSD1Only = [bool]$Env:RefreshPSD1Only
+
 Clear-Host
 
 Build-Module -ModuleName 'PSParseHTML' {
@@ -98,7 +100,7 @@ Build-Module -ModuleName 'PSParseHTML' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $false
+        RefreshPSD1Only                   = $RefreshPSD1Only
         NETBinaryModuleDocumenation       = $true
     }
 

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,10 +1,4 @@
-<<<<<<< implement-psd1-rebuild-for-cross-platform-github-actions -- Incoming Change
-$RefreshPSD1Only = [bool]$Env:RefreshPSD1Only
-
-Clear-Host
-=======
 Import-Module PSPublishModule -Force -ErrorAction Stop
->>>>>>> v2-speedygonzales -- Current Change
 
 Build-Module -ModuleName 'PSParseHTML' {
     # Usual defaults as per standard module
@@ -104,11 +98,7 @@ Build-Module -ModuleName 'PSParseHTML' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-<<<<<<< implement-psd1-rebuild-for-cross-platform-github-actions -- Incoming Change
-        RefreshPSD1Only                   = $RefreshPSD1Only
-=======
         RefreshPSD1Only                   = $true
->>>>>>> v2-speedygonzales -- Current Change
         NETBinaryModuleDocumenation       = $true
     }
 


### PR DESCRIPTION
## Summary
- allow Build-Module.ps1 to consume `RefreshPSD1Only` from an environment variable
- build refreshed manifest on Windows and reuse it for tests

## Testing
- `pwsh -NoLogo -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501d62d870832eab329f3be1ecbe63