### PR TITLE
Enable pipeline example documentation

### DIFF
--- a/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
+++ b/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
@@ -6136,6 +6136,10 @@
         <maml:title>----------  Example 1  ----------</maml:title>
         <dev:code>Save-HTMLPdf -Url https://example.com -OutFile page.pdf</dev:code>
       </command:example>
+      <command:example>
+        <maml:title>----------  Example 2  ----------</maml:title>
+        <dev:code>Invoke-HTMLRendering -Url https://example.com -Session | Save-HTMLPdf -OutFile page.pdf</dev:code>
+      </command:example>
     </command:examples>
   </command:command>
   <!-- Cmdlet: Invoke-HTMLRendering -->

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
@@ -10,6 +10,10 @@ namespace PSParseHTML.PowerShell;
 /// <example>
 ///   <code>Save-HTMLPdf -Url https://example.com -OutFile page.pdf</code>
 /// </example>
+/// <example>
+///   <code>Invoke-HTMLRendering -Url https://example.com -Session |
+///   Save-HTMLPdf -OutFile page.pdf</code>
+/// </example>
 [Cmdlet(VerbsData.Save, "HTMLPdf", DefaultParameterSetName = ParameterSetSession)]
 public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
     private const string ParameterSetDefault = "Default";

--- a/Tests/Save-HTMLPdf.Tests.ps1
+++ b/Tests/Save-HTMLPdf.Tests.ps1
@@ -6,4 +6,13 @@ Describe 'Save-HTMLPdf' {
         Save-HTMLPdf -Url $uri -OutFile $outfile -Selector '#loaded'
         (Test-Path $outfile) | Should -BeTrue
     }
+
+    It 'Accepts session objects from the pipeline' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $outfile = Join-Path $TestDrive 'pipe.pdf'
+        Invoke-HTMLRendering -Url $uri -Session |
+            Save-HTMLPdf -OutFile $outfile -Selector '#loaded'
+        (Test-Path $outfile) | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- remove unnecessary PowerShell wrapper for `Save-HTMLPdf`
- document pipeline usage in cmdlet's XML docs and C# comments
- keep test verifying pipeline input

## Testing
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: missing cmdlets)*

------
https://chatgpt.com/codex/tasks/task_e_685465f5d91c832ea2108fab818b724f