### PR TITLE
Add CancellationToken to all HtmlBrowser APIs

### DIFF
--- a/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
+++ b/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
@@ -91,9 +91,21 @@
         <maml:description>
           <maml:para>Optional path to write the formatted CSS.</maml:para>
         </maml:description>
-        <command:parameterValue required="true">string</command:parameterValue>
+      <command:parameterValue required="true">string</command:parameterValue>
+      <dev:type>
+        <maml:name>System.String</maml:name>
+        <maml:uri />
+      </dev:type>
+      </command:parameter>
+      <!-- Parameter: CancellationToken -->
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>CancellationToken</maml:name>
+        <maml:description>
+          <maml:para>Cancellation token to stop the operation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true">CancellationToken</command:parameterValue>
         <dev:type>
-          <maml:name>System.String</maml:name>
+          <maml:name>System.Threading.CancellationToken</maml:name>
           <maml:uri />
         </dev:type>
       </command:parameter>
@@ -414,12 +426,21 @@
           <maml:name>UseEmailFormatter</maml:name>
           <command:parameterValue required="true">SwitchParameter</command:parameterValue>
           <dev:type>
-            <maml:name>System.Management.Automation.SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
+          <maml:name>System.Management.Automation.SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <!-- Parameter: CancellationToken -->
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>CancellationToken</maml:name>
+        <command:parameterValue required="true">CancellationToken</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Threading.CancellationToken</maml:name>
+          <maml:uri />
+        </dev:type>
+      </command:parameter>
+    </command:syntaxItem>
       <!-- Parameter set: File -->
       <command:syntaxItem>
         <maml:name>Optimize-Email</maml:name>
@@ -1822,6 +1843,15 @@
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
+        <!-- Parameter: CancellationToken -->
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>CancellationToken</maml:name>
+          <command:parameterValue required="true">CancellationToken</command:parameterValue>
+          <dev:type>
+            <maml:name>System.Threading.CancellationToken</maml:name>
+            <maml:uri />
+          </dev:type>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -2796,6 +2826,15 @@
             <maml:uri />
           </dev:type>
         </command:parameter>
+        <!-- Parameter: CancellationToken -->
+        <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+          <maml:name>CancellationToken</maml:name>
+          <command:parameterValue required="true">CancellationToken</command:parameterValue>
+          <dev:type>
+            <maml:name>System.Threading.CancellationToken</maml:name>
+            <maml:uri />
+          </dev:type>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -2861,6 +2900,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <!-- Parameter: CancellationToken -->
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>CancellationToken</maml:name>
+        <maml:description>
+          <maml:para>Cancellation token to stop the operation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true">CancellationToken</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Threading.CancellationToken</maml:name>
+          <maml:uri />
+        </dev:type>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>

--- a/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
+++ b/Docs/en-US/PSParseHTML.PowerShell.dll-Help.xml
@@ -107,6 +107,16 @@
         <dev:type>
           <maml:name>System.Threading.CancellationToken</maml:name>
           <maml:uri />
+        </dev:type>      <!-- Parameter: CancellationToken -->
+      <command:parameter required="false" globbing="false" pipelineInput="false" position="named">
+        <maml:name>CancellationToken</maml:name>
+        <maml:description>
+          <maml:para>Cancellation token to stop the operation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true">CancellationToken</command:parameterValue>
+        <dev:type>
+          <maml:name>System.Threading.CancellationToken</maml:name>
+          <maml:uri />
         </dev:type>
       </command:parameter>
     </command:parameters>

--- a/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -13,9 +14,14 @@ public sealed class CmdletCloseHtmlSession : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
     public HtmlBrowserSession Session { get; set; } = null!;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        await HtmlBrowser.CloseSessionAsync(Session).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+        await HtmlBrowser.CloseSessionAsync(Session, token).ConfigureAwait(false);
         object? defaultSession = GetVariableValue("PSParseHTML_DefaultSession");
         if (defaultSession is HtmlBrowserSession sess && ReferenceEquals(sess, Session)) {
             SessionState.PSVariable.Remove("PSParseHTML_DefaultSession");

--- a/Sources/PSParseHTML.PowerShell/CmdletExportHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportHtmlSession.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -16,10 +17,15 @@ public sealed class CmdletExportHtmlSession : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public string Path { get; set; } = string.Empty;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         Session ??= (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-        await HtmlBrowser.ExportSessionAsync(Session, Path).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+        await HtmlBrowser.ExportSessionAsync(Session, Path, token).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlContent.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlContent.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -29,10 +30,15 @@ public sealed class CmdletGetHtmlContent : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter AsText { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
 
         int flags = (InnerHtml.IsPresent ? 1 : 0) + (OuterHtml.IsPresent ? 1 : 0) + (AsText.IsPresent ? 1 : 0);
         if (flags > 1) {
@@ -46,7 +52,8 @@ public sealed class CmdletGetHtmlContent : AsyncPSCmdlet {
             session.Page,
             Selector,
             InnerHtml.IsPresent,
-            AsText.IsPresent).ConfigureAwait(false);
+            AsText.IsPresent,
+            token).ConfigureAwait(false);
 
         WriteObject(result);
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -14,11 +15,16 @@ public sealed class CmdletGetHtmlCookie : AsyncPSCmdlet {
     [Parameter(Position = 0, ValueFromPipeline = true)]
     public HtmlBrowserSession? Session { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-        List<HtmlCookie> cookies = await HtmlBrowser.GetCookiesAsync(session).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+        List<HtmlCookie> cookies = await HtmlBrowser.GetCookiesAsync(session, token).ConfigureAwait(false);
         WriteObject(cookies, true);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Management.Automation;
 using PSParseHTML;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -64,6 +65,9 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Include elements hidden from view.</summary>
     [Parameter]
     public SwitchParameter IncludeHidden { get; set; }
@@ -110,6 +114,8 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
         List<HtmlInteractableInfo> list;
         string? pUser = ProxyCredential?.UserName;
         string? pPass = ProxyCredential?.GetNetworkCredential().Password;
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
         switch (ParameterSetName) {
             case ParameterSetUrl:
                 string? user = Credential?.UserName ?? Username;
@@ -140,8 +146,9 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     proxy: Proxy,
                     proxyUsername: pUser,
                     proxyPassword: pPass,
-                    timeout: Timeout).ConfigureAwait(false)) {
-                    list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
+                    timeout: Timeout,
+                    cancellationToken: token).ConfigureAwait(false)) {
+                    list = await HtmlBrowser.GetInteractablesAsync(sess.Page, token).ConfigureAwait(false);
                 }
                 break;
             case ParameterSetFile:
@@ -159,14 +166,15 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
                     proxy: Proxy,
                     proxyUsername: pUser,
                     proxyPassword: pPass,
-                    timeout: Timeout).ConfigureAwait(false)) {
-                    list = await HtmlBrowser.GetInteractablesAsync(sess.Page).ConfigureAwait(false);
+                    timeout: Timeout,
+                    cancellationToken: token).ConfigureAwait(false)) {
+                    list = await HtmlBrowser.GetInteractablesAsync(sess.Page, token).ConfigureAwait(false);
                 }
                 break;
             default:
                 HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
                     ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-                list = await HtmlBrowser.GetInteractablesAsync(session.Page).ConfigureAwait(false);
