### PR TITLE
Add documentation comments

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
@@ -14,6 +14,7 @@ public sealed class CmdletCloseHtmlSession : AsyncPSCmdlet {
     [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
     public HtmlBrowserSession Session { get; set; } = null!;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlHar.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlHar.cs
@@ -4,17 +4,30 @@ using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
+/// <summary>
+/// Saves network traffic from a browser session to a HAR file.
+/// </summary>
 [Cmdlet(VerbsData.Save, "HTMLHar")]
 public sealed class CmdletSaveHtmlHar : AsyncPSCmdlet {
+    /// <summary>
+    /// Browser session to export.
+    /// </summary>
     [Parameter(ValueFromPipeline = true, Position = 0)]
     public HtmlBrowserSession? Session { get; set; }
 
+    /// <summary>
+    /// Destination HAR file path.
+    /// </summary>
     [Parameter(Mandatory = true)]
     public string OutFile { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Optional cancellation token.
+    /// </summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 
+    /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlTracing.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlTracing.cs
@@ -4,23 +4,34 @@ using System.Threading;
 
 namespace PSParseHTML.PowerShell;
 
+/// <summary>
+/// Starts capturing a Playwright trace for the given session.
+/// </summary>
 [Cmdlet(VerbsLifecycle.Start, "HTMLTracing")]
 public sealed class CmdletStartHtmlTracing : AsyncPSCmdlet {
+    /// <summary>
+    /// Browser session to trace.
+    /// </summary>
     [Parameter(ValueFromPipeline = true, Position = 0)]
     public HtmlBrowserSession? Session { get; set; }
 
+    /// <summary>Include screenshots in the trace.</summary>
     [Parameter]
     public SwitchParameter Screenshots { get; set; } = true;
 
+    /// <summary>Include DOM snapshots in the trace.</summary>
     [Parameter]
     public SwitchParameter Snapshots { get; set; } = true;
 
+    /// <summary>Include page sources in the trace.</summary>
     [Parameter]
     public SwitchParameter Sources { get; set; } = true;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 
+    /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");

--- a/Sources/PSParseHTML.PowerShell/Communication/HttpClientHelper.cs
+++ b/Sources/PSParseHTML.PowerShell/Communication/HttpClientHelper.cs
@@ -5,7 +5,16 @@ using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
+/// <summary>
+/// Helper methods for creating <see cref="HttpClient"/> instances.
+/// </summary>
 internal static class HttpClientHelper {
+    /// <summary>
+    /// Creates a new <see cref="HttpClient"/> using optional proxy settings.
+    /// </summary>
+    /// <param name="proxy">Proxy server address.</param>
+    /// <param name="credential">Credentials for the proxy.</param>
+    /// <returns>A configured <see cref="HttpClient"/> instance.</returns>
     internal static HttpClient Create(string? proxy, PSCredential? credential) {
         ICredentials? creds = credential?.GetNetworkCredential();
         return HtmlHttpClientFactory.Create(proxy, creds);

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
@@ -8,12 +8,28 @@ using System.Threading.Tasks;
 namespace PSParseHTML;
 
 public static partial class HtmlBrowser {
+    /// <summary>
+    /// Starts Playwright tracing for the given session.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="screenshots">Capture screenshots while tracing.</param>
+    /// <param name="snapshots">Capture DOM snapshots while tracing.</param>
+    /// <param name="sources">Include source code in the trace.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A running task for the tracing start operation.</returns>
     public static Task StartTracingAsync(HtmlBrowserSession session, bool screenshots = true, bool snapshots = true, bool sources = true, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return session.Context.Tracing.StartAsync(new Microsoft.Playwright.TracingStartOptions { Screenshots = screenshots, Snapshots = snapshots, Sources = sources });
     }
 
+    /// <summary>
+    /// Stops tracing and saves the resulting trace file.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="path">Target path for the trace file.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public static Task StopTracingAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
         string full = HtmlUtilities.ResolvePath(path);
@@ -21,6 +37,13 @@ public static partial class HtmlBrowser {
         return session.Context.Tracing.StopAsync(new Microsoft.Playwright.TracingStopOptions { Path = full });
     }
 
+    /// <summary>
+    /// Exports the network log of a session to a HAR file.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="path">Destination HAR file path.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A task that completes when the file has been written.</returns>
     public static Task ExportHarAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
         string full = HtmlUtilities.ResolvePath(path);
@@ -50,3 +73,4 @@ public static partial class HtmlBrowser {
         return Task.CompletedTask;
     }
 }
+


### PR DESCRIPTION
## Summary
- document tracing helper methods
- document cmdlet Save-HtmlHar
- document HttpClient helper
- document Start-HtmlTracing cmdlet
- document parameter on Close-HtmlSession

## Testing
- `dotnet build PSParseHTML.sln`

------
https://chatgpt.com/codex/tasks/task_e_68583594bdc4832eaf2f1abde4c3938c