### PR TITLE
Add Playwright network tracing example

### DIFF
--- a/Examples/Example-PlaywrightNetwork.ps1
+++ b/Examples/Example-PlaywrightNetwork.ps1
@@ -1,0 +1,11 @@
+Import-Module .\PSParseHTML.psd1 -Force
+
+$session = Invoke-HTMLRendering -Url 'https://example.com' -Session
+Start-HTMLTracing -Session $session
+
+Invoke-HTMLNavigation -Session $session -Url 'https://example.com/profile'
+
+Stop-HTMLTracing -Session $session -OutFile "$PSScriptRoot\Output\trace.zip"
+Save-HTMLHar -Session $session -OutFile "$PSScriptRoot\Output\traffic.har"
+
+Close-HTMLSession -Session $session

--- a/README.MD
+++ b/README.MD
@@ -171,6 +171,7 @@ The expected input is a string literal or data read from a file.  The output can
 It may not seem like much, but those thirteen cmdlets are powerful enough to enable robust HTML processing in shell.
 
 ## Examples
+Additional sample scripts are available in the `Examples` directory. See `Example-PlaywrightNetwork.ps1` for tracing and HAR capture.
 
 ```powershell
 # Parse tables from a web page (rowspan and colspan handled automatically)


### PR DESCRIPTION
## Summary
- add Example-PlaywrightNetwork.ps1
- reference the new example in README

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6854667a2cc8832eb6a6785e2eecfa0b