### PR TITLE
Fix charset handling in HtmlUtilities

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlUtilitiesTests.cs
@@ -78,4 +78,18 @@ public class HtmlUtilitiesTests {
         string result = await HtmlUtilities.GetStringWithProperEncodingAsync(client, server.BaseAddress.ToString());
         Assert.Equal("Hello", result);
     }
+
+    [Fact]
+    public async Task GetStringWithProperEncodingAsync_TrimsQuotedCharset() {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.Run(async ctx => {
+                ctx.Response.ContentType = "text/plain; charset=\"utf-8\"";
+                var bytes = System.Text.Encoding.UTF8.GetBytes("Hello");
+                await ctx.Response.Body.WriteAsync(bytes);
+            }));
+        using var server = new TestServer(builder);
+        using HttpClient client = server.CreateClient();
+        string result = await HtmlUtilities.GetStringWithProperEncodingAsync(client, server.BaseAddress.ToString());
+        Assert.Equal("Hello", result);
+    }
 }

--- a/Sources/PSParseHTML/HtmlUtilities.cs
+++ b/Sources/PSParseHTML/HtmlUtilities.cs
@@ -72,7 +72,8 @@ public static class HtmlUtilities {
         var contentType = response.Content.Headers.ContentType;
         if (contentType?.CharSet != null) {
             try {
-                var encoding = System.Text.Encoding.GetEncoding(contentType.CharSet);
+                string charset = contentType.CharSet.Trim().Trim('"').Trim('\'');
+                var encoding = System.Text.Encoding.GetEncoding(charset);
                 return encoding.GetString(bytes);
             } catch {
                 // If the specified encoding is not supported, fall through to detection


### PR DESCRIPTION
## Summary
- trim quotes and spaces from the `charset` header before decoding
- add test for quoted charset header

## Testing
- `dotnet test Sources/PSParseHTML.sln --no-build --verbosity normal` *(fails: TaskCanceledException, unsupported encoding)*

------
https://chatgpt.com/codex/tasks/task_e_6855d12a24b4832ebc01b0a31b876473