### PR TITLE
Add HAR example

### DIFF
--- a/Examples/Example-ShowHTMLHar.ps1
+++ b/Examples/Example-ShowHTMLHar.ps1
@@ -1,5 +1,6 @@
-Import-Module ./PSParseHTML.psd1 -Force
+$null = Import-Module ./PSParseHTML.psd1 -Force
 
-$har = Join-Path $PSScriptRoot 'example.har'
+# Example HAR file is stored inside the Input folder
+$har = Join-Path $PSScriptRoot 'Input/sample.har'
 $viewer = Show-HTMLHar -Path $har -OutFile (Join-Path $PSScriptRoot 'example.html')
 $viewer.Log.entries | Format-Table

--- a/Examples/Input/sample.har
+++ b/Examples/Input/sample.har
@@ -1,0 +1,14 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": { "name": "PSParseHTML", "version": "test" },
+    "entries": [
+      {
+        "startedDateTime": "2024-01-01T00:00:00.000Z",
+        "request": { "method": "GET", "url": "https://example.com" },
+        "response": { "status": 200 },
+        "timings": { "wait": 0 }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a HAR file under `Examples/Input`
- update `Example-ShowHTMLHar.ps1` to point to the new HAR location

## Testing
- `dotnet test Sources/PSParseHTML.sln --no-build --verbosity minimal`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: `Export-BrowserState` not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_686500c2c334832e84f9888894d702aa