### PR TITLE
Add 20 unit tests

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlDifferTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlDifferTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlDifferTests {
+    [Fact]
+    public void Compare_Identical_ReturnsEmpty() {
+        var diffs = HtmlDiffer.Compare("<p>a</p>", "<p>a</p>");
+        Assert.Empty(diffs);
+    }
+
+    [Fact]
+    public void Compare_Different_ReturnsDiffs() {
+        var diffs = HtmlDiffer.Compare("<p>a</p>", "<p>b</p>");
+        Assert.NotEmpty(diffs);
+    }
+
+    [Fact]
+    public void Compare_NullReference_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlDiffer.Compare(null!, "<p></p>"));
+    }
+
+    [Fact]
+    public void Compare_NullDifference_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlDiffer.Compare("<p></p>", null!));
+    }
+}

--- a/Sources/PSParseHTML.Tests/HtmlHttpClientFactoryTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlHttpClientFactoryTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlHttpClientFactoryTests {
+    private static HttpClientHandler GetHandler(HttpClient client) {
+        FieldInfo? field = typeof(HttpMessageInvoker).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (HttpClientHandler)field!.GetValue(client)!;
+    }
+
+    [Fact]
+    public void Create_AppliesDefaultHeaders() {
+        HtmlHttpClientFactory.DefaultHeaders["X-Test"] = "1";
+        using HttpClient client = HtmlHttpClientFactory.Create();
+        Assert.True(client.DefaultRequestHeaders.Contains("X-Test"));
+        HtmlHttpClientFactory.DefaultHeaders.Clear();
+    }
+
+    [Fact]
+    public void Shared_ReturnsSameInstance() {
+        HtmlHttpClientFactory.ResetShared();
+        HttpClient first = HtmlHttpClientFactory.Shared;
+        HttpClient second = HtmlHttpClientFactory.Shared;
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void ResetShared_RecreatesInstance() {
+        HttpClient first = HtmlHttpClientFactory.Shared;
+        HtmlHttpClientFactory.ResetShared();
+        HttpClient second = HtmlHttpClientFactory.Shared;
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void Create_WithProxy_ConfiguresProxy() {
+        var cred = new NetworkCredential("u", "p");
+        using HttpClient client = HtmlHttpClientFactory.Create("http://localhost:1234", cred);
+        HttpClientHandler handler = GetHandler(client);
+        Assert.Equal("http://localhost:1234/", handler.Proxy?.GetProxy(new System.Uri("http://localhost")).ToString());
+        Assert.Same(cred, handler.Proxy?.Credentials);
+    }
+}

--- a/Sources/PSParseHTML.Tests/HtmlParserExtensionsFileTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserExtensionsFileTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlParserExtensionsFileTests {
+    private static string GetPath(string name) {
+        var baseDir = AppContext.BaseDirectory;
+        return Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "Documents", name));
+    }
+
+    [Fact]
+    public void GetElements_EmptyHtml_ReturnsEmpty() {
+        var elements = HtmlParserExtensions.GetElements(string.Empty, tag: "p");
+        Assert.Empty(elements);
+    }
+
+    [Fact]
+    public void GetElementsFromFile_ByTag_ReturnsElements() {
+        string path = GetPath("sample_form.html");
+        var elements = HtmlParserExtensions.GetElementsFromFile(path, tag: "form").ToArray();
+        Assert.Equal(2, elements.Length);
+    }
+}

--- a/Sources/PSParseHTML.Tests/HtmlScriptRunnerTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlScriptRunnerTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlScriptRunnerTests {
+    [Fact]
+    public async Task RunAsync_ReturnsResult() {
+        const string html = "<html></html>";
+        const string script = "1 + 2";
+        int? result = await HtmlScriptRunner.RunAsync<int>(html, script);
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task RunAsync_NullHtml_Throws() {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => HtmlScriptRunner.RunAsync<int>(null!, "1"));
+    }
+
+    [Fact]
+    public async Task RunAsync_NullScript_Throws() {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => HtmlScriptRunner.RunAsync<int>("<html></html>", null!));
+    }
+}

--- a/Sources/PSParseHTML.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlUtilitiesTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlUtilitiesTests {
+    private static TestServer CreateServer(string content, string charset) {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.Run(async ctx => {
+                ctx.Response.ContentType = $"text/plain; charset={charset}";
+                var bytes = System.Text.Encoding.GetEncoding(charset).GetBytes(content);
+                await ctx.Response.Body.WriteAsync(bytes);
+            }));
+        return new TestServer(builder);
+    }
+
+    [Fact]
+    public void ResolvePath_ExpandsEnvironmentVariables() {
+        string temp = Path.GetTempPath();
+        Environment.SetEnvironmentVariable("TMP_TEST", temp);
+        string result = HtmlUtilities.ResolvePath("%TMP_TEST%");
+        Assert.Equal(Path.GetFullPath(temp), result);
+    }
+
+    [Fact]
+    public void ResolvePath_RelativePathToAbsolute() {
+        string relative = "..";
+        string result = HtmlUtilities.ResolvePath(relative);
+        Assert.True(Path.IsPathRooted(result));
+    }
+
+    [Fact]
+    public void ReadFileChecked_ReturnsContent() {
+        string path = Path.GetTempFileName();
+        try {
+            File.WriteAllText(path, "data");
+            string content = HtmlUtilities.ReadFileChecked(path);
+            Assert.Equal("data", content);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReadFileChecked_MissingThrows() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        Assert.Throws<FileNotFoundException>(() => HtmlUtilities.ReadFileChecked(path));
+    }
+
+    [Fact]
+    public async Task ReadFileCheckedAsync_ReturnsContent() {
+        string path = Path.GetTempFileName();
+        try {
+            await File.WriteAllTextAsync(path, "async");
+            string content = await HtmlUtilities.ReadFileCheckedAsync(path);
+            Assert.Equal("async", content);
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ReadFileCheckedAsync_MissingThrows() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        await Assert.ThrowsAsync<FileNotFoundException>(() => HtmlUtilities.ReadFileCheckedAsync(path));
+    }
+
+    [Fact]
+    public async Task GetStringWithProperEncodingAsync_UsesHeaderEncoding() {
+        using var server = CreateServer("Hello", "utf-16");
+        using HttpClient client = server.CreateClient();
+        string result = await HtmlUtilities.GetStringWithProperEncodingAsync(client, server.BaseAddress.ToString());
+        Assert.Equal("Hello", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for HtmlUtilities
- cover HtmlScriptRunner
- add HttpClientFactory tests
- test HtmlDiffer functionality
- extend HtmlParserExtensions coverage

## Testing
- `dotnet test Sources/PSParseHTML.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68546eb3ae28832e9ad0839f34c09a33