### PR TITLE
Switch MoveCssInline to async

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -123,7 +123,7 @@ public sealed class CmdletOptimizeEmail : AsyncPSCmdlet {
     /// <summary>
     /// Processes the input HTML or file and outputs optimized HTML.
     /// </summary>
-    protected override Task ProcessRecordAsync() {
+    protected override async Task ProcessRecordAsync() {
         PreMailerOptions options = new() {
             BaseUri = BaseUri,
             RemoveStyleElements = RemoveStyleElements,
@@ -144,8 +144,12 @@ public sealed class CmdletOptimizeEmail : AsyncPSCmdlet {
         };
 
         PreMailerResult result = ParameterSetName == "File"
-            ? PreMailerClient.MoveCssInlineFromFile(Path, options)
-            : PreMailerClient.MoveCssInline(Body, options);
+            ? await PreMailerClient
+                .MoveCssInlineFromFile(Path, options)
+                .ConfigureAwait(false)
+            : await PreMailerClient
+                .MoveCssInline(Body, options)
+                .ConfigureAwait(false);
 
         WriteObject(result.Html);
 
@@ -153,6 +157,6 @@ public sealed class CmdletOptimizeEmail : AsyncPSCmdlet {
             LoggingMessages.Logger.WriteWarning(warning.Message);
         }
 
-        return Task.CompletedTask;
+        return;
     }
 }

--- a/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
@@ -8,30 +8,30 @@ public class PreMailerClientTests
     private const string HtmlWithMediaQuery = "<html><head><style>h1{color:red;}@media(max-width:600px){h1{font-size:14px;}}</style></head><body><h1>Hello</h1></body></html>";
 
     [Fact]
-    public void MoveCssInline_RemovesStyleElements_WhenEnabled()
+    public async Task MoveCssInline_RemovesStyleElements_WhenEnabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = true };
-        PreMailerResult result = PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
         Assert.DoesNotContain("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void MoveCssInline_PreservesStyleElements_WhenDisabled()
+    public async Task MoveCssInline_PreservesStyleElements_WhenDisabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = false };
-        PreMailerResult result = PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
         Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void MoveCssInline_PreservesMediaQueries_WhenRequested()
+    public async Task MoveCssInline_PreservesMediaQueries_WhenRequested()
     {
         var options = new PreMailerOptions
         {
             RemoveStyleElements = true,
             PreserveMediaQueries = true
         };
-        PreMailerResult result = PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
         Assert.Contains("@media", result.Html, System.StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -43,7 +43,7 @@ public class PreMailerClient {
     /// <summary>
     /// Processes the HTML and returns the result.
     /// </summary>
-    public PreMailerResult MoveCssInline() {
+    public async Task<PreMailerResult> MoveCssInline() {
         try {
             string cssContent = Options.Css ?? string.Empty;
             string htmlToProcess = _html;
@@ -72,7 +72,9 @@ public class PreMailerClient {
                             if (uri.IsFile)
                             {
                                 string localPath = NormalizeFileUriPath(uri);
-                                cssContent += File.ReadAllText(localPath);
+                                cssContent += await HtmlUtilities
+                                    .ReadFileCheckedAsync(localPath)
+                                    .ConfigureAwait(false);
                             }
                             else if (uri.IsAbsoluteUri)
                             {
@@ -91,11 +93,9 @@ public class PreMailerClient {
 
             htmlToProcess = document.DocumentElement.OuterHtml;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
-                string cssPath = HtmlUtilities.ResolvePath(Options.CssFilePath!);
-                if (!File.Exists(cssPath)) {
-                    throw new FileNotFoundException($"CSS file not found: {Options.CssFilePath}", cssPath);
-                }
-                cssContent += File.ReadAllText(cssPath);
+                cssContent += await HtmlUtilities
+                    .ReadFileCheckedAsync(Options.CssFilePath!)
+                    .ConfigureAwait(false);
             }
 
             PreMailer.Net.PreMailer preMailer = Options.BaseUri != null
@@ -232,14 +232,14 @@ public class PreMailerClient {
     /// <summary>
     /// Convenience method for processing a HTML string directly using options.
     /// </summary>
-    public static PreMailerResult MoveCssInline(string html, PreMailerOptions? options = null) {
+    public static Task<PreMailerResult> MoveCssInline(string html, PreMailerOptions? options = null) {
         return FromHtml(html, options).MoveCssInline();
     }
 
     /// <summary>
     /// Convenience method for processing a HTML file directly using options.
     /// </summary>
-    public static PreMailerResult MoveCssInlineFromFile(string htmlFilePath, PreMailerOptions? options = null) {
+    public static Task<PreMailerResult> MoveCssInlineFromFile(string htmlFilePath, PreMailerOptions? options = null) {
         return FromFile(htmlFilePath, options).MoveCssInline();
     }
 
@@ -260,7 +260,7 @@ public class PreMailerClient {
     /// <summary>
     /// Parameter-based helper constructing an options object internally.
     /// </summary>
-    public static PreMailerResult MoveCssInline(
+    public static Task<PreMailerResult> MoveCssInline(
         string html,
         Uri? baseUri = null,
         bool removeStyleElements = false,
@@ -306,7 +306,7 @@ public class PreMailerClient {
     /// <summary>
     /// Parameter-based helper for processing a HTML file directly.
     /// </summary>
-    public static PreMailerResult MoveCssInlineFromFile(
+    public static Task<PreMailerResult> MoveCssInlineFromFile(
         string htmlFilePath,
         Uri? baseUri = null,
         bool removeStyleElements = false,


### PR DESCRIPTION
## Summary
- make `MoveCssInline` asynchronous
- update CmdletOptimizeEmail to await new API
- adjust tests for async method

## Testing
- `dotnet test Sources/PSParseHTML.sln -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLTracing, Save-HTMLHar not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0459964832e92afa34df64053a3