### PR TITLE
Improve UNC path handling

### DIFF
--- a/Sources/PSParseHTML.Tests/PreMailerClientPathTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientPathTests.cs
@@ -24,7 +24,7 @@ public class PreMailerClientPathTests
         }
         else
         {
-            Assert.Equal(@"\\server\\share\\test.css", normalized);
+            Assert.Equal(@"\\server\share\test.css", normalized);
         }
     }
 
@@ -39,7 +39,7 @@ public class PreMailerClientPathTests
         }
         else
         {
-            Assert.Equal(@"\\tmp\\test.css", normalized);
+            Assert.Equal(@"\\tmp\test.css", normalized);
         }
     }
 }

--- a/Sources/PSParseHTML.Tests/PreMailerClientPathTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientPathTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class PreMailerClientPathTests
+{
+    private static string InvokeNormalize(Uri uri)
+    {
+        var method = typeof(PreMailerClient).GetMethod("NormalizeFileUriPath", BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object[] { uri })!;
+    }
+
+    [Fact]
+    public void NormalizeFileUriPath_UncPaths()
+    {
+        Uri uri = new("file:////server/share/test.css");
+        string normalized = InvokeNormalize(uri);
+        if (Path.DirectorySeparatorChar == '/')
+        {
+            Assert.Equal("/server/share/test.css", normalized);
+        }
+        else
+        {
+            Assert.Equal(@"\\server\\share\\test.css", normalized);
+        }
+    }
+
+    [Fact]
+    public void NormalizeFileUriPath_LocalPaths()
+    {
+        Uri uri = new("file:////tmp/test.css");
+        string normalized = InvokeNormalize(uri);
+        if (Path.DirectorySeparatorChar == '/')
+        {
+            Assert.Equal("/tmp/test.css", normalized);
+        }
+        else
+        {
+            Assert.Equal(@"\\tmp\\test.css", normalized);
+        }
+    }
+}

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -71,11 +71,7 @@ public class PreMailerClient {
 
                             if (uri.IsFile)
                             {
-                                string localPath = uri.LocalPath;
-                                if (uri.IsUnc && Path.DirectorySeparatorChar == '/')
-                                {
-                                    localPath = "/" + localPath.TrimStart('\\');
-                                }
+                                string localPath = NormalizeFileUriPath(uri);
                                 cssContent += File.ReadAllText(localPath);
                             }
                             else if (uri.IsAbsoluteUri)
@@ -170,10 +166,7 @@ public class PreMailerClient {
                         }
 
                         if (uri.IsFile) {
-                            string localPath = uri.LocalPath;
-                            if (uri.IsUnc && Path.DirectorySeparatorChar == '/') {
-                                localPath = "/" + localPath.TrimStart('\\');
-                            }
+                            string localPath = NormalizeFileUriPath(uri);
 #if NETSTANDARD2_0 || NETFRAMEWORK
                             cssContent += await Task.Run(() => File.ReadAllText(localPath)).ConfigureAwait(false);
 #else
@@ -354,5 +347,15 @@ public class PreMailerClient {
         };
 
         return MoveCssInlineFromFile(htmlFilePath, opts);
+    }
+
+    private static string NormalizeFileUriPath(Uri uri)
+    {
+        string localPath = uri.LocalPath;
+        if (uri.IsUnc && Path.DirectorySeparatorChar == '/')
+        {
+            localPath = "/" + localPath.TrimStart('\\').Replace('\\', '/');
+        }
+        return localPath;
     }
 }


### PR DESCRIPTION
## Summary
- handle UNC paths consistently for Unix hosts
- expose NormalizeFileUriPath for internal use and add tests

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68546646c99c832ea5d118ec1a078e6f