### PR TITLE
Fix specific nullability warnings

### DIFF
--- a/Sources/PSParseHTML/HtmlParserFromForm.cs
+++ b/Sources/PSParseHTML/HtmlParserFromForm.cs
@@ -46,8 +46,8 @@ public static class HtmlParserFromForm {
                     type = field.NodeName.ToLowerInvariant();
                 }
                 result.Fields.Add(new HtmlFormField {
-                    Name = name,
-                    Type = type!
+                    Name = name!,
+                    Type = type ?? string.Empty
                 });
             }
             results.Add(result);

--- a/Sources/PSParseHTML/HtmlParserFromTable.cs
+++ b/Sources/PSParseHTML/HtmlParserFromTable.cs
@@ -142,7 +142,7 @@ public static class HtmlParserFromTable {
                             }
                         }
                         if (string.IsNullOrEmpty(value) && !string.IsNullOrEmpty(emptyValuePlaceholder)) {
-                            value = emptyValuePlaceholder;
+                            value = emptyValuePlaceholder ?? string.Empty;
                         }
                         int colspan = 1;
                         int rowspan = 1;
@@ -528,7 +528,7 @@ public static class HtmlParserFromTable {
                             }
                         }
                         if (string.IsNullOrEmpty(value) && !string.IsNullOrEmpty(emptyValuePlaceholder)) {
-                            value = emptyValuePlaceholder;
+                            value = emptyValuePlaceholder ?? string.Empty;
                         }
                         int colspan = 1;
                         int rowspan = 1;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
@@ -14,5 +14,5 @@ public static partial class HtmlBrowser {
     /// <param name="script">JavaScript code to execute.</param>
     /// <returns>Value returned by the script.</returns>
     public static Task<T?> EvaluateAsync<T>(HtmlBrowserSession session, string script)
-        => session.Page.EvaluateAsync<T>(script);
+        => session.Page.EvaluateAsync<T?>(script);
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -119,7 +119,7 @@ public static partial class HtmlBrowser {
         }
 
         if (!string.IsNullOrEmpty(elementSelector)) {
-            var locator = page.Locator(elementSelector);
+            var locator = page.Locator(elementSelector!);
             var box = await locator.BoundingBoxAsync();
             if (box != null) {
                 clipX = (int)Math.Floor(box.X);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -59,7 +59,7 @@ public static partial class HtmlBrowser {
         };
         if (!string.IsNullOrEmpty(proxy)) {
             launchOptions.Proxy = new Proxy {
-                Server = proxy,
+                Server = proxy!,
                 Username = proxyUsername,
                 Password = proxyPassword
             };

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -48,15 +48,18 @@ public class PreMailerClient {
             string htmlToProcess = _html;
 
             var document = HtmlParser.ParseWithAngleSharp(_html);
-                foreach (var link in document.QuerySelectorAll("link")) {
-                    string? href = link.GetAttribute("href");
-                    string? rel = link.GetAttribute("rel");
-                    bool isCss = !string.IsNullOrEmpty(href) &&
-                        (href.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
-                         (rel != null && rel.Equals("stylesheet", StringComparison.OrdinalIgnoreCase)));
-                    if (!isCss) {
-                        continue;
-                    }
+            foreach (var link in document.QuerySelectorAll("link")) {
+                string? href = link.GetAttribute("href");
+                string? rel = link.GetAttribute("rel");
+
+                bool isCss = false;
+                if (!string.IsNullOrEmpty(href)) {
+                    isCss = href!.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
+                        (rel != null && rel.Equals("stylesheet", StringComparison.OrdinalIgnoreCase));
+                }
+                if (!isCss) {
+                    continue;
+                }
 
                     if (Options.DownloadRemoteCss && href != null) {
                         try {


### PR DESCRIPTION
## Summary
- ensure Playwright EvaluateAsync handles nullable return values
- improve handling of possibly null references in PreMailerClient
- prevent null assignments in HTML form/table parsers
- allow optional proxy while launching Playwright
- guard element selectors in screenshot helper

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6852f8a1897c832ea2c50dc0748481d6