+                list = await HtmlBrowser.GetInteractablesAsync(session.Page, token).ConfigureAwait(false);
                 break;
         }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletImportHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletImportHtmlSession.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -60,8 +61,13 @@ public sealed class CmdletImportHtmlSession : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter NoDefault { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
         HtmlBrowserSession session = await HtmlBrowser.ImportSessionAsync(
             Url,
             Path,
@@ -79,7 +85,8 @@ public sealed class CmdletImportHtmlSession : AsyncPSCmdlet {
             geoLatitude: GeoLatitude,
             geoLongitude: GeoLongitude,
             timezone: Timezone,
-            timeout: Timeout).ConfigureAwait(false);
+            timeout: Timeout,
+            cancellationToken: token).ConfigureAwait(false);
 
         if (!NoDefault.IsPresent) {
             SessionState.PSVariable.Set("PSParseHTML_DefaultSession", session);

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlNavigation.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlNavigation.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.Playwright;
 
 namespace PSParseHTML.PowerShell;
@@ -52,21 +53,26 @@ public sealed class CmdletInvokeHtmlNavigation : AsyncPSCmdlet {
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
 
         try {
             switch (ParameterSetName) {
                 case ParameterSetUrl:
-                    await HtmlBrowser.NavigateAsync(session, Url!, Timeout).ConfigureAwait(false);
+                    await HtmlBrowser.NavigateAsync(session, Url!, Timeout, token).ConfigureAwait(false);
                     break;
                 case ParameterSetSelector:
-                    await HtmlBrowser.ClickSelectorAsync(session, Selector!, WaitForNavigation.IsPresent, Timeout).ConfigureAwait(false);
+                    await HtmlBrowser.ClickSelectorAsync(session, Selector!, WaitForNavigation.IsPresent, Timeout, token).ConfigureAwait(false);
                     break;
                 case ParameterSetText:
-                    await HtmlBrowser.ClickTextAsync(session, Text!, Exact.IsPresent, Regex, WaitForNavigation.IsPresent, Timeout).ConfigureAwait(false);
+                    await HtmlBrowser.ClickTextAsync(session, Text!, Exact.IsPresent, Regex, WaitForNavigation.IsPresent, Timeout, token).ConfigureAwait(false);
                     break;
             }
         } catch (PlaywrightException ex) when (ex.Message.Contains("strict mode violation")) {

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
 using System.IO;
+using System.Threading;
 using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
@@ -99,6 +100,9 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     public int Timeout { get; set; } = 10000;
 
     [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
+    [Parameter]
     public string? UserAgent { get; set; }
 
     [Parameter]
@@ -127,6 +131,8 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
         string? pass = Credential?.GetNetworkCredential().Password ?? Password;
         string? pUser = ProxyCredential?.UserName;
         string? pPass = ProxyCredential?.GetNetworkCredential().Password;
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
         HtmlFormLogin? form = null;
         if (!string.IsNullOrEmpty(LoginUrl) && !string.IsNullOrEmpty(UsernameSelector) && !string.IsNullOrEmpty(PasswordSelector) && !string.IsNullOrEmpty(SubmitSelector)) {
             form = new HtmlFormLogin {
@@ -162,16 +168,17 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
                 geoLatitude: GeoLatitude,
                 geoLongitude: GeoLongitude,
                 timezone: Timezone,
-                timeout: Timeout).ConfigureAwait(false);
+                timeout: Timeout,
+                cancellationToken: token).ConfigureAwait(false);
             if (!NoDefault.IsPresent) {
                 SessionState.PSVariable.Set("PSParseHTML_DefaultSession", sess);
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
             string outPath = HtmlUtilities.ResolvePath(OutFile!);
-            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout).ConfigureAwait(false);
+            await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout, token).ConfigureAwait(false);
         } else {
-            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout).ConfigureAwait(false);
+            string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout, token).ConfigureAwait(false);
             WriteObject(html);
         }
     }

