### PR TITLE
Improve XML docs in PSParseHTML

### DIFF
--- a/Sources/PSParseHTML/Logging/InternalLogger.cs
+++ b/Sources/PSParseHTML/Logging/InternalLogger.cs
@@ -206,6 +206,9 @@ public class InternalLogger {
     }
 }
 
+/// <summary>
+/// Provides information about a logging event raised by <see cref="InternalLogger"/>.
+/// </summary>
 public class LogEventArgs : EventArgs {
     /// <summary>
     /// Progress percentage
@@ -242,19 +245,39 @@ public class LogEventArgs : EventArgs {
     /// </summary>
     public string? Message { get; set; }
 
+    /// <summary>
+    /// Parameters that were supplied with the formatted message.
+    /// </summary>
     public object[] Args { get; set; } = Array.Empty<object>();
 
+    /// <summary>
+    /// Creates a new instance using the provided formatted message.
+    /// </summary>
+    /// <param name="message">Message template.</param>
+    /// <param name="args">Arguments used when formatting the message.</param>
     public LogEventArgs(string message, object[] args) {
         Message = message;
         Args = args;
         FullMessage = string.Format(message, args);
     }
 
+    /// <summary>
+    /// Creates a new instance with a simple message.
+    /// </summary>
+    /// <param name="message">Message text.</param>
     public LogEventArgs(string message) {
         Message = message;
         FullMessage = message;
     }
 
+    /// <summary>
+    /// Creates a new instance representing progress information.
+    /// </summary>
+    /// <param name="activity">Overall activity name.</param>
+    /// <param name="currentOperation">Current operation description.</param>
+    /// <param name="currentSteps">Current progress step number.</param>
+    /// <param name="totalSteps">Total number of steps expected.</param>
+    /// <param name="percentage">Progress percentage value.</param>
     public LogEventArgs(string activity, string currentOperation, int? currentSteps, int? totalSteps, int? percentage) {
         ProgressActivity = activity;
         ProgressCurrentOperation = currentOperation;

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Console.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Console.cs
@@ -2,10 +2,14 @@ using System.Collections.Generic;
 
 namespace PSParseHTML;
 
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
 public static partial class HtmlBrowser {
     /// <summary>
     /// Returns console log captured in the specified session.
     /// </summary>
+    /// <param name="session">Browser session containing console log entries.</param>
     public static IEnumerable<HtmlConsoleEntry> GetConsoleLog(HtmlBrowserSession session)
         => session.ConsoleLog;
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Cookies.cs
@@ -5,10 +5,15 @@ using System.Threading.Tasks;
 
 namespace PSParseHTML;
 
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
 public static partial class HtmlBrowser {
     /// <summary>
     /// Retrieves cookies from the browser context.
     /// </summary>
+    /// <param name="session">Session from which cookies will be read.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static async Task<List<HtmlCookie>> GetCookiesAsync(HtmlBrowserSession session, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
         IReadOnlyList<BrowserContextCookiesResult> cookies = await session.Context.CookiesAsync();
@@ -31,6 +36,9 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Adds cookies to the browser context.
     /// </summary>
+    /// <param name="session">Session to which cookies will be added.</param>
+    /// <param name="cookies">Collection of cookies to add.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static Task SetCookiesAsync(HtmlBrowserSession session, IEnumerable<HtmlCookie> cookies, CancellationToken cancellationToken = default) {
         List<Cookie> list = new();
         foreach (HtmlCookie c in cookies) {

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Network.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Network.cs
@@ -2,10 +2,14 @@ using System.Collections.Generic;
 
 namespace PSParseHTML;
 
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
 public static partial class HtmlBrowser {
     /// <summary>
     /// Returns network log captured in the specified session.
     /// </summary>
+    /// <param name="session">Browser session containing network data.</param>
     public static IEnumerable<HtmlNetworkEntry> GetNetworkLog(HtmlBrowserSession session)
         => session.NetworkLog;
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Routes.cs
@@ -5,30 +5,45 @@ using Microsoft.Playwright;
 
 namespace PSParseHTML;
 
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
 public static partial class HtmlBrowser {
     /// <summary>
     /// Registers a network route handler on the specified page.
     /// </summary>
-public static Task RegisterRouteAsync(IPage page, string pattern, Func<IRoute, Task> handler, CancellationToken cancellationToken = default)
-{
-    cancellationToken.ThrowIfCancellationRequested();
-    return page.RouteAsync(pattern, handler);
-}
+    /// <param name="page">Target page.</param>
+    /// <param name="pattern">Matching pattern for the route.</param>
+    /// <param name="handler">Handler invoked for matching requests.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public static Task RegisterRouteAsync(IPage page, string pattern, Func<IRoute, Task> handler, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return page.RouteAsync(pattern, handler);
+    }
 
     /// <summary>
     /// Registers a network route handler on the session page.
     /// </summary>
-public static Task RegisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task> handler, CancellationToken cancellationToken = default)
-    => RegisterRouteAsync(session.Page, pattern, handler, cancellationToken);
+    /// <param name="session">Browser session to register on.</param>
+    /// <param name="pattern">Matching pattern for the route.</param>
+    /// <param name="handler">Handler invoked for matching requests.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public static Task RegisterRouteAsync(HtmlBrowserSession session, string pattern, Func<IRoute, Task> handler, CancellationToken cancellationToken = default)
+        => RegisterRouteAsync(session.Page, pattern, handler, cancellationToken);
 
     /// <summary>
     /// Removes a previously registered route handler from the page.
     /// </summary>
-public static Task UnregisterRouteAsync(IPage page, string pattern, Func<IRoute, Task>? handler = null, CancellationToken cancellationToken = default)
-{
-    cancellationToken.ThrowIfCancellationRequested();
-    return handler is null ? page.UnrouteAsync(pattern) : page.UnrouteAsync(pattern, handler);
-}
+    /// <param name="page">Target page.</param>
+    /// <param name="pattern">Pattern used when registering the route.</param>
+    /// <param name="handler">Optional handler instance.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public static Task UnregisterRouteAsync(IPage page, string pattern, Func<IRoute, Task>? handler = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return handler is null ? page.UnrouteAsync(pattern) : page.UnrouteAsync(pattern, handler);
+    }
 
     /// <summary>
     /// Removes a previously registered route handler from the session page.

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Tracing.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace PSParseHTML;
 
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
 public static partial class HtmlBrowser {
     /// <summary>
     /// Starts Playwright tracing for the given session.

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -5,10 +5,32 @@ using Microsoft.Playwright;
 
 namespace PSParseHTML;
 
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
 public static partial class HtmlBrowser {
     /// <summary>
     /// Starts a new browser session with video recording enabled.
     /// </summary>
+    /// <param name="url">URL to navigate to.</param>
+    /// <param name="videoPath">Output path for the recorded video.</param>
+    /// <param name="browser">Browser engine to use.</param>
+    /// <param name="clean">Reinstall the browser runtime.</param>
+    /// <param name="username">Optional basic authentication user name.</param>
+    /// <param name="password">Optional basic authentication password.</param>
+    /// <param name="formLogin">Login form information when authentication is required.</param>
+    /// <param name="headless">Run the browser in headless mode.</param>
+    /// <param name="slowMo">Delay between Playwright actions in milliseconds.</param>
+    /// <param name="width">Video width.</param>
+    /// <param name="height">Video height.</param>
+    /// <param name="userAgent">Custom user agent string.</param>
+    /// <param name="viewportWidth">Width of the browser viewport.</param>
+    /// <param name="viewportHeight">Height of the browser viewport.</param>
+    /// <param name="deviceScaleFactor">Device scale factor.</param>
+    /// <param name="geoLatitude">Latitude used for geolocation.</param>
+    /// <param name="geoLongitude">Longitude used for geolocation.</param>
+    /// <param name="timezone">Time zone identifier.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static Task<HtmlBrowserSession> StartVideoRecordingAsync(
         string url,
         string videoPath,
@@ -34,6 +56,20 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Starts a video recording session based on an existing <see cref="HtmlBrowserSession"/>.
     /// </summary>
+    /// <param name="session">Existing browser session.</param>
+    /// <param name="videoPath">Output path for the recorded video.</param>
+    /// <param name="headless">Run the new session in headless mode.</param>
+    /// <param name="slowMo">Delay between Playwright actions in milliseconds.</param>
+    /// <param name="width">Video width.</param>
+    /// <param name="height">Video height.</param>
+    /// <param name="userAgent">Custom user agent string.</param>
+    /// <param name="viewportWidth">Width of the browser viewport.</param>
+    /// <param name="viewportHeight">Height of the browser viewport.</param>
+    /// <param name="deviceScaleFactor">Device scale factor.</param>
+    /// <param name="geoLatitude">Latitude used for geolocation.</param>
+    /// <param name="geoLongitude">Longitude used for geolocation.</param>
+    /// <param name="timezone">Time zone identifier.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static async Task<HtmlBrowserSession> StartVideoRecordingAsync(
         HtmlBrowserSession session,
         string videoPath,
@@ -90,6 +126,9 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Stops the specified video recording session and saves the file.
     /// </summary>
+    /// <param name="session">Session that was recording video.</param>
+    /// <param name="path">Optional path where the video should be saved.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static async Task StopVideoRecordingAsync(HtmlBrowserSession session, string? path = null, CancellationToken cancellationToken = default) {
         string outFile = path ?? session.VideoPath ?? throw new System.ArgumentException("Output path required.");
         IVideo? video = session.Video;

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -26,6 +26,8 @@ public class PreMailerClient {
     /// <summary>
     /// Creates a client from a HTML file path.
     /// </summary>
+    /// <param name="htmlFilePath">Path to the HTML file.</param>
+    /// <param name="options">Optional processing options.</param>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     public static PreMailerClient FromFile(string htmlFilePath, PreMailerOptions? options = null) {
         string path = HtmlUtilities.ResolvePath(htmlFilePath);
@@ -39,6 +41,8 @@ public class PreMailerClient {
     /// <summary>
     /// Creates a client from a HTML string.
     /// </summary>
+    /// <param name="html">HTML markup to process.</param>
+    /// <param name="options">Optional processing options.</param>
     public static PreMailerClient FromHtml(string html, PreMailerOptions? options = null) {
         return new PreMailerClient(html, options);
     }
@@ -235,6 +239,8 @@ public class PreMailerClient {
     /// <summary>
     /// Convenience method for processing a HTML string directly using options.
     /// </summary>
+    /// <param name="html">HTML markup to process.</param>
+    /// <param name="options">Optional processing options.</param>
     public static Task<PreMailerResult> MoveCssInline(string html, PreMailerOptions? options = null) {
         return FromHtml(html, options).MoveCssInline();
     }
@@ -242,6 +248,8 @@ public class PreMailerClient {
     /// <summary>
     /// Convenience method for processing a HTML file directly using options.
     /// </summary>
+    /// <param name="htmlFilePath">Path to the HTML file.</param>
+    /// <param name="options">Optional processing options.</param>
     public static Task<PreMailerResult> MoveCssInlineFromFile(string htmlFilePath, PreMailerOptions? options = null) {
         return FromFile(htmlFilePath, options).MoveCssInline();
     }
@@ -249,12 +257,16 @@ public class PreMailerClient {
     /// <summary>
     /// Asynchronously processes a HTML string using the provided options.
     /// </summary>
+    /// <param name="html">HTML markup to process.</param>
+    /// <param name="options">Optional processing options.</param>
     public static Task<PreMailerResult> MoveCssInlineAsync(string html, PreMailerOptions? options = null)
         => FromHtml(html, options).MoveCssInlineAsync();
 
     /// <summary>
     /// Asynchronously processes a HTML file using the provided options.
     /// </summary>
+    /// <param name="htmlFilePath">Path to the HTML file.</param>
+    /// <param name="options">Optional processing options.</param>
     public static async Task<PreMailerResult> MoveCssInlineFromFileAsync(string htmlFilePath, PreMailerOptions? options = null) {
         string html = await HtmlUtilities.ReadFileCheckedAsync(htmlFilePath).ConfigureAwait(false);
         return await MoveCssInlineAsync(html, options).ConfigureAwait(false);
@@ -263,6 +275,24 @@ public class PreMailerClient {
     /// <summary>
     /// Parameter-based helper constructing an options object internally.
     /// </summary>
+    /// <param name="html">HTML markup to process.</param>
+    /// <param name="baseUri">Base URI used for resolving relative links.</param>
+    /// <param name="removeStyleElements">Remove &lt;style&gt; elements after inlining.</param>
+    /// <param name="ignoreElements">CSS selector of elements to ignore.</param>
+    /// <param name="css">CSS content to inline.</param>
+    /// <param name="cssFilePath">Path to a CSS file to inline.</param>
+    /// <param name="stripIdAndClassAttributes">Strip id and class attributes from the output.</param>
+    /// <param name="removeComments">Remove HTML and CSS comments.</param>
+    /// <param name="customFormatter">Custom formatter used when generating HTML.</param>
+    /// <param name="preserveMediaQueries">Preserve media queries from style nodes.</param>
+    /// <param name="useEmailFormatter">Use the built in email formatter.</param>
+    /// <param name="downloadRemoteCss">Download remote CSS referenced by link tags.</param>
+    /// <param name="addAnalyticsTags">Add Google Analytics tags.</param>
+    /// <param name="analyticsSource">UTM source parameter.</param>
+    /// <param name="analyticsMedium">UTM medium parameter.</param>
+    /// <param name="analyticsCampaign">UTM campaign parameter.</param>
+    /// <param name="analyticsContent">UTM content parameter.</param>
+    /// <param name="analyticsDomain">Domain used when constructing analytics links.</param>
     public static Task<PreMailerResult> MoveCssInline(
         string html,
         Uri? baseUri = null,
@@ -309,6 +339,24 @@ public class PreMailerClient {
     /// <summary>
     /// Parameter-based helper for processing a HTML file directly.
     /// </summary>
+    /// <param name="htmlFilePath">Path to the HTML file.</param>
+    /// <param name="baseUri">Base URI used for resolving relative links.</param>
+    /// <param name="removeStyleElements">Remove &lt;style&gt; elements after inlining.</param>
+    /// <param name="ignoreElements">CSS selector of elements to ignore.</param>
+    /// <param name="css">CSS content to inline.</param>
+    /// <param name="cssFilePath">Path to a CSS file to inline.</param>
+    /// <param name="stripIdAndClassAttributes">Strip id and class attributes from the output.</param>
+    /// <param name="removeComments">Remove HTML and CSS comments.</param>
+    /// <param name="customFormatter">Custom formatter used when generating HTML.</param>
+    /// <param name="preserveMediaQueries">Preserve media queries from style nodes.</param>
+    /// <param name="useEmailFormatter">Use the built in email formatter.</param>
+    /// <param name="downloadRemoteCss">Download remote CSS referenced by link tags.</param>
+    /// <param name="addAnalyticsTags">Add Google Analytics tags.</param>
+    /// <param name="analyticsSource">UTM source parameter.</param>
+    /// <param name="analyticsMedium">UTM medium parameter.</param>
+    /// <param name="analyticsCampaign">UTM campaign parameter.</param>
+    /// <param name="analyticsContent">UTM content parameter.</param>
+    /// <param name="analyticsDomain">Domain used when constructing analytics links.</param>
     public static Task<PreMailerResult> MoveCssInlineFromFile(
         string htmlFilePath,
         Uri? baseUri = null,


### PR DESCRIPTION
## Summary
- document `LogEventArgs` class and constructors
- add class summaries and parameter docs across HtmlBrowser partial classes
- document PreMailer helpers

## Testing
- `dotnet build Sources/PSParseHTML/PSParseHTML.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6865012aba3c832ea5a86843854da5b3