### PR TITLE
Add CleanHeaderName unit tests

### DIFF
--- a/Sources/PSParseHTML.Tests/CleanHeaderNameTests.cs
+++ b/Sources/PSParseHTML.Tests/CleanHeaderNameTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class CleanHeaderNameTests {
+    [Theory]
+    [InlineData("Header-Name", "HeaderName")]
+    [InlineData("[Header]", "Header")]
+    [InlineData("A&B", "AandB")]
+    [InlineData("#Price ($)!", "Price")]
+    public void CleanHeaderName_ReturnsExpected(string input, string expected) {
+        string result = HtmlParser.CleanHeaderName(input);
+        Assert.Equal(expected, result);
+    }
+}

--- a/Tests/CleanHeaderName.Tests.ps1
+++ b/Tests/CleanHeaderName.Tests.ps1
@@ -1,0 +1,17 @@
+Describe 'CleanHeaderName' {
+    It 'Removes dashes from header name' {
+        [PSParseHTML.HtmlParser]::CleanHeaderName('Header-Name') | Should -Be 'HeaderName'
+    }
+
+    It 'Cleans brackets from header name' {
+        [PSParseHTML.HtmlParser]::CleanHeaderName('[Header]') | Should -Be 'Header'
+    }
+
+    It 'Replaces ampersand with and' {
+        [PSParseHTML.HtmlParser]::CleanHeaderName('A&B') | Should -Be 'AandB'
+    }
+
+    It 'Removes common symbols consistently' {
+        [PSParseHTML.HtmlParser]::CleanHeaderName('#Price ($)!') | Should -Be 'Price'
+    }
+}


### PR DESCRIPTION
## Summary
- add PowerShell tests for `CleanHeaderName`
- add C# `CleanHeaderNameTests`

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording command not found)*
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68542b1d32a8832ea4e45c6aa7bbc189