### PR TITLE
Add missing XML documentation comments

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletExportBrowserState.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportBrowserState.cs
@@ -17,6 +17,7 @@ public sealed class CmdletExportBrowserState : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public string Path { get; set; } = string.Empty;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletExportHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportHtmlSession.cs
@@ -17,6 +17,7 @@ public sealed class CmdletExportHtmlSession : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public string Path { get; set; } = string.Empty;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlContent.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlContent.cs
@@ -30,6 +30,7 @@ public sealed class CmdletGetHtmlContent : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter AsText { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
@@ -15,6 +15,7 @@ public sealed class CmdletGetHtmlCookie : AsyncPSCmdlet {
     [Parameter(Position = 0, ValueFromPipeline = true)]
     public HtmlBrowserSession? Session { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -61,10 +61,12 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>Timeout in milliseconds for browser operations.</summary>
     [Parameter]
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlLoginForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlLoginForm.cs
@@ -62,6 +62,7 @@ public sealed class CmdletGetHtmlLoginForm : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletImportBrowserState.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletImportBrowserState.cs
@@ -18,49 +18,63 @@ public sealed class CmdletImportBrowserState : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public string Url { get; set; } = string.Empty;
 
+    /// <summary>Browser engine used for launching the session.</summary>
     [Parameter]
     public HtmlBrowserEngine Browser { get; set; } = HtmlBrowserEngine.Chromium;
 
+    /// <summary>Reinstall browser runtimes before starting.</summary>
     [Parameter]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
     [Parameter]
     public SwitchParameter Visible { get; set; }
 
+    /// <summary>Delay in milliseconds between actions.</summary>
     [Parameter]
     [ValidateRange(0,int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>Timeout in milliseconds for browser operations.</summary>
     [Parameter]
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    /// <summary>User agent string used when launching the browser.</summary>
     [Parameter]
     public string? UserAgent { get; set; }
 
+    /// <summary>Viewport width in pixels.</summary>
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int? ViewportWidth { get; set; }
 
+    /// <summary>Viewport height in pixels.</summary>
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int? ViewportHeight { get; set; }
 
+    /// <summary>Scaling factor for high DPI devices.</summary>
     [Parameter]
     public double? DeviceScaleFactor { get; set; }
 
+    /// <summary>Latitude used for geolocation.</summary>
     [Parameter]
     public double? GeoLatitude { get; set; }
 
+    /// <summary>Longitude used for geolocation.</summary>
     [Parameter]
     public double? GeoLongitude { get; set; }
 
+    /// <summary>Timezone identifier.</summary>
     [Parameter]
     public string? Timezone { get; set; }
 
+    /// <summary>Do not store this session as the default.</summary>
     [Parameter]
     public SwitchParameter NoDefault { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletImportHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletImportHtmlSession.cs
@@ -18,49 +18,63 @@ public sealed class CmdletImportHtmlSession : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public string Url { get; set; } = string.Empty;
 
+    /// <summary>Browser engine used for launching the session.</summary>
     [Parameter]
     public HtmlBrowserEngine Browser { get; set; } = HtmlBrowserEngine.Chromium;
 
+    /// <summary>Reinstall browser runtimes before starting.</summary>
     [Parameter]
     public SwitchParameter Clean { get; set; }
 
+    /// <summary>Show the browser instead of running headless.</summary>
     [Parameter]
     public SwitchParameter Visible { get; set; }
 
+    /// <summary>Delay in milliseconds between actions.</summary>
     [Parameter]
     [ValidateRange(0,int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>Timeout in milliseconds for browser operations.</summary>
     [Parameter]
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    /// <summary>User agent string used when launching the browser.</summary>
     [Parameter]
     public string? UserAgent { get; set; }
 
+    /// <summary>Viewport width in pixels.</summary>
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int? ViewportWidth { get; set; }
 
+    /// <summary>Viewport height in pixels.</summary>
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int? ViewportHeight { get; set; }
 
+    /// <summary>Scaling factor for high DPI devices.</summary>
     [Parameter]
     public double? DeviceScaleFactor { get; set; }
 
+    /// <summary>Latitude used for geolocation.</summary>
     [Parameter]
     public double? GeoLatitude { get; set; }
 
+    /// <summary>Longitude used for geolocation.</summary>
     [Parameter]
     public double? GeoLongitude { get; set; }
 
+    /// <summary>Timezone identifier.</summary>
     [Parameter]
     public string? Timezone { get; set; }
 
+    /// <summary>Do not store this session as the default.</summary>
     [Parameter]
     public SwitchParameter NoDefault { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlNavigation.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlNavigation.cs
@@ -53,6 +53,7 @@ public sealed class CmdletInvokeHtmlNavigation : AsyncPSCmdlet {
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -95,33 +95,42 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
     [ValidateRange(0, int.MaxValue)]
     public int SlowMo { get; set; } = 0;
 
+    /// <summary>Timeout in milliseconds for browser operations.</summary>
     [Parameter]
     [ValidateRange(0,int.MaxValue)]
     public int Timeout { get; set; } = 10000;
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 
+    /// <summary>User agent string used when launching the browser.</summary>
     [Parameter]
     public string? UserAgent { get; set; }
 
+    /// <summary>Viewport width in pixels.</summary>
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int? ViewportWidth { get; set; }
 
+    /// <summary>Viewport height in pixels.</summary>
     [Parameter]
     [ValidateRange(1,int.MaxValue)]
     public int? ViewportHeight { get; set; }
 
+    /// <summary>Scaling factor for high DPI devices.</summary>
     [Parameter]
     public double? DeviceScaleFactor { get; set; }
 
+    /// <summary>Latitude used for geolocation.</summary>
     [Parameter]
     public double? GeoLatitude { get; set; }
 
+    /// <summary>Longitude used for geolocation.</summary>
     [Parameter]
     public double? GeoLongitude { get; set; }
 
+    /// <summary>Timezone identifier.</summary>
     [Parameter]
     public string? Timezone { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletRegisterHtmlRoute.cs
@@ -23,6 +23,7 @@ public sealed class CmdletRegisterHtmlRoute : AsyncPSCmdlet {
     [Parameter(Mandatory = true, Position = 2)]
     public ScriptBlock? ScriptBlock { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -54,6 +54,7 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
     [Parameter]
     public string? Filter { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlChecked.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlChecked.cs
@@ -31,6 +31,7 @@ public sealed class CmdletSetHtmlChecked : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlCookie.cs
@@ -19,6 +19,7 @@ public sealed class CmdletSetHtmlCookie : AsyncPSCmdlet {
     [AllowEmptyCollection]
     public HtmlCookie[]? Cookie { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlInput.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlInput.cs
@@ -31,6 +31,7 @@ public sealed class CmdletSetHtmlInput : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlSelectOption.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlSelectOption.cs
@@ -31,6 +31,7 @@ public sealed class CmdletSetHtmlSelectOption : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletUnregisterHtmlRoute.cs
@@ -23,6 +23,7 @@ public sealed class CmdletUnregisterHtmlRoute : AsyncPSCmdlet {
     [Parameter(Position = 2)]
     public Delegate? Handler { get; set; }
 
+    /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
 


### PR DESCRIPTION
## Summary
- add XML comments for `CancellationToken` and other parameters across cmdlets
- document timeout and browser configuration options in import/export cmdlets

## Testing
- `dotnet build Sources/PSParseHTML.sln`
- `dotnet test Sources/PSParseHTML.sln`


------
https://chatgpt.com/codex/tasks/task_e_685feb415740832e8745379ed04e9ff6