### PR TITLE
Check clientFactory for null

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlParserTableClientFactoryTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserTableClientFactoryTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlParserTableClientFactoryTests {
+    [Fact]
+    public async Task ParseUrlTablesWithAngleSharpAsync_NullUrl_Throws() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => HtmlParser.ParseUrlTablesWithAngleSharpAsync(null!, null, null, false, null, () => new HttpClient()));
+    }
+
+    [Fact]
+    public async Task ParseUrlTablesWithAngleSharpAsync_NullClientFactory_Throws() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => HtmlParser.ParseUrlTablesWithAngleSharpAsync("http://example.com", null, null, false, null, null!));
+    }
+
+    [Fact]
+    public async Task ParseUrlTablesWithHtmlAgilityPackAsync_NullUrl_Throws() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => HtmlParser.ParseUrlTablesWithHtmlAgilityPackAsync(null!, false, null, null, false, null, () => new HttpClient()));
+    }
+
+    [Fact]
+    public async Task ParseUrlTablesWithHtmlAgilityPackAsync_NullClientFactory_Throws() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => HtmlParser.ParseUrlTablesWithHtmlAgilityPackAsync("http://example.com", false, null, null, false, null, null!));
+    }
+}

--- a/Sources/PSParseHTML/HtmlParserFromTable.cs
+++ b/Sources/PSParseHTML/HtmlParserFromTable.cs
@@ -333,16 +333,12 @@ public static class HtmlParserFromTable {
             throw new ArgumentNullException(nameof(url));
         }
 
-        bool disposeClient = false;
-        HttpClient http;
-        if (client != null) {
-            http = client;
-        } else if (clientFactory != null) {
-            http = clientFactory();
-            disposeClient = true;
-        } else {
-            http = HtmlHttpClientFactory.Shared;
+        if (clientFactory == null) {
+            throw new ArgumentNullException(nameof(clientFactory));
         }
+
+        bool disposeClient = client == null;
+        HttpClient http = client ?? clientFactory();
 
         try {
             string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
@@ -762,16 +758,12 @@ public static class HtmlParserFromTable {
             throw new ArgumentNullException(nameof(url));
         }
 
-        bool disposeClient = false;
-        HttpClient http;
-        if (client != null) {
-            http = client;
-        } else if (clientFactory != null) {
-            http = clientFactory();
-            disposeClient = true;
-        } else {
-            http = HtmlHttpClientFactory.Shared;
+        if (clientFactory == null) {
+            throw new ArgumentNullException(nameof(clientFactory));
         }
+
+        bool disposeClient = client == null;
+        HttpClient http = client ?? clientFactory();
 
         try {
             string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure `clientFactory` isn't null for table parsing methods
- add tests for null `url` and `clientFactory`

## Testing
- `dotnet test "Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj" --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68650111080c832e87a5a50e178222aa