### PR TITLE
Add screenshot format and quality options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -42,7 +42,7 @@
 - `Invoke-HTMLRendering` - render pages with a headless browser (supports basic and form authentication)
   - `Open-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
   - `Start-HTMLSession` is an alias to allow for nicer cmdlet naming alignment under different conditons
-- `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, `-ElementSelector`, clipping parameters, `-Delay`, `-Selector`, `-HighlightSelector` and `-OverlayText`)
+- `Save-HTMLScreenshot` - capture page screenshots (supports `-Full`, `-Open`, `-ElementSelector`, clipping parameters, `-Delay`, `-Selector`, `-HighlightSelector`, `-Format`, `-Quality` and `-OverlayText`)
 - `Visible` and `-SlowMo` parameters let you see the browser or slow down execution
 - `UserAgent`, `-ViewportWidth`, `-ViewportHeight` and `-DeviceScaleFactor` allow customizing the browser context
 - `Save-HTMLPdf` - generate a PDF of a rendered page
@@ -117,9 +117,9 @@ Invoke-HTMLRendering -Url 'https://example.com/protected' `
     -UsernameSelector 'input[name=log]' `
     -PasswordSelector 'input[name=pwd]' `
     -SubmitSelector '#wp-submit'
-Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\page.png -Full -Open -Delay 1000 -Selector '#content'
-Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\header.png -ElementSelector 'header'
-Save-HTMLScreenshot -Url 'https://example.com/login' -OutFile .\login.png -HighlightSelector 'form#login' -OverlayText 'Login Form'
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\page.jpg -Full -Open -Delay 1000 -Selector '#content' -Format Jpeg -Quality 80
+Save-HTMLScreenshot -Url 'https://example.com' -OutFile .\header.gif -ElementSelector 'header' -Format Gif
+Save-HTMLScreenshot -Url 'https://example.com/login' -OutFile .\login.jpg -HighlightSelector 'form#login' -OverlayText 'Login Form' -Format Jpeg -Quality 90
 Save-HTMLPdf -Url 'https://example.com' -OutFile .\page.pdf -PrintBackground
 Save-HTMLAttachment -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads'
 Save-HTMLAttachment -Url 'https://github.com/user/repo/releases/tag/v1.0' -Path '.\Downloads' -Filter '.zip'
@@ -135,9 +135,9 @@ $session = Start-HTMLSession -Url 'https://example.com/protected' `
     -UsernameSelector 'input[name=user]' `
     -PasswordSelector 'input[name=pass]' `
     -SubmitSelector 'button[type=submit]'
-Save-HTMLScreenshot -Session $session -OutFile '.\secure.png' -Selector '#content'
+Save-HTMLScreenshot -Session $session -OutFile '.\secure.bmp' -Selector '#content' -Format Bmp
 Invoke-HTMLNavigation -Session $session -Url 'https://example.com/downloads' |
-    Save-HTMLScreenshot -OutFile '.\downloads.png'
+    Save-HTMLScreenshot -OutFile '.\downloads.gif' -Format Gif
 Save-HTMLAttachment -Session $session -Path '.\Downloads'
 # Mock an API response
 $handler = Register-HTMLRoute -Session $session -Pattern '*api/data' -ScriptBlock {

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -103,6 +103,15 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
     [Parameter]
     public string? OverlayText { get; set; }
 
+    /// <summary>Image format for the screenshot.</summary>
+    [Parameter]
+    public ImageFormat Format { get; set; } = ImageFormat.Png;
+
+    /// <summary>Encoder quality for JPEG output.</summary>
+    [Parameter]
+    [ValidateRange(1,100)]
+    public int Quality { get; set; } = 100;
+
     /// <summary>X coordinate for a clip region.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetClip)]
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetSessionClip)]
@@ -155,6 +164,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Clean.IsPresent,
                     false,
                     Delay,
+                    Format,
+                    Quality,
                     Selector,
                     ElementSelector,
                     X,
@@ -177,6 +188,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Clean.IsPresent,
                     false,
                     Delay,
+                    Format,
+                    Quality,
                     Selector,
                     ElementSelector,
                     X,
@@ -197,6 +210,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     HtmlUtilities.ResolvePath(OutFile!),
                     false,
                     Delay,
+                    Format,
+                    Quality,
                     Selector,
                     ElementSelector,
                     X,
@@ -212,6 +227,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     HtmlUtilities.ResolvePath(OutFile!),
                     Full.IsPresent,
                     Delay,
+                    Format,
+                    Quality,
                     Selector,
                     ElementSelector,
                     highlightSelectors: HighlightSelector,
@@ -228,6 +245,8 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     Clean.IsPresent,
                     Full.IsPresent,
                     Delay,
+                    Format,
+                    Quality,
                     Selector,
                     ElementSelector,
                     highlightSelectors: HighlightSelector,

