### PR TITLE
Add missing XML docs

### DIFF
--- a/Sources/PSParseHTML/Models/HtmlListMetadata.cs
+++ b/Sources/PSParseHTML/Models/HtmlListMetadata.cs
@@ -6,11 +6,38 @@ namespace PSParseHTML;
 /// Metadata about a parsed HTML list.
 /// </summary>
 public class HtmlListMetadata {
+    /// <summary>
+    /// Index of the list element within the document.
+    /// </summary>
     public int ListIndex { get; set; }
+
+    /// <summary>
+    /// Value of the id attribute on the list element.
+    /// </summary>
     public string? Id { get; set; }
+
+    /// <summary>
+    /// Indicates whether the list element is visible.
+    /// </summary>
     public bool IsVisible { get; set; } = true;
+
+    /// <summary>
+    /// CSS classes applied to the list element.
+    /// </summary>
     public string? Classes { get; set; }
+
+    /// <summary>
+    /// Additional attributes found on the list element.
+    /// </summary>
     public Dictionary<string, string> Attributes { get; set; } = new();
+
+    /// <summary>
+    /// True if the list is ordered (<c>&lt;ol&gt;</c>).
+    /// </summary>
     public bool IsOrdered { get; set; }
+
+    /// <summary>
+    /// Number of items contained in the list.
+    /// </summary>
     public int ItemCount { get; set; }
 }

--- a/Sources/PSParseHTML/Models/HtmlListResult.cs
+++ b/Sources/PSParseHTML/Models/HtmlListResult.cs
@@ -6,6 +6,13 @@ namespace PSParseHTML;
 /// Result of HTML list parsing with metadata.
 /// </summary>
 public class HtmlListResult {
+    /// <summary>
+    /// Metadata describing the parsed list.
+    /// </summary>
     public HtmlListMetadata Metadata { get; set; } = new();
+
+    /// <summary>
+    /// Collection of list items grouped by list element.
+    /// </summary>
     public List<List<string>> Items { get; set; } = new();
 }

--- a/Sources/PSParseHTML/Models/HtmlTableMetadata.cs
+++ b/Sources/PSParseHTML/Models/HtmlTableMetadata.cs
@@ -12,12 +12,43 @@ namespace PSParseHTML;
 /// Metadata about a parsed table.
 /// </summary>
 public class HtmlTableMetadata {
+    /// <summary>
+    /// Index of the table within the document.
+    /// </summary>
     public int TableIndex { get; set; }
+
+    /// <summary>
+    /// Indicates whether the table is visible.
+    /// </summary>
     public bool IsVisible { get; set; } = true;
+
+    /// <summary>
+    /// Value of the id attribute on the table element.
+    /// </summary>
     public string? Id { get; set; }
+
+    /// <summary>
+    /// CSS classes applied to the table element.
+    /// </summary>
     public string? Classes { get; set; }
+
+    /// <summary>
+    /// Additional attributes found on the table element.
+    /// </summary>
     public Dictionary<string, string> Attributes { get; set; } = new();
+
+    /// <summary>
+    /// Number of rows detected in the table.
+    /// </summary>
     public int RowCount { get; set; }
+
+    /// <summary>
+    /// Number of columns detected in the table.
+    /// </summary>
     public int ColumnCount { get; set; }
+
+    /// <summary>
+    /// Table header names, if any were detected.
+    /// </summary>
     public List<string> Headers { get; set; } = new();
 }

--- a/Sources/PSParseHTML/Models/HtmlTableResult.cs
+++ b/Sources/PSParseHTML/Models/HtmlTableResult.cs
@@ -12,6 +12,13 @@ namespace PSParseHTML;
 /// Result of table parsing with metadata.
 /// </summary>
 public class HtmlTableResult {
+    /// <summary>
+    /// Metadata describing the parsed table.
+    /// </summary>
     public HtmlTableMetadata Metadata { get; set; } = new();
+
+    /// <summary>
+    /// Table rows with values indexed by header name.
+    /// </summary>
     public List<Dictionary<string, string?>> Data { get; set; } = new();
 }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -13,6 +13,9 @@ namespace PSParseHTML;
 /// </summary>
 public class PreMailerClient {
     private readonly string _html;
+    /// <summary>
+    /// Options controlling how CSS is inlined.
+    /// </summary>
     public PreMailerOptions Options { get; }
 
     private PreMailerClient(string html, PreMailerOptions? options) {


### PR DESCRIPTION
## Summary
- add XML docs for list result and metadata models
- document table metadata and result properties
- document PreMailer options property

## Testing
- `dotnet build Sources/PSParseHTML/PSParseHTML.csproj -v:minimal`
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -v:minimal`


------
https://chatgpt.com/codex/tasks/task_e_685ff2039840832e84028e8ca891495a