### PR TITLE
Add directory creation for browser saves

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserFileSavingTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserFileSavingTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Moq;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlBrowserFileSavingTests {
+    [Fact]
+    public async Task CaptureScreenshotAsync_CreatesDirectoryAndFile() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string file = Path.Combine(dir, "test.png");
+        var page = new Mock<IPage>();
+        page.Setup(p => p.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()))
+            .ReturnsAsync(new byte[] {1,2,3});
+
+        await HtmlBrowser.CaptureScreenshotAsync(page.Object, file);
+
+        Assert.True(Directory.Exists(dir));
+        Assert.True(File.Exists(file));
+        byte[] data = File.ReadAllBytes(file);
+        Assert.Equal(new byte[] {1,2,3}, data);
+
+        File.Delete(file);
+        Directory.Delete(dir);
+    }
+
+    [Fact]
+    public async Task SavePagePdfAsync_CreatesDirectoryAndFile() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string file = Path.Combine(dir, "test.pdf");
+        var page = new Mock<IPage>();
+        page.Setup(p => p.PdfAsync(It.IsAny<PagePdfOptions>()))
+            .Callback<PagePdfOptions>(o => File.WriteAllText(o.Path!, "pdf"))
+            .ReturnsAsync(Array.Empty<byte>());
+
+        await HtmlBrowser.SavePagePdfAsync(page.Object, file);
+
+        Assert.True(Directory.Exists(dir));
+        Assert.True(File.Exists(file));
+        string content = File.ReadAllText(file);
+        Assert.Equal("pdf", content);
+
+        File.Delete(file);
+        Directory.Delete(dir);
+    }
+}

--- a/Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj
+++ b/Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.17" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -124,8 +124,10 @@ public static partial class HtmlBrowser {
             await page.WaitForTimeoutAsync(delayMs);
         }
 
+        string fullPath = HtmlUtilities.ResolvePath(path);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
         var options = new PagePdfOptions {
-            Path = path,
+            Path = fullPath,
             Landscape = landscape,
             PrintBackground = printBackground,
             Format = format,

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -154,6 +154,7 @@ public static partial class HtmlBrowser {
         }
 
         string fullPath = HtmlUtilities.ResolvePath(path);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
         var options = new PageScreenshotOptions { FullPage = fullPage };
         options.Type = format == ImageFormat.Jpeg ? ScreenshotType.Jpeg : ScreenshotType.Png;
         if (options.Type == ScreenshotType.Jpeg) {


### PR DESCRIPTION
## Summary
- ensure output directories exist in HtmlBrowser before saving screenshots/PDFs
- add tests verifying directories are created when saving
- include Moq for mocking Playwright interfaces

## Testing
- `dotnet test Sources/PSParseHTML.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685651f3fbf0832e971e92be3a235a3e