### PR TITLE
Add unique header detection

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlParserHeaderCollisionTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserHeaderCollisionTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlParserHeaderCollisionTests {
+    private const string DuplicateHeaders = "<table><tr><th>A*</th><th>A#</th><th>A!</th><th>B</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr></table>";
+
+    [Fact]
+    public void ParseTablesWithAngleSharpDetailed_UniqueHeaders() {
+        var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(DuplicateHeaders, null, null, true, false, true, null);
+        var result = tables[0];
+        Assert.Equal(new[] { "A", "A1", "A2", "B" }, result.Metadata.Headers);
+        var row = result.Data[0];
+        Assert.Equal("1", row["A"]);
+        Assert.Equal("2", row["A1"]);
+        Assert.Equal("3", row["A2"]);
+        Assert.Equal("4", row["B"]);
+    }
+
+    [Fact]
+    public void ParseTablesWithHtmlAgilityPackDetailed_UniqueHeaders() {
+        var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(DuplicateHeaders, false, null, null, true, false, true, null);
+        var result = tables[0];
+        Assert.Equal(new[] { "A", "A1", "A2", "B" }, result.Metadata.Headers);
+        var row = result.Data[0];
+        Assert.Equal("1", row["A"]);
+        Assert.Equal("2", row["A1"]);
+        Assert.Equal("3", row["A2"]);
+        Assert.Equal("4", row["B"]);
+    }
+}

--- a/Sources/PSParseHTML/HtmlParser.cs
+++ b/Sources/PSParseHTML/HtmlParser.cs
@@ -1,11 +1,11 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using HtmlAgilityPack;
 using System;
-using System.Net.Http;
-using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using AngleSharp.Html.Parser;
-using AngleSharp.Dom;
-using HtmlAgilityPack;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace PSParseHTML;
 
@@ -331,5 +331,34 @@ public static class HtmlParser {
             .Replace("+", "")           // Remove plus
             .Replace("-", "")           // Remove hyphens
             .Trim();                    // Remove leading/trailing whitespace
+    }
+
+    /// <summary>
+    /// Ensure all names are unique by appending an index when duplicates are detected.
+    /// </summary>
+    /// <param name="names">Collection of names to sanitize.</param>
+    public static void EnsureUniqueNames(IList<string> names) {
+        if (names == null) {
+            throw new ArgumentNullException(nameof(names));
+        }
+
+        Dictionary<string, int> counters = new(StringComparer.OrdinalIgnoreCase);
+
+        for (int i = 0; i < names.Count; i++) {
+            string name = names[i];
+            if (string.IsNullOrEmpty(name)) {
+                continue;
+            }
+
+            if (counters.TryGetValue(name, out int count)) {
+                count++;
+                counters[name] = count;
+                string unique = name + count;
+                LoggingMessages.Logger.WriteWarning($"Duplicate header '{name}' detected. Renaming to '{unique}'.");
+                names[i] = unique;
+            } else {
+                counters[name] = 0;
+            }
+        }
     }
 }

--- a/Sources/PSParseHTML/HtmlParserFromTable.cs
+++ b/Sources/PSParseHTML/HtmlParserFromTable.cs
@@ -1,10 +1,10 @@
+using AngleSharp.Dom;
+using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using AngleSharp.Dom;
-using HtmlAgilityPack;
 
 namespace PSParseHTML;
 
@@ -102,10 +102,11 @@ public static class HtmlParserFromTable {
                 }
             } else {
                 for (int i = 0; i < headerCells.Length; i++) {
-                    headers.Add($"Column{ i + 1 }");
+                    headers.Add($"Column{i + 1}");
                 }
             }
 
+            HtmlParser.EnsureUniqueNames(headers);
             metadata.Headers = headers;
             metadata.ColumnCount = headers.Count;
 
@@ -242,7 +243,7 @@ public static class HtmlParserFromTable {
                 }
             } else {
                 for (int i = 0; i < headerCells.Length; i++) {
-                    headers.Add($"Column{ i + 1 }");
+                    headers.Add($"Column{i + 1}");
                 }
             }
 
@@ -489,9 +490,10 @@ public static class HtmlParserFromTable {
                 }
             } else {
                 for (int i = 0; i < headerCells.Count; i++) {
-                    headers.Add($"Column{ i + 1 }");
+                    headers.Add($"Column{i + 1}");
                 }
             }
+            HtmlParser.EnsureUniqueNames(headers);
 
             metadata.Headers = headers;
             metadata.ColumnCount = headers.Count;
@@ -667,7 +669,7 @@ public static class HtmlParserFromTable {
                 }
             } else {
                 for (int i = 0; i < headerCells.Count; i++) {
-                    headers.Add($"Column{ i + 1 }");
+                    headers.Add($"Column{i + 1}");
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure unique header names with warnings
- unify header names when parsing tables
- add tests for header collisions

## Testing
- `dotnet format Sources/PSParseHTML.sln --include "Sources/PSParseHTML/HtmlParser.cs" "Sources/PSParseHTML/HtmlParserFromTable.cs" "Sources/PSParseHTML.Tests/HtmlParserHeaderCollisionTests.cs" --severity warn`
- `dotnet test Sources/PSParseHTML.sln -c Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686500eaaff8832e965d2521c077662d