### PR TITLE
Handle empty cookie list

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
@@ -16,6 +16,7 @@ public sealed class CmdletSetHtmlCookie : AsyncPSCmdlet {
 
     /// <summary>Cookies to add.</summary>
     [Parameter(Mandatory = true)]
+    [AllowEmptyCollection]
     public HtmlCookie[]? Cookie { get; set; }
 
     [Parameter]

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
@@ -48,6 +48,8 @@ public static partial class HtmlBrowser {
             list.Add(nc);
         }
         cancellationToken.ThrowIfCancellationRequested();
-        return session.Context.AddCookiesAsync(list);
+        return list.Count == 0
+            ? Task.CompletedTask
+            : session.Context.AddCookiesAsync(list);
     }
 }

--- a/Tests/GetSet-HTMLCookie.Tests.ps1
+++ b/Tests/GetSet-HTMLCookie.Tests.ps1
@@ -25,4 +25,10 @@ Describe 'HTML Cookie cmdlets' {
 
         ($after | Where-Object Name -eq 'mycookie').Value | Should -Be 'choco'
     }
+
+    It 'Accepts an empty cookie list' {
+        $session = Invoke-HTMLRendering -Url 'about:blank' -Session
+        { Set-HTMLCookie -Session $session -Cookie @() } | Should -Not -Throw
+        Close-HTMLSession -Session $session
+    }
 }


### PR DESCRIPTION
## Summary
- skip AddCookiesAsync when there's no cookies to add
- test that Set-HTMLCookie allows empty lists

## Testing
- `dotnet test Sources/PSParseHTML.sln --no-build --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Start-HTMLTracing, Save-HTMLHar not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0502e8c832ebef6d83fe64f8669