### PR TITLE
Remove unused runtime checks

### DIFF
--- a/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
+++ b/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
@@ -70,20 +70,4 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
     }
 
-    // Determine if the current runtime is .NET Core
-    private bool IsNetCore() {
-        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Determine if the current runtime is .NET 5 or higher
-    /// </summary>
-    /// <returns></returns>
-    private bool IsNet5OrHigher() {
-        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 7", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 8", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 9", StringComparison.OrdinalIgnoreCase);
-    }
 }


### PR DESCRIPTION
## Summary
- cleanup OnImportAndRemove.cs
- remove unused IsNetCore and IsNet5OrHigher helpers

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6864c93b88cc832e85fc2743297158a9