### PR TITLE
Fix ConfigureAwait on dispose

### DIFF
--- a/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
@@ -69,10 +69,10 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// /// </summary>
     public async ValueTask DisposeAsync() {
         if (Context != null) {
-            await Context.CloseAsync();
+            await Context.CloseAsync().ConfigureAwait(false);
         }
         if (Browser != null) {
-            await Browser.CloseAsync();
+            await Browser.CloseAsync().ConfigureAwait(false);
         }
         if (Playwright != null) {
             Playwright.Dispose();


### PR DESCRIPTION
## Summary
- ensure `DisposeAsync` uses `ConfigureAwait(false)` for async calls

## Testing
- `dotnet test Sources/PSParseHTML.sln`

------
https://chatgpt.com/codex/tasks/task_e_6864c941a908832e88f18d169de99611