### PR TITLE
Add offline screenshot example

### DIFF
--- a/Examples/Example-Screenshot1.ps1
+++ b/Examples/Example-Screenshot1.ps1
@@ -1,9 +1,16 @@
-﻿Import-Module .\PSParseHTML.psd1 -Force
+Import-Module .\PSParseHTML.psd1 -Force
 
-Save-HTMLScreenshot -Url 'https://www.goal.com/en-us/premier-league/table/2kwbbcootiqqgmrzs6o5inle5' -OutFile "$PSScriptRoot\Output\PremierLeague.png" -Full -Open
-Save-HTMLScreenshot -Url 'https://evotec.xyz' -OutFile "$PSScriptRoot\Output\EvotecPage.png" -Open -Browser Chromium
-Save-HTMLScreenshot -Url 'https://evotec.xyz' -OutFile "$PSScriptRoot\Output\EvotecPageFull.png" -Full -Open -Browser Chromium
-Save-HTMLScreenshot -Url 'https://evotec.xyz/hub' -OutFile "$PSScriptRoot\Output\EvotecPageHub.png" -Full -Open -Browser Chromium
-Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser Firefox
-Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser Webkit
-Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Open -Browser Chromium -X 100 -Y 100 -Width 500 -Height 500
+$internetAvailable = Test-Connection -ComputerName 'www.google.com' -Count 1 -Quiet
+
+if ($internetAvailable) {
+    Save-HTMLScreenshot -Url 'https://www.goal.com/en-us/premier-league/table/2kwbbcootiqqgmrzs6o5inle5' -OutFile "$PSScriptRoot\Output\PremierLeague.png" -Full -Open
+    Save-HTMLScreenshot -Url 'https://evotec.xyz' -OutFile "$PSScriptRoot\Output\EvotecPage.png" -Open -Browser Chromium
+    Save-HTMLScreenshot -Url 'https://evotec.xyz' -OutFile "$PSScriptRoot\Output\EvotecPageFull.png" -Full -Open -Browser Chromium
+    Save-HTMLScreenshot -Url 'https://evotec.xyz/hub' -OutFile "$PSScriptRoot\Output\EvotecPageHub.png" -Full -Open -Browser Chromium
+    Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser Firefox
+    Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser Webkit
+    Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Open -Browser Chromium -X 100 -Y 100 -Width 500 -Height 500
+} else {
+    $localPath = Join-Path $PSScriptRoot 'Input\Screenshot1.html'
+    Save-HTMLScreenshot -Path $localPath -OutFile "$PSScriptRoot\Output\LocalScreenshot.png" -Full -Open
+}

--- a/Examples/Input/Screenshot1.html
+++ b/Examples/Input/Screenshot1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Local Screenshot Example</title>
+</head>
+<body>
+    <h1>Local Screenshot Example</h1>
+    <p>This page is used when no internet connection is available.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Screenshot1.html` sample HTML
- update screenshot example to use local file offline

## Testing
- `Invoke-Pester` *(fails: 'Invoke-HTMLRendering' not found)*
- `dotnet test Sources/PSParseHTML.sln --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_686500d98fd0832e8a3013cf917e4c09