### PR TITLE
Fix download saving and export cmdlets

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,7 +1,50 @@
 ﻿@{
     AliasesToExport        = @('Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Format-JS', 'Start-HTMLSession', 'Open-HTMLSession', 'Save-HTMLDownload')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HTMLSession', 'Compare-HTML', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HtmlForm', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLInteractable', 'Get-HTMLNetworkLog', 'Invoke-HTMLClick', 'Invoke-HTMLNavigation', 'Invoke-HTMLRendering', 'Invoke-HTMLScript', 'Invoke-HTMLDomScript', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HTMLAttachment', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLCookie', 'Set-HTMLHttpClientOption', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Start-HTMLVideoRecording', 'Stop-HTMLVideoRecording', 'Submit-HTMLForm', 'Unregister-HTMLRoute')
+    CmdletsToExport        = @(
+        'Close-HTMLSession',
+        'Compare-HTML',
+        'ConvertFrom-HTML',
+        'ConvertFrom-HtmlAttributes',
+        'ConvertFrom-HtmlForm',
+        'ConvertFrom-HtmlList',
+        'ConvertFrom-HtmlTable',
+        'Convert-HTMLToText',
+        'Export-HTMLSession',
+        'Format-CSS',
+        'Format-HTML',
+        'Format-JavaScript',
+        'Get-HTMLContent',
+        'Get-HTMLCookie',
+        'Get-HTMLInteractable',
+        'Get-HTMLNetworkLog',
+        'Import-HTMLSession',
+        'Invoke-HTMLClick',
+        'Invoke-HTMLNavigation',
+        'Invoke-HTMLRendering',
+        'Invoke-HTMLScript',
+        'Invoke-HTMLDomScript',
+        'Optimize-CSS',
+        'Optimize-Email',
+        'Optimize-HTML',
+        'Optimize-JavaScript',
+        'Register-HTMLRoute',
+        'Save-HTMLAttachment',
+        'Save-HTMLHar',
+        'Save-HTMLPdf',
+        'Save-HTMLScreenshot',
+        'Set-HTMLChecked',
+        'Set-HTMLCookie',
+        'Set-HTMLHttpClientOption',
+        'Set-HTMLInput',
+        'Set-HTMLSelectOption',
+        'Start-HTMLTracing',
+        'Stop-HTMLTracing',
+        'Start-HTMLVideoRecording',
+        'Stop-HTMLVideoRecording',
+        'Submit-HTMLForm',
+        'Unregister-HTMLRoute'
+    )
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -45,8 +45,9 @@ public static partial class HtmlBrowser {
         string dir = HtmlUtilities.ResolvePath(directory);
         Directory.CreateDirectory(dir);
         List<string> downloads = new();
+        List<Task> saves = new();
         object sync = new();
-        page.Download += async (_, dl) => {
+        page.Download += (_, dl) => {
             bool match = string.IsNullOrEmpty(filter) ||
                          dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
                          dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
@@ -59,10 +60,8 @@ public static partial class HtmlBrowser {
                 save = !downloads.Contains(filePath);
                 if (save) {
                     downloads.Add(filePath);
+                    saves.Add(dl.SaveAsAsync(filePath));
                 }
-            }
-            if (save) {
-                await dl.SaveAsAsync(filePath).ConfigureAwait(false);
             }
         };
 
@@ -81,7 +80,7 @@ public static partial class HtmlBrowser {
             cancellationToken.ThrowIfCancellationRequested();
             await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
         }
-        await page.WaitForTimeoutAsync(500);
+        await Task.WhenAll(saves).ConfigureAwait(false);
         return downloads;
     }
 }

--- a/Tests/Save-HTMLDownloadUrl.Tests.ps1
+++ b/Tests/Save-HTMLDownloadUrl.Tests.ps1
@@ -7,11 +7,19 @@ Describe 'Save-HTMLAttachment' {
         $Item2 = Get-Item -Path $File[1]
 
         $List = @(
-            'DnsClientX-PowerShellModule.v0.4.0.zip'
+            'DnsClientX-PowerShellModule.v0.4.0.zip',
             'DnsClientX-DnsClientX-PowerShellModule.v0.4.0.zip'
         )
 
         $List | Should -Contain $Item1.Name
         $List | Should -Contain $Item2.Name
+    }
+
+    It 'Downloads are fully written to disk' {
+        $Dest = Join-Path $TestDrive 'dl-full'
+        [array] $File = Save-HTMLAttachment -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$Dest" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip'
+        foreach ($path in $File) {
+            (Get-Item $path).Length | Should -BeGreaterThan 0
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure all downloads finish before returning
- export missing Playwright cmdlets in module manifest
- add test verifying downloads are fully written

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685656d07c7c832ea0d4e4963406a5f2