### PR TITLE
Fix assembly load for dev mode

### DIFF
--- a/PSParseHTML.psm1
+++ b/PSParseHTML.psm1
@@ -72,7 +72,8 @@ $BinaryDev = @(
 )
 
 if ($Development) {
-    $Assembly = Get-ChildItem -Path "$($DevelopmentAssemblyFolder.Path)\*.dll" -ErrorAction SilentlyContinue -File
+    $Assembly = Get-ChildItem -Path "$($DevelopmentAssemblyFolder.Path)\*.dll" -ErrorAction SilentlyContinue -File |
+        Where-Object { $_.Name -notlike 'lib*' }
 } else {
     $Assembly = @(
         if ($Framework -and $PSEdition -eq 'Core') {


### PR DESCRIPTION
## Summary
- skip loading native libraries in development mode

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68514958eb8c832ebc7d1b271d610f27