--- a/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.Playwright;
 
 namespace PSParseHTML.PowerShell;
@@ -22,10 +23,15 @@ public sealed class CmdletRegisterHtmlRoute : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 2)]
     public ScriptBlock? ScriptBlock { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
 
         ScriptBlock block = ScriptBlock ?? throw new PSArgumentNullException(nameof(ScriptBlock));
         Func<IRoute, Task> handler = route => {
@@ -33,7 +39,7 @@ public sealed class CmdletRegisterHtmlRoute : AsyncPSCmdlet {
             return result is Task t ? t : Task.CompletedTask;
         };
 
-        await HtmlBrowser.RegisterRouteAsync(session, Pattern, handler).ConfigureAwait(false);
+        await HtmlBrowser.RegisterRouteAsync(session, Pattern, handler, token).ConfigureAwait(false);
         WriteObject(handler);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
@@ -53,15 +54,21 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
     [Parameter]
     public string? Filter { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
 
         List<string> files = ParameterSetName switch {
             ParameterSetSession => await HtmlBrowser.SavePageDownloadsAsync(
                 (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
                 HtmlUtilities.ResolvePath(Path),
-                Filter).ConfigureAwait(false),
+                Filter,
+                token).ConfigureAwait(false),
             _ => await HtmlBrowser.SavePageDownloadsAsync(
                 Url,
                 HtmlUtilities.ResolvePath(Path),
@@ -69,7 +76,8 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
                 Clean.IsPresent,
                 Filter,
                 headless: !Visible.IsPresent,
-                slowMo: SlowMo).ConfigureAwait(false)
+                slowMo: SlowMo,
+                cancellationToken: token).ConfigureAwait(false)
         };
 
         WriteObject(files.ToArray(), true);

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlHar.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlHar.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -11,9 +12,14 @@ public sealed class CmdletSaveHtmlHar : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     public string OutFile { get; set; } = string.Empty;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-        await HtmlBrowser.ExportHarAsync(session, OutFile).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+        await HtmlBrowser.ExportHarAsync(session, OutFile, token).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlChecked.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlChecked.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -30,12 +31,18 @@ public sealed class CmdletSetHtmlChecked : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
 
-        await HtmlBrowser.SetCheckedAsync(session, Selector, !Uncheck.IsPresent, Timeout).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+
+        await HtmlBrowser.SetCheckedAsync(session, Selector, !Uncheck.IsPresent, Timeout, token).ConfigureAwait(false);
 
         if (PassThru.IsPresent) {
             WriteObject(session);

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -17,11 +18,16 @@ public sealed class CmdletSetHtmlCookie : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     public HtmlCookie[]? Cookie { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
         IEnumerable<HtmlCookie> cookies = Cookie ?? System.Array.Empty<HtmlCookie>();
-        await HtmlBrowser.SetCookiesAsync(session, cookies).ConfigureAwait(false);
+        await HtmlBrowser.SetCookiesAsync(session, cookies, token).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlInput.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlInput.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -30,12 +31,18 @@ public sealed class CmdletSetHtmlInput : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
 
-        await HtmlBrowser.FillInputAsync(session, Selector, Value, Timeout).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+
+        await HtmlBrowser.FillInputAsync(session, Selector, Value, Timeout, token).ConfigureAwait(false);
 
         if (PassThru.IsPresent) {
             WriteObject(session);

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlSelectOption.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlSelectOption.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -30,12 +31,18 @@ public sealed class CmdletSetHtmlSelectOption : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
 
-        await HtmlBrowser.SelectOptionAsync(session, Selector, Value, Timeout).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+
+        await HtmlBrowser.SelectOptionAsync(session, Selector, Value, Timeout, token).ConfigureAwait(false);
 
         if (PassThru.IsPresent) {
             WriteObject(session);

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlTracing.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlTracing.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -17,9 +18,14 @@ public sealed class CmdletStartHtmlTracing : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Sources { get; set; } = true;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-        await HtmlBrowser.StartTracingAsync(session, Screenshots.IsPresent, Snapshots.IsPresent, Sources.IsPresent).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+        await HtmlBrowser.StartTracingAsync(session, Screenshots.IsPresent, Snapshots.IsPresent, Sources.IsPresent, token).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlTracing.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlTracing.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
@@ -11,9 +12,14 @@ public sealed class CmdletStopHtmlTracing : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     public string OutFile { get; set; } = string.Empty;
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-        await HtmlBrowser.StopTracingAsync(session, OutFile).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+        await HtmlBrowser.StopTracingAsync(session, OutFile, token).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.Playwright;
 
 namespace PSParseHTML.PowerShell;
@@ -22,11 +23,17 @@ public sealed class CmdletUnregisterHtmlRoute : AsyncPSCmdlet {
     [Parameter(Position = 2)]
     public Delegate? Handler { get; set; }
 
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
 
-        await HtmlBrowser.UnregisterRouteAsync(session, Pattern, Handler as Func<IRoute, Task>).ConfigureAwait(false);
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
+        CancellationToken token = linkedCts.Token;
+
+        await HtmlBrowser.UnregisterRouteAsync(session, Pattern, Handler as Func<IRoute, Task>, token).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -8,7 +9,8 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Retrieves cookies from the browser context.
     /// </summary>
-    public static async Task<List<HtmlCookie>> GetCookiesAsync(HtmlBrowserSession session) {
+    public static async Task<List<HtmlCookie>> GetCookiesAsync(HtmlBrowserSession session, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         IReadOnlyList<BrowserContextCookiesResult> cookies = await session.Context.CookiesAsync();
         List<HtmlCookie> result = new();
         foreach (BrowserContextCookiesResult c in cookies) {
@@ -29,7 +31,7 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Adds cookies to the browser context.
     /// </summary>
-    public static Task SetCookiesAsync(HtmlBrowserSession session, IEnumerable<HtmlCookie> cookies) {
+    public static Task SetCookiesAsync(HtmlBrowserSession session, IEnumerable<HtmlCookie> cookies, CancellationToken cancellationToken = default) {
         List<Cookie> list = new();
         foreach (HtmlCookie c in cookies) {
             Cookie nc = new() {
@@ -45,6 +47,7 @@ public static partial class HtmlBrowser {
             };
             list.Add(nc);
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return session.Context.AddCookiesAsync(list);
     }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Evaluate.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -13,6 +14,9 @@ public static partial class HtmlBrowser {
     /// <param name="session">Browser session.</param>
     /// <param name="script">JavaScript code to execute.</param>
     /// <returns>Value returned by the script.</returns>
-    public static Task<T?> EvaluateAsync<T>(HtmlBrowserSession session, string script)
-        => session.Page.EvaluateAsync<T?>(script);
+    public static Task<T?> EvaluateAsync<T>(HtmlBrowserSession session, string script, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return session.Page.EvaluateAsync<T?>(script);
+    }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Forms.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Forms.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -11,27 +12,32 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Fills text into an element identified by a CSS selector.
     /// </summary>
-    public static async Task FillInputAsync(IPage page, string selector, string value, int timeout = 10000) {
+    public static async Task FillInputAsync(IPage page, string selector, string value, int timeout = 10000, CancellationToken cancellationToken = default) {
         var locator = page.Locator(selector);
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.FillAsync(value, new LocatorFillOptions { Timeout = timeout });
     }
 
     /// <summary>
     /// Fills text into an element using an existing browser session.
     /// </summary>
-    public static Task FillInputAsync(HtmlBrowserSession session, string selector, string value, int timeout = 10000)
-        => FillInputAsync(session.Page, selector, value, timeout);
+    public static Task FillInputAsync(HtmlBrowserSession session, string selector, string value, int timeout = 10000, CancellationToken cancellationToken = default)
+        => FillInputAsync(session.Page, selector, value, timeout, cancellationToken);
 
     /// <summary>
     /// Sets the checked state of a checkbox or radio input.
     /// </summary>
-    public static async Task SetCheckedAsync(IPage page, string selector, bool check = true, int timeout = 10000) {
+    public static async Task SetCheckedAsync(IPage page, string selector, bool check = true, int timeout = 10000, CancellationToken cancellationToken = default) {
         var locator = page.Locator(selector);
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
         if (check) {
+            cancellationToken.ThrowIfCancellationRequested();
             await locator.CheckAsync(new LocatorCheckOptions { Timeout = timeout });
         } else {
+            cancellationToken.ThrowIfCancellationRequested();
             await locator.UncheckAsync(new LocatorUncheckOptions { Timeout = timeout });
         }
     }
@@ -39,40 +45,44 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Sets the checked state of a checkbox or radio input using a session.
     /// </summary>
-    public static Task SetCheckedAsync(HtmlBrowserSession session, string selector, bool check = true, int timeout = 10000)
-        => SetCheckedAsync(session.Page, selector, check, timeout);
+    public static Task SetCheckedAsync(HtmlBrowserSession session, string selector, bool check = true, int timeout = 10000, CancellationToken cancellationToken = default)
+        => SetCheckedAsync(session.Page, selector, check, timeout, cancellationToken);
 
     /// <summary>
     /// Selects option values from a &lt;select&gt; element.
     /// </summary>
-    public static async Task SelectOptionAsync(IPage page, string selector, IEnumerable<string> values, int timeout = 10000) {
+    public static async Task SelectOptionAsync(IPage page, string selector, IEnumerable<string> values, int timeout = 10000, CancellationToken cancellationToken = default) {
         var locator = page.Locator(selector);
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.SelectOptionAsync(values, new LocatorSelectOptionOptions { Timeout = timeout });
     }
 
     /// <summary>
     /// Selects option values from a &lt;select&gt; element using a session.
     /// </summary>
-    public static Task SelectOptionAsync(HtmlBrowserSession session, string selector, IEnumerable<string> values, int timeout = 10000)
-        => SelectOptionAsync(session.Page, selector, values, timeout);
+    public static Task SelectOptionAsync(HtmlBrowserSession session, string selector, IEnumerable<string> values, int timeout = 10000, CancellationToken cancellationToken = default)
+        => SelectOptionAsync(session.Page, selector, values, timeout, cancellationToken);
 
     /// <summary>
     /// Performs a mouse click on an element.
     /// </summary>
-    public static async Task MouseClickAsync(IPage page, string selector, MouseButton button = MouseButton.Left, int clickCount = 1, KeyboardModifier[]? modifiers = null, int timeout = 10000) {
+    public static async Task MouseClickAsync(IPage page, string selector, MouseButton button = MouseButton.Left, int clickCount = 1, KeyboardModifier[]? modifiers = null, int timeout = 10000, CancellationToken cancellationToken = default) {
         var locator = page.Locator(selector);
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout });
         var options = new LocatorClickOptions { Button = button, ClickCount = clickCount, Timeout = timeout };
         if (modifiers != null) {
             options.Modifiers = modifiers;
         }
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.ClickAsync(options);
     }
 
     /// <summary>
     /// Performs a mouse click on an element using a session.
     /// </summary>
-    public static Task MouseClickAsync(HtmlBrowserSession session, string selector, MouseButton button = MouseButton.Left, int clickCount = 1, KeyboardModifier[]? modifiers = null, int timeout = 10000)
-        => MouseClickAsync(session.Page, selector, button, clickCount, modifiers, timeout);
+    public static Task MouseClickAsync(HtmlBrowserSession session, string selector, MouseButton button = MouseButton.Left, int clickCount = 1, KeyboardModifier[]? modifiers = null, int timeout = 10000, CancellationToken cancellationToken = default)
+        => MouseClickAsync(session.Page, selector, button, clickCount, modifiers, timeout, cancellationToken);
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 
@@ -8,24 +9,30 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Registers a network route handler on the specified page.
     /// </summary>
-    public static Task RegisterRouteAsync(IPage page, string pattern, Func<IRoute, Task> handler)
-        => page.RouteAsync(pattern, handler);
+public static Task RegisterRouteAsync(IPage page, string pattern, Func<IRoute, Task> handler, CancellationToken cancellationToken = default)
+{
+    cancellationToken.ThrowIfCancellationRequested();
+    return page.RouteAsync(pattern, handler);
+}
 
     /// <summary>
     /// Registers a network route handler on the session page.
     /// </summary>
-    public static Task RegisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task> handler)
-        => RegisterRouteAsync(session.Page, pattern, handler);
+public static Task RegisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task> handler, CancellationToken cancellationToken = default)
+    => RegisterRouteAsync(session.Page, pattern, handler, cancellationToken);
 
     /// <summary>
     /// Removes a previously registered route handler from the page.
     /// </summary>
-    public static Task UnregisterRouteAsync(IPage page, string pattern, Func<IRoute, Task>? handler = null)
-        => handler is null ? page.UnrouteAsync(pattern) : page.UnrouteAsync(pattern, handler);
+public static Task UnregisterRouteAsync(IPage page, string pattern, Func<IRoute, Task>? handler = null, CancellationToken cancellationToken = default)
+{
+    cancellationToken.ThrowIfCancellationRequested();
+    return handler is null ? page.UnrouteAsync(pattern) : page.UnrouteAsync(pattern, handler);
+}
 
     /// <summary>
     /// Removes a previously registered route handler from the session page.
     /// </summary>
-    public static Task UnregisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task>? handler = null)
-        => UnregisterRouteAsync(session.Page, pattern, handler);
+public static Task UnregisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task>? handler = null, CancellationToken cancellationToken = default)
+    => UnregisterRouteAsync(session.Page, pattern, handler, cancellationToken);
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -21,7 +22,7 @@ public static partial class HtmlBrowser {
     /// <param name="clean">Reinstall the browser runtime.</param>
     /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
     /// <returns>Paths of downloaded files.</returns>
-    public static async Task<List<string>> SavePageDownloadsAsync(string url, string directory, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? filter = null, bool headless = true, int slowMo = 0) {
+    public static async Task<List<string>> SavePageDownloadsAsync(string url, string directory, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? filter = null, bool headless = true, int slowMo = 0, CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -31,16 +32,17 @@ public static partial class HtmlBrowser {
             null,
             headless,
             slowMo,
-            null).ConfigureAwait(false);
+            null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         var page = session.Page;
         string dir = HtmlUtilities.ResolvePath(directory);
-        return await SavePageDownloadsAsync(page, dir, filter).ConfigureAwait(false);
+        return await SavePageDownloadsAsync(page, dir, filter, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Saves files downloaded from an already loaded page.
     /// </summary>
-    public static async Task<List<string>> SavePageDownloadsAsync(IPage page, string directory, string? filter = null) {
+    public static async Task<List<string>> SavePageDownloadsAsync(IPage page, string directory, string? filter = null, CancellationToken cancellationToken = default) {
 
         string dir = HtmlUtilities.ResolvePath(directory);
         Directory.CreateDirectory(dir);
@@ -56,6 +58,7 @@ public static partial class HtmlBrowser {
             }
         };
 
+        cancellationToken.ThrowIfCancellationRequested();
         await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -63,9 +66,11 @@ public static partial class HtmlBrowser {
             ? "a[download],a[href*='/download/'],a[href*='/archive/']"
             : $"a[href*=\"{filter}\"]";
 
+        cancellationToken.ThrowIfCancellationRequested();
         await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 });
         var anchors = await page.QuerySelectorAllAsync(selector);
         foreach (var anchor in anchors) {
+            cancellationToken.ThrowIfCancellationRequested();
             var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
             string filePath = Path.Combine(dir, download.SuggestedFilename);
             await download.SaveAsAsync(filePath);
@@ -73,7 +78,6 @@ public static partial class HtmlBrowser {
                 downloads.Add(filePath);
             }
         }
-
         await page.WaitForTimeoutAsync(500);
         return downloads;
     }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -46,7 +47,8 @@ public static partial class HtmlBrowser {
         int slowMo = 0,
         string? proxy = null,
         string? proxyUsername = null,
-        string? proxyPassword = null) {
+        string? proxyPassword = null,
+        CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -59,7 +61,8 @@ public static partial class HtmlBrowser {
             null,
             proxy: proxy,
             proxyUsername: proxyUsername,
-            proxyPassword: proxyPassword).ConfigureAwait(false);
+            proxyPassword: proxyPassword,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await SavePagePdfAsync(
             session.Page,
@@ -82,7 +85,8 @@ public static partial class HtmlBrowser {
             footerTemplate,
             preferCssPageSize,
             outline,
-            tagged).ConfigureAwait(false);
+            tagged,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -109,11 +113,14 @@ public static partial class HtmlBrowser {
         string? footerTemplate = null,
         bool preferCssPageSize = false,
         bool outline = false,
-        bool tagged = false) {
+        bool tagged = false,
+        CancellationToken cancellationToken = default) {
         if (!string.IsNullOrEmpty(selector)) {
+            cancellationToken.ThrowIfCancellationRequested();
             await page.WaitForSelectorAsync(selector!, new PageWaitForSelectorOptions { Timeout = 10000 });
         }
         if (delayMs > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
             await page.WaitForTimeoutAsync(delayMs);
         }
 
@@ -142,6 +149,7 @@ public static partial class HtmlBrowser {
             };
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         await page.PdfAsync(options).ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
@@ -65,7 +66,8 @@ public static partial class HtmlBrowser {
         int slowMo = 0,
         string? proxy = null,
         string? proxyUsername = null,
-        string? proxyPassword = null) {
+        string? proxyPassword = null,
+        CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -78,7 +80,8 @@ public static partial class HtmlBrowser {
             null,
             proxy: proxy,
             proxyUsername: proxyUsername,
-            proxyPassword: proxyPassword).ConfigureAwait(false);
+            proxyPassword: proxyPassword,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         string fullPath = HtmlUtilities.ResolvePath(path);
         await CaptureScreenshotAsync(
@@ -95,7 +98,8 @@ public static partial class HtmlBrowser {
             clipWidth,
             clipHeight,
             highlightSelectors,
-            overlayText).ConfigureAwait(false);
+            overlayText,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -127,11 +131,14 @@ public static partial class HtmlBrowser {
         int? clipWidth = null,
         int? clipHeight = null,
         IEnumerable<string>? highlightSelectors = null,
-        string? overlayText = null) {
+        string? overlayText = null,
+        CancellationToken cancellationToken = default) {
         if (!string.IsNullOrEmpty(selector)) {
+            cancellationToken.ThrowIfCancellationRequested();
             await page.WaitForSelectorAsync(selector!, new PageWaitForSelectorOptions { Timeout = 10000 });
         }
         if (delayMs > 0) {
+            cancellationToken.ThrowIfCancellationRequested();
             await page.WaitForTimeoutAsync(delayMs);
         }
 
@@ -160,6 +167,7 @@ public static partial class HtmlBrowser {
                 Height = clipHeight.Value,
             };
         }
+        cancellationToken.ThrowIfCancellationRequested();
         byte[] data = await page.ScreenshotAsync(options);
 
         bool needsProcessing = (highlightSelectors != null && System.Linq.Enumerable.Any(highlightSelectors)) || !string.IsNullOrEmpty(overlayText) || (format != ImageFormat.Png && format != ImageFormat.Jpeg);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SessionState.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SessionState.cs
@@ -2,6 +2,7 @@ namespace PSParseHTML;
 
 using Microsoft.Playwright;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -13,12 +14,13 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="session">Browser session to export.</param>
     /// <param name="path">File path where the session state should be stored.</param>
-    public static Task ExportSessionAsync(HtmlBrowserSession session, string path) {
+    public static Task ExportSessionAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         string fullPath = HtmlUtilities.ResolvePath(path);
         string? dir = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(dir)) {
             Directory.CreateDirectory(dir);
         }
+        cancellationToken.ThrowIfCancellationRequested();
         return session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = fullPath });
     }
 
@@ -44,7 +46,8 @@ public static partial class HtmlBrowser {
         double? geoLatitude = null,
         double? geoLongitude = null,
         string? timezone = null,
-        int timeout = 10000)
+        int timeout = 10000,
+        CancellationToken cancellationToken = default)
         => OpenSessionAsync(
             url,
             browser,
@@ -68,5 +71,6 @@ public static partial class HtmlBrowser {
             geoLatitude: geoLatitude,
             geoLongitude: geoLongitude,
             timezone: timezone,
-            timeout: timeout);
+            timeout: timeout,
+            cancellationToken: cancellationToken);
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
@@ -2,21 +2,27 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
 
 public static partial class HtmlBrowser {
-    public static Task StartTracingAsync(HtmlBrowserSession session, bool screenshots = true, bool snapshots = true, bool sources = true)
-        => session.Context.Tracing.StartAsync(new Microsoft.Playwright.TracingStartOptions { Screenshots = screenshots, Snapshots = snapshots, Sources = sources });
+    public static Task StartTracingAsync(HtmlBrowserSession session, bool screenshots = true, bool snapshots = true, bool sources = true, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return session.Context.Tracing.StartAsync(new Microsoft.Playwright.TracingStartOptions { Screenshots = screenshots, Snapshots = snapshots, Sources = sources });
+    }
 
-    public static Task StopTracingAsync(HtmlBrowserSession session, string path) {
+    public static Task StopTracingAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string full = HtmlUtilities.ResolvePath(path);
         Directory.CreateDirectory(Path.GetDirectoryName(full)!);
         return session.Context.Tracing.StopAsync(new Microsoft.Playwright.TracingStopOptions { Path = full });
     }
 
-    public static Task ExportHarAsync(HtmlBrowserSession session, string path) {
+    public static Task ExportHarAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         string full = HtmlUtilities.ResolvePath(path);
         Directory.CreateDirectory(Path.GetDirectoryName(full)!);
         var log = new {

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 
@@ -26,8 +27,9 @@ public static partial class HtmlBrowser {
         float? deviceScaleFactor = null,
         double? geoLatitude = null,
         double? geoLongitude = null,
-        string? timezone = null)
-        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy: null, proxyUsername: null, proxyPassword: null, geoLatitude: geoLatitude, geoLongitude: geoLongitude, timezone: timezone);
+        string? timezone = null,
+        CancellationToken cancellationToken = default)
+        => OpenSessionAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, width, height, null, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy: null, proxyUsername: null, proxyPassword: null, geoLatitude: geoLatitude, geoLongitude: geoLongitude, timezone: timezone, cancellationToken: cancellationToken);
 
     /// <summary>
     /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
@@ -45,7 +47,8 @@ public static partial class HtmlBrowser {
         float? deviceScaleFactor = null,
         double? geoLatitude = null,
         double? geoLongitude = null,
-        string? timezone = null) {
+        string? timezone = null,
+        CancellationToken cancellationToken = default) {
         string temp = Path.GetTempFileName();
         await session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = temp }).ConfigureAwait(false);
         string url = session.Page.Url;
@@ -77,7 +80,8 @@ public static partial class HtmlBrowser {
             proxyPassword: null,
             geoLatitude: geoLatitude,
             geoLongitude: geoLongitude,
-            timezone: timezone).ConfigureAwait(false);
+            timezone: timezone,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         File.Delete(temp);
         return newSession;
@@ -86,10 +90,11 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Stops the specified video recording session and saves the file.
     /// </summary>
-    public static async Task StopVideoRecordingAsync(HtmlBrowserSession session, string? path = null) {
+    public static async Task StopVideoRecordingAsync(HtmlBrowserSession session, string? path = null, CancellationToken cancellationToken = default) {
         string outFile = path ?? session.VideoPath ?? throw new System.ArgumentException("Output path required.");
         IVideo? video = session.Video;
         if (video != null) {
+            cancellationToken.ThrowIfCancellationRequested();
             await session.Context.CloseAsync().ConfigureAwait(false);
             string fullPath = HtmlUtilities.ResolvePath(outFile);
             await video.SaveAsAsync(fullPath).ConfigureAwait(false);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -37,7 +38,9 @@ public static partial class HtmlBrowser {
         double? geoLatitude = null,
         double? geoLongitude = null,
         string? timezone = null,
-        int timeout = 10000) {
+        int timeout = 10000,
+        CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         if (clean) {
             CleanInstallDir();
         }
@@ -47,6 +50,7 @@ public static partial class HtmlBrowser {
         string engine = browser.ToString().ToLowerInvariant();
         Microsoft.Playwright.Program.Main(new[] { "install", engine });
 
+        cancellationToken.ThrowIfCancellationRequested();
         var playwright = await Playwright.CreateAsync();
         IBrowserType type = browser switch {
             HtmlBrowserEngine.Firefox => playwright.Firefox,
@@ -65,6 +69,7 @@ public static partial class HtmlBrowser {
                 Password = proxyPassword
             };
         }
+        cancellationToken.ThrowIfCancellationRequested();
         var browserInstance = await type.LaunchAsync(launchOptions);
         BrowserNewContextOptions? contextOptions = null;
         if (formLogin == null && !string.IsNullOrEmpty(username) && password != null) {
@@ -108,6 +113,7 @@ public static partial class HtmlBrowser {
             contextOptions.TimezoneId = timezone;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var context = await browserInstance.NewContextAsync(contextOptions);
         var page = await context.NewPageAsync();
 
@@ -131,6 +137,7 @@ public static partial class HtmlBrowser {
         };
 
         if (formLogin != null) {
+            cancellationToken.ThrowIfCancellationRequested();
             await page.GotoAsync(formLogin.LoginUrl, new PageGotoOptions { Timeout = timeout });
             await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
             if (username != null) {
@@ -143,6 +150,7 @@ public static partial class HtmlBrowser {
             await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         await page.GotoAsync(url, new PageGotoOptions { Timeout = timeout });
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
 
@@ -180,14 +188,16 @@ public static partial class HtmlBrowser {
         double? geoLatitude = null,
         double? geoLongitude = null,
         string? timezone = null,
-        int timeout = 10000)
-        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout);
+        int timeout = 10000,
+        CancellationToken cancellationToken = default)
+        => CreatePageAsync(url, browser, clean, username, password, formLogin, headless, slowMo, videoPath, videoWidth, videoHeight, storageStatePath, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout, cancellationToken);
 
     /// <summary>
     /// Disposes the specified browser session.
     /// </summary>
-    public static async Task CloseSessionAsync(HtmlBrowserSession session) {
+    public static async Task CloseSessionAsync(HtmlBrowserSession session, CancellationToken cancellationToken = default) {
         if (session != null) {
+            cancellationToken.ThrowIfCancellationRequested();
             await session.DisposeAsync().ConfigureAwait(false);
         }
     }
@@ -196,7 +206,7 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">The URL to load.</param>
     /// <returns>The rendered HTML markup.</returns>
-    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000) {
+    public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000, CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -220,7 +230,8 @@ public static partial class HtmlBrowser {
             geoLatitude: geoLatitude,
             geoLongitude: geoLongitude,
             timezone: timezone,
-            timeout: timeout).ConfigureAwait(false);
+            timeout: timeout,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return await session.Page.ContentAsync().ConfigureAwait(false);
     }
@@ -230,9 +241,9 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
-    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000) {
+    public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000, CancellationToken cancellationToken = default) {
         string fullPath = HtmlUtilities.ResolvePath(path);
-        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout).ConfigureAwait(false);
+        string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout, cancellationToken).ConfigureAwait(false);
         File.WriteAllText(fullPath, content);
     }
 
@@ -244,15 +255,18 @@ public static partial class HtmlBrowser {
     /// <param name="innerHtml">Return inner HTML instead of outer HTML.</param>
     /// <param name="asText">Return text content instead of markup.</param>
     /// <returns>Extracted markup or text.</returns>
-    public static async Task<string> GetContentAsync(IPage page, string? selector = null, bool innerHtml = false, bool asText = false) {
+    public static async Task<string> GetContentAsync(IPage page, string? selector = null, bool innerHtml = false, bool asText = false, CancellationToken cancellationToken = default) {
         if (string.IsNullOrEmpty(selector)) {
             if (asText) {
+                cancellationToken.ThrowIfCancellationRequested();
                 return await page.InnerTextAsync("html").ConfigureAwait(false);
             }
+            cancellationToken.ThrowIfCancellationRequested();
             return await page.ContentAsync().ConfigureAwait(false);
         }
 
         var locator = page.Locator(selector!);
+        cancellationToken.ThrowIfCancellationRequested();
         await locator.WaitForAsync();
 
         if (asText) {
@@ -269,11 +283,13 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="page">Playwright page instance.</param>
     /// <returns>List of interactable element descriptions.</returns>
-    public static async Task<List<HtmlInteractableInfo>> GetInteractablesAsync(IPage page) {
+    public static async Task<List<HtmlInteractableInfo>> GetInteractablesAsync(IPage page, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         var elements = await page.QuerySelectorAllAsync("a,button,[role=button],input[type=button],input[type=submit]");
         List<HtmlInteractableInfo> list = new();
         int index = 0;
         foreach (var el in elements) {
+            cancellationToken.ThrowIfCancellationRequested();
             string rawText = await el.InnerTextAsync();
             string text = Regex.Replace(rawText, "\\s+", " ").Trim();
             string tag = await el.EvaluateAsync<string>("el => el.tagName.toLowerCase()");
@@ -296,6 +312,7 @@ public static partial class HtmlBrowser {
                 }
                 return false;
             }");
+            cancellationToken.ThrowIfCancellationRequested();
             string selector = await el.EvaluateAsync<string>(@"el => {
                 const esc = (CSS && CSS.escape) ? CSS.escape : (s => s);
                 let sel = el.tagName.toLowerCase();
@@ -324,7 +341,8 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Navigates the specified session to a new URL and waits for the network to be idle.
     /// </summary>
-    public static async Task NavigateAsync(HtmlBrowserSession session, string url, int timeout = 10000) {
+    public static async Task NavigateAsync(HtmlBrowserSession session, string url, int timeout = 10000, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         await session.Page.GotoAsync(url, new PageGotoOptions { Timeout = timeout }).ConfigureAwait(false);
         await session.Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout }).ConfigureAwait(false);
     }
@@ -332,7 +350,7 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Clicks an element by CSS selector.
     /// </summary>
-    public static async Task ClickSelectorAsync(HtmlBrowserSession session, string selector, bool waitForNavigation = false, int timeout = 10000) {
+    public static async Task ClickSelectorAsync(HtmlBrowserSession session, string selector, bool waitForNavigation = false, int timeout = 10000, CancellationToken cancellationToken = default) {
         if (waitForNavigation) {
             Task waitTask = session.Page.WaitForURLAsync("**", new PageWaitForURLOptions { Timeout = timeout });
             await session.Page.ClickAsync(selector, new PageClickOptions { Timeout = timeout }).ConfigureAwait(false);
@@ -345,7 +363,7 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Clicks an element specified by text content.
     /// </summary>
-    public static async Task ClickTextAsync(HtmlBrowserSession session, string text, bool exact = false, string? regex = null, bool waitForNavigation = false, int timeout = 10000) {
+    public static async Task ClickTextAsync(HtmlBrowserSession session, string text, bool exact = false, string? regex = null, bool waitForNavigation = false, int timeout = 10000, CancellationToken cancellationToken = default) {
         ILocator locator = !string.IsNullOrEmpty(regex)
             ? session.Page.GetByText(new Regex(regex))
             : exact


### PR DESCRIPTION
## Summary
- add CancellationToken parameters to all public HtmlBrowser async methods
- propagate tokens through methods like SavePagePdfAsync and FillInputAsync

## Testing
- `dotnet build Sources/PSParseHTML.sln -nologo`
- `pwsh -File PSParseHTML.Tests.ps1` *(fails: cmdlets missing)*

------
https://chatgpt.com/codex/tasks/task_e_685466078fd0832eb4f091bb5fe7d776