--- a/Sources/PSParseHTML/Enums/ImageFormat.cs
+++ b/Sources/PSParseHTML/Enums/ImageFormat.cs
@@ -1,0 +1,15 @@
+namespace PSParseHTML;
+
+/// <summary>
+/// Supported image formats for screenshots.
+/// </summary>
+public enum ImageFormat {
+    /// <summary>Png image format.</summary>
+    Png,
+    /// <summary>Jpeg image format.</summary>
+    Jpeg,
+    /// <summary>Bmp image format.</summary>
+    Bmp,
+    /// <summary>Gif image format.</summary>
+    Gif,
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -10,6 +10,11 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.Fonts;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Bmp;
+using SixLabors.ImageSharp.Formats.Gif;
 
 namespace PSParseHTML;
 
@@ -26,6 +31,10 @@ public static partial class HtmlBrowser {
     /// <param name="clean">Force re-download of browser runtimes.</param>
     /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
     /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
+    /// <param name="format">Image file format.</param>
+    /// <param name="quality">Encoder quality for JPEG output.</param>
+    /// <param name="format">Image file format.</param>
+    /// <param name="quality">Encoder quality for JPEG output.</param>
     /// <param name="selector">Optional CSS selector to wait for before capturing.</param>
     /// <param name="elementSelector">CSS selector of an element to capture.</param>
     /// <param name="clipX">Optional clip region X coordinate.</param>
@@ -39,6 +48,8 @@ public static partial class HtmlBrowser {
         bool clean = false,
         bool fullPage = false,
         int delayMs = 0,
+        ImageFormat format = ImageFormat.Png,
+        int quality = 100,
         string? selector = null,
         string? elementSelector = null,
         int? clipX = null,
@@ -75,6 +86,8 @@ public static partial class HtmlBrowser {
             fullPath,
             fullPage,
             delayMs,
+            format,
+            quality,
             selector,
             elementSelector,
             clipX,
@@ -92,6 +105,8 @@ public static partial class HtmlBrowser {
     /// <param name="path">File path for the screenshot.</param>
     /// <param name="fullPage">Capture the entire document instead of just the viewport.</param>
     /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
+    /// <param name="format">Image file format.</param>
+    /// <param name="quality">Encoder quality for JPEG output.</param>
     /// <param name="selector">Optional CSS selector to wait for before capturing.</param>
     /// <param name="elementSelector">CSS selector of an element to capture.</param>
     /// <param name="clipX">Optional clip region X coordinate.</param>
@@ -103,6 +118,8 @@ public static partial class HtmlBrowser {
         string path,
         bool fullPage = false,
         int delayMs = 0,
+        ImageFormat format = ImageFormat.Png,
+        int quality = 100,
         string? selector = null,
         string? elementSelector = null,
         int? clipX = null,
@@ -131,6 +148,10 @@ public static partial class HtmlBrowser {
 
         string fullPath = HtmlUtilities.ResolvePath(path);
         var options = new PageScreenshotOptions { FullPage = fullPage };
+        options.Type = format == ImageFormat.Jpeg ? ScreenshotType.Jpeg : ScreenshotType.Png;
+        if (options.Type == ScreenshotType.Jpeg) {
+            options.Quality = quality;
+        }
         if (clipX.HasValue && clipY.HasValue && clipWidth.HasValue && clipHeight.HasValue) {
             options.Clip = new Clip {
                 X = clipX.Value,
@@ -141,7 +162,8 @@ public static partial class HtmlBrowser {
         }
         byte[] data = await page.ScreenshotAsync(options);
 
-        if ((highlightSelectors != null && System.Linq.Enumerable.Any(highlightSelectors)) || !string.IsNullOrEmpty(overlayText)) {
+        bool needsProcessing = (highlightSelectors != null && System.Linq.Enumerable.Any(highlightSelectors)) || !string.IsNullOrEmpty(overlayText) || (format != ImageFormat.Png && format != ImageFormat.Jpeg);
+        if (needsProcessing) {
             using var image = SixLabors.ImageSharp.Image.Load(data);
             var pen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(SixLabors.ImageSharp.Color.Red, 3);
             if (highlightSelectors != null) {
@@ -171,9 +193,16 @@ public static partial class HtmlBrowser {
                 image.Mutate(c => c.DrawText(overlayText, font, SixLabors.ImageSharp.Color.Red, new SixLabors.ImageSharp.PointF(10, 10)));
             }
 
-            await image.SaveAsync(fullPath);
+            await image.SaveAsync(fullPath, GetEncoder(format, quality));
         } else {
             File.WriteAllBytes(fullPath, data);
         }
     }
+
+    private static IImageEncoder GetEncoder(ImageFormat format, int quality) => format switch {
+        ImageFormat.Jpeg => new JpegEncoder { Quality = quality },
+        ImageFormat.Bmp => new BmpEncoder(),
+        ImageFormat.Gif => new GifEncoder(),
+        _ => new PngEncoder()
+    };
 }


### PR DESCRIPTION
## Summary
- extend `CaptureScreenshotAsync` to set image format and encoder quality
- add `ImageFormat` enum
- expose `-Format` and `-Quality` parameters in `Save-HTMLScreenshot`
- document screenshot format options

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68542b14e9ac832ea51bcabaf0a7203c