### PR TITLE
Add JavaScript formatting example

### DIFF
--- a/Examples/Example-FormatJavaScriptAdvanced.ps1
+++ b/Examples/Example-FormatJavaScriptAdvanced.ps1
@@ -2,9 +2,4 @@ Import-Module .\PSParseHTML.psd1 -Force
 
 $Script = 'function greet(name){var data=[name];return data.map(function(x){return "Hello "+x;}).join().toUpperCase();}greet("World");'
 
-Format-JavaScript -Content $Script \
-    -IndentSize 2 \
-    -BraceStyle Expand \
-    -IndentWithTabs \
-    -KeepArrayIndentation \
-    -BreakChainedMethods
+Format-JavaScript -Content $Script -IndentSize 2 -BraceStyle Expand -IndentWithTabs -KeepArrayIndentation -BreakChainedMethods

--- a/Examples/Example-FormatJavaScriptAdvanced.ps1
+++ b/Examples/Example-FormatJavaScriptAdvanced.ps1
@@ -1,5 +1,27 @@
 Import-Module .\PSParseHTML.psd1 -Force
 
-$Script = 'function greet(name){var data=[name];return data.map(function(x){return "Hello "+x;}).join().toUpperCase();}greet("World");'
+$Script = @'
+function greet(name){
+    var data = [name];
+    return data.map(function(x){
+        return "Hello " + x;
+    }).join().toUpperCase();
+}
 
-Format-JavaScript -Content $Script -IndentSize 2 -BraceStyle Expand -IndentWithTabs -KeepArrayIndentation -BreakChainedMethods
+greet("World");
+'@
+
+$opts = @{
+    Content              = $Script
+    IndentSize           = 2
+    IndentChar           = ' '
+    BraceStyle           = 'Expand'
+    IndentWithTabs       = $false
+    KeepArrayIndentation = $true
+    KeepFunctionIndentation = $false
+    BreakChainedMethods  = $true
+    MaxPreserveNewlines  = 2
+    JslintHappy          = $true
+}
+
+Format-JavaScript @opts

--- a/Examples/Example-FormatJavaScriptAdvanced.ps1
+++ b/Examples/Example-FormatJavaScriptAdvanced.ps1
@@ -1,0 +1,10 @@
+Import-Module .\PSParseHTML.psd1 -Force
+
+$Script = 'function greet(name){var data=[name];return data.map(function(x){return "Hello "+x;}).join().toUpperCase();}greet("World");'
+
+Format-JavaScript -Content $Script \
+    -IndentSize 2 \
+    -BraceStyle Expand \
+    -IndentWithTabs \
+    -KeepArrayIndentation \
+    -BreakChainedMethods

--- a/README.MD
+++ b/README.MD
@@ -200,6 +200,10 @@ $markup = Get-Content './catalog.html' -Raw
 ConvertFrom-HTMLAttributes -Content $markup -Class 'product'
 ```
 
+Additional sample scripts can be found in the [Examples](Examples) folder. See
+[Example-FormatJavaScriptAdvanced.ps1](Examples/Example-FormatJavaScriptAdvanced.ps1)
+for customizing JavaScript formatting options with `BeautifierOptions`.
+
 ## Installation
 
 ### Install from PSGallery

--- a/README.MD
+++ b/README.MD
@@ -200,9 +200,9 @@ $markup = Get-Content './catalog.html' -Raw
 ConvertFrom-HTMLAttributes -Content $markup -Class 'product'
 ```
 
-Additional sample scripts can be found in the [Examples](Examples) folder. See
+More sample scripts are in the [Examples](Examples) folder, including
 [Example-FormatJavaScriptAdvanced.ps1](Examples/Example-FormatJavaScriptAdvanced.ps1)
-for customizing JavaScript formatting options with `BeautifierOptions`.
+which demonstrates custom `BeautifierOptions`.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add `Example-FormatJavaScriptAdvanced.ps1` showing BeautifierOptions
- document example in README

## Testing
- `Invoke-Pester -Script './Tests/Format-JS.Tests.ps1' -Output Detailed` *(fails: Format-JavaScript not found)*

------
https://chatgpt.com/codex/tasks/task_e_685465fe6dec832e84ef0c48eb2c223d