### PR TITLE
Fix HtmlBrowserSession disposal

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+using PSParseHTML;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlBrowserSessionDisposeTests {
+    [Fact]
+    public async Task DisposeAsync_AllowsNullProperties() {
+        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        await session.DisposeAsync();
+    }
+}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
@@ -56,8 +56,14 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// Asynchronously disposes of the browser session, closing the page, context, and browser.
     /// /// </summary>
     public async ValueTask DisposeAsync() {
-        await Context.CloseAsync();
-        await Browser.CloseAsync();
-        Playwright.Dispose();
+        if (Context != null) {
+            await Context.CloseAsync();
+        }
+        if (Browser != null) {
+            await Browser.CloseAsync();
+        }
+        if (Playwright != null) {
+            Playwright.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle null objects in `HtmlBrowserSession.DisposeAsync`
- ensure disposal doesn't throw on partially constructed sessions

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855d132644c832ebf2b9ea9f4baac15