### PR TITLE
Use ImageFormat enum in screenshot tests

### DIFF
--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -3,31 +3,31 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'shot.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -Format ([PSParseHTML.ImageFormat]::Png)
         (Test-Path $outfile) | Should -BeTrue
     }
 
     It 'Supports proxy parameters' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
-        $outfile = Join-Path $TestDrive 'proxy.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -Proxy 'http://localhost:8080'
+        $outfile = Join-Path $TestDrive 'proxy.jpeg'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -Proxy 'http://localhost:8080' -Format ([PSParseHTML.ImageFormat]::Jpeg)
         (Test-Path $outfile) | Should -BeTrue
     }
 
     It 'Creates a full page screenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
-        $outfile = Join-Path $TestDrive 'full.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full -Selector '#loaded'
+        $outfile = Join-Path $TestDrive 'full.bmp'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Full -Selector '#loaded' -Format ([PSParseHTML.ImageFormat]::Bmp)
         (Test-Path $outfile) | Should -BeTrue
     }
 
     It 'Creates a clipped screenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
-        $outfile = Join-Path $TestDrive 'clip.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50 -Selector '#loaded'
+        $outfile = Join-Path $TestDrive 'clip.gif'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -X 0 -Y 0 -Width 50 -Height 50 -Selector '#loaded' -Format ([PSParseHTML.ImageFormat]::Gif)
         (Test-Path $outfile) | Should -BeTrue
     }
 
@@ -35,15 +35,15 @@ Describe 'Save-HTMLScreenshot' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $outfile = Join-Path $TestDrive 'element.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -ElementSelector '#loaded'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -ElementSelector '#loaded' -Format ([PSParseHTML.ImageFormat]::Png)
         (Test-Path $outfile) | Should -BeTrue
     }
 
     It 'Highlights elements and overlays text' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
-        $outfile = Join-Path $TestDrive 'highlight.png'
-        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -HighlightSelector '#loaded' -OverlayText 'demo'
+        $outfile = Join-Path $TestDrive 'highlight.jpeg'
+        Save-HTMLScreenshot -Url $uri -OutFile $outfile -Selector '#loaded' -HighlightSelector '#loaded' -OverlayText 'demo' -Format ([PSParseHTML.ImageFormat]::Jpeg)
         (Test-Path $outfile) | Should -BeTrue
     }
 
@@ -52,7 +52,7 @@ Describe 'Save-HTMLScreenshot' {
         $uri = [System.Uri]::new($path).AbsoluteUri
         $before = Get-ChildItem ([System.IO.Path]::GetTempPath()) -Filter '*.png' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
         $beforeTime = if ($before) { $before.LastWriteTime } else { [datetime]::MinValue }
-        Save-HTMLScreenshot -Url $uri -Selector '#loaded' -Open
+        Save-HTMLScreenshot -Url $uri -Selector '#loaded' -Open -Format ([PSParseHTML.ImageFormat]::Png)
         $after = Get-ChildItem ([System.IO.Path]::GetTempPath()) -Filter '*.png' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
         $after.LastWriteTime | Should -BeGreaterThan $beforeTime
     }


### PR DESCRIPTION
## Summary
- update Pester tests to pass ImageFormat enum values

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File PSParseHTML.Tests.ps1` *(fails: Export-BrowserState cmdlet missing, Starts recording from existing session)*

------
https://chatgpt.com/codex/tasks/task_e_686501569744832e90ededc300b6ac11