### PR TITLE
Fix directory check before creation

### DIFF
--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SavePdf.cs
@@ -125,7 +125,10 @@ public static partial class HtmlBrowser {
         }
 
         string fullPath = HtmlUtilities.ResolvePath(path);
-        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        string? dir = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
         var options = new PagePdfOptions {
             Path = fullPath,
             Landscape = landscape,

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -154,7 +154,10 @@ public static partial class HtmlBrowser {
         }
 
         string fullPath = HtmlUtilities.ResolvePath(path);
-        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        string? dir = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
         var options = new PageScreenshotOptions { FullPage = fullPage };
         options.Type = format == ImageFormat.Jpeg ? ScreenshotType.Jpeg : ScreenshotType.Png;
         if (options.Type == ScreenshotType.Jpeg) {

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
@@ -33,7 +33,10 @@ public static partial class HtmlBrowser {
     public static Task StopTracingAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
         string full = HtmlUtilities.ResolvePath(path);
-        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        string? dir = Path.GetDirectoryName(full);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
         return session.Context.Tracing.StopAsync(new Microsoft.Playwright.TracingStopOptions { Path = full });
     }
 
@@ -47,7 +50,10 @@ public static partial class HtmlBrowser {
     public static Task ExportHarAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
         string full = HtmlUtilities.ResolvePath(path);
-        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        string? dir = Path.GetDirectoryName(full);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
         var log = new {
             log = new {
                 version = "1.2",


### PR DESCRIPTION
## Summary
- ensure `Path.GetDirectoryName()` result is validated before calling `Directory.CreateDirectory`

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6864c94509c4832eabd6d993a5e605a3