### PR TITLE
Fix duplicate downloads

### DIFF
--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 
 namespace PSParseHTML;
@@ -47,6 +45,26 @@ public static partial class HtmlBrowser {
         string dir = HtmlUtilities.ResolvePath(directory);
         Directory.CreateDirectory(dir);
         List<string> downloads = new();
+        object sync = new();
+        page.Download += async (_, dl) => {
+            bool match = string.IsNullOrEmpty(filter) ||
+                         dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                         dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+            if (!match) {
+                return;
+            }
+            string filePath = Path.Combine(dir, dl.SuggestedFilename);
+            bool save;
+            lock (sync) {
+                save = !downloads.Contains(filePath);
+                if (save) {
+                    downloads.Add(filePath);
+                }
+            }
+            if (save) {
+                await dl.SaveAsAsync(filePath).ConfigureAwait(false);
+            }
+        };
 
         cancellationToken.ThrowIfCancellationRequested();
         await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
@@ -61,12 +79,7 @@ public static partial class HtmlBrowser {
         var anchors = await page.QuerySelectorAllAsync(selector);
         foreach (var anchor in anchors) {
             cancellationToken.ThrowIfCancellationRequested();
-            var download = await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
-            string filePath = Path.Combine(dir, download.SuggestedFilename);
-            await download.SaveAsAsync(filePath);
-            if (!downloads.Contains(filePath)) {
-                downloads.Add(filePath);
-            }
+            await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
         }
         await page.WaitForTimeoutAsync(500);
         return downloads;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -47,16 +47,6 @@ public static partial class HtmlBrowser {
         string dir = HtmlUtilities.ResolvePath(directory);
         Directory.CreateDirectory(dir);
         List<string> downloads = new();
-        page.Download += async (_, dl) => {
-            bool match = string.IsNullOrEmpty(filter) ||
-                         dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                         dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
-            if (match) {
-                string filePath = Path.Combine(dir, dl.SuggestedFilename);
-                await dl.SaveAsAsync(filePath);
-                downloads.Add(filePath);
-            }
-        };
 
         cancellationToken.ThrowIfCancellationRequested();
         await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");


### PR DESCRIPTION
## Summary
- remove page download event from `SavePageDownloadsAsync`

## Testing
- `pwsh -NoLogo -Command Invoke-Pester -Path Tests/Save-HTMLDownloadUrl.Tests.ps1 -Verbose`
- `pwsh -NoLogo -ExecutionPolicy Bypass -File ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68564cca5b80832e9124b45a18fbea06