### PR TITLE
Add whitespace/comment parsing test

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlParserWhitespaceTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserWhitespaceTests.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using AngleSharp.Dom;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlParserWhitespaceTests {
+    [Fact]
+    public void Parsers_HandleWhitespaceAndComments_Consistently() {
+        const string html = "<div>\n  <p> <!--comment--> Hello </p>\n  <!-- another -->\n</div>";
+
+        var angleDoc = HtmlParser.ParseWithAngleSharp(html);
+        var angleText = angleDoc.QuerySelector("p")!.TextContent.Trim();
+        var angleComments = angleDoc.Descendents<IComment>().Count();
+
+        var agilityDoc = HtmlParser.ParseWithHtmlAgilityPack(html);
+        var agilityText = agilityDoc.DocumentNode.SelectSingleNode("//p")!.InnerText.Trim();
+        var agilityComments = agilityDoc.DocumentNode.SelectNodes("//comment()")?.Count ?? 0;
+
+        Assert.Equal(angleComments, agilityComments);
+        Assert.Equal(angleText, agilityText);
+        Assert.Equal("Hello", angleText);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test for HTML fragments with unusual whitespace and comments

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln -c Release --no-build`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Playwright download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68650169cac8832e8ab5a588754be3c6