### PR TITLE
Add timeout parameter for browser session methods

### DIFF
--- a/Examples/Example-BrowserSession.ps1
+++ b/Examples/Example-BrowserSession.ps1
@@ -6,7 +6,8 @@ $session = Start-HTMLSession -Url 'https://example.com/protected' `
     -LoginUrl 'https://example.com/login' `
     -UsernameSelector 'input[name=user]' `
     -PasswordSelector 'input[name=pass]' `
-    -SubmitSelector 'button[type=submit]'
+    -SubmitSelector 'button[type=submit]' `
+    -Timeout 15000
 Save-HTMLScreenshot -Session $session -OutFile "$PSScriptRoot\Output\secure1.png" -Selector '#content'
 Invoke-HTMLNavigation -Session $session -Url 'https://example.com/downloads' | Save-HTMLScreenshot -OutFile "$PSScriptRoot\Output\secure2.png"
 Save-HTMLAttachment -Session $session -Path "$PSScriptRoot\Output" -Filter '.pdf'

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -60,6 +60,10 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    [Parameter]
+    [ValidateRange(0,int.MaxValue)]
+    public int Timeout { get; set; } = 10000;
+
     /// <summary>Include elements hidden from view.</summary>
     [Parameter]
     public SwitchParameter IncludeHidden { get; set; }
@@ -135,7 +139,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     storageStatePath: null,
                     proxy: Proxy,
                     proxyUsername: pUser,
-                    proxyPassword: pPass).ConfigureAwait(false)) {
+                    proxyPassword: pPass,
+                    timeout: Timeout).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;
@@ -153,7 +158,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     storageStatePath: null,
                     proxy: Proxy,
                     proxyUsername: pUser,
-                    proxyPassword: pPass).ConfigureAwait(false)) {
+                    proxyPassword: pPass,
+                    timeout: Timeout).ConfigureAwait(false)) {
                     list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
                 }
                 break;

--- a/Sources/PSParseHTML.PowerShell/CmdletImportHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletImportHtmlSession.cs
@@ -31,6 +31,10 @@ public sealed class CmdletImportHtmlSession : AsyncPSCmdlet {
     public int SlowMo { get; set; } = 0;
 
     [Parameter]
+    [ValidateRange(0,int.MaxValue)]
+    public int Timeout { get; set; } = 10000;
+
+    [Parameter]
     public string? UserAgent { get; set; }
 
     [Parameter]
@@ -74,7 +78,8 @@ public sealed class CmdletImportHtmlSession : AsyncPSCmdlet {
             proxyPassword: null,
             geoLatitude: GeoLatitude,
             geoLongitude: GeoLongitude,
-            timezone: Timezone).ConfigureAwait(false);
+            timezone: Timezone,
+            timeout: Timeout).ConfigureAwait(false);
 
         if (!NoDefault.IsPresent) {
             SessionState.PSVariable.Set("PSParseHTML_DefaultSession", session);

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -95,6 +95,10 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     public int SlowMo { get; set; } = 0;
 
     [Parameter]
+    [ValidateRange(0,int.MaxValue)]
+    public int Timeout { get; set; } = 10000;
+
+    [Parameter]
     public string? UserAgent { get; set; }
 
     [Parameter]
@@ -157,16 +161,17 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 proxyPassword: pPass,
                 geoLatitude: GeoLatitude,
                 geoLongitude: GeoLongitude,
-                timezone: Timezone).ConfigureAwait(false);
+                timezone: Timezone,
+                timeout: Timeout).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             string outPath = HtmlUtilities.ResolvePath(OutFile!);
-            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone).ConfigureAwait(false);
+            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone).ConfigureAwait(false);
+            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SessionState.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SessionState.cs
@@ -43,7 +43,8 @@ public static partial class HtmlBrowser {
         string? proxyPassword = null,
         double? geoLatitude = null,
         double? geoLongitude = null,
-        string? timezone = null)
+        string? timezone = null,
+        int timeout = 10000)
         => OpenSessionAsync(
             url,
             browser,
@@ -66,5 +67,6 @@ public static partial class HtmlBrowser {
             proxyPassword: proxyPassword,
             geoLatitude: geoLatitude,
             geoLongitude: geoLongitude,
-            timezone: timezone);
+            timezone: timezone,
+            timeout: timeout);
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -36,7 +36,8 @@ public static partial class HtmlBrowser {
         string? proxyPassword = null,
         double? geoLatitude = null,
         double? geoLongitude = null,
-        string? timezone = null) {
+        string? timezone = null,
+        int timeout = 10000) {
         if (clean) {
             CleanInstallDir();
         }
@@ -130,20 +131,20 @@ public static partial class HtmlBrowser {
         };
 
         if (formLogin != null) {
-            await page.GotoAsync(formLogin.LoginUrl);
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await page.GotoAsync(formLogin.LoginUrl, new PageGotoOptions { Timeout = timeout });
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
             if (username != null) {
-                await page.FillAsync(formLogin.UsernameSelector, username);
+                await page.FillAsync(formLogin.UsernameSelector, username, new PageFillOptions { Timeout = timeout });
             }
             if (password != null) {
-                await page.FillAsync(formLogin.PasswordSelector, password);
+                await page.FillAsync(formLogin.PasswordSelector, password, new PageFillOptions { Timeout = timeout });
             }
-            await page.ClickAsync(formLogin.SubmitSelector);
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await page.ClickAsync(formLogin.SubmitSelector, new PageClickOptions { Timeout = timeout });
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
         }
 
-        await page.GotoAsync(url);
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GotoAsync(url, new PageGotoOptions { Timeout = timeout });
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
 
         IVideo? video = null;
         if (!string.IsNullOrEmpty(videoPath)) {
@@ -178,8 +179,9 @@ public static partial class HtmlBrowser {
         string? proxyPassword = null,
         double? geoLatitude = null,
         double? geoLongitude = null,
-        string? timezone = null)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone);
+        string? timezone = null,
+        int timeout = 10000)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout);
 
     /// <summary>
     /// Disposes the specified browser session.
@@ -194,7 +196,7 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null) {
+    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -217,7 +219,8 @@ public static partial class HtmlBrowser {
             proxyPassword: proxyPassword,
             geoLatitude: geoLatitude,
             geoLongitude: geoLongitude,
-            timezone: timezone).ConfigureAwait(false);
+            timezone: timezone,
+            timeout: timeout).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -227,9 +230,9 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null) {
+    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000) {
         string fullPath = HtmlUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone).ConfigureAwait(false);
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 


### PR DESCRIPTION
## Summary
- support optional timeout for browser session startup
- wire timeout through Playwright calls
- expose Timeout parameter on cmdlets
- demonstrate new option in browser session example

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLVideoRecording not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68545dab5e94832ea736b4320bd28681