### PR TITLE
Add HtmlBrowser cookies tests

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserCookiesTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserCookiesTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlBrowserCookiesTests
+{
+    [Fact]
+    public async Task GetCookiesAsync_ReturnsMappedCookies()
+    {
+        var context = new Mock<IBrowserContext>();
+        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        typeof(HtmlBrowserSession)
+            .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(session, context.Object);
+
+        var cookies = new List<BrowserContextCookiesResult>
+        {
+            new BrowserContextCookiesResult
+            {
+                Name = "name",
+                Value = "value",
+                Domain = "domain",
+                Path = "/path",
+                Expires = 123f,
+                HttpOnly = true,
+                Secure = false,
+                SameSite = SameSiteAttribute.Lax
+            }
+        };
+        context.Setup(c => c.CookiesAsync()).ReturnsAsync(cookies);
+
+        List<HtmlCookie> result = await HtmlBrowser.GetCookiesAsync(session);
+
+        Assert.Single(result);
+        HtmlCookie c = result[0];
+        Assert.Equal("name", c.Name);
+        Assert.Equal("value", c.Value);
+        Assert.Equal("domain", c.Domain);
+        Assert.Equal("/path", c.Path);
+        Assert.Equal(123f, c.Expires);
+        Assert.True(c.HttpOnly);
+        Assert.False(c.Secure);
+        Assert.Equal(SameSiteAttribute.Lax, c.SameSite);
+    }
+
+    [Fact]
+    public async Task SetCookiesAsync_ForwardsCookiesToAddCookiesAsync()
+    {
+        var context = new Mock<IBrowserContext>();
+        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        typeof(HtmlBrowserSession)
+            .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(session, context.Object);
+
+        List<HtmlCookie> cookies = new()
+        {
+            new HtmlCookie
+            {
+                Name = "name",
+                Value = "value",
+                Url = "https://example.com",
+                Domain = "domain",
+                Path = "/path",
+                Expires = 456f,
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteAttribute.Strict
+            }
+        };
+
+        context.Setup(c => c.AddCookiesAsync(It.Is<IEnumerable<Cookie>>(l =>
+            l.Count() == 1 &&
+            l.First().Name == "name" &&
+            l.First().Value == "value" &&
+            l.First().Url == "https://example.com" &&
+            l.First().Domain == "domain" &&
+            l.First().Path == "/path" &&
+            l.First().Expires == 456f &&
+            l.First().HttpOnly == true &&
+            l.First().Secure == true &&
+            l.First().SameSite == SameSiteAttribute.Strict
+        ))).Returns(Task.CompletedTask).Verifiable();
+
+        await HtmlBrowser.SetCookiesAsync(session, cookies);
+
+        context.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for HtmlBrowser cookie helpers

## Testing
- `dotnet build Sources/PSParseHTML.sln --configuration Debug`
- `dotnet test Sources/PSParseHTML.sln --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68660afb59e4832eb60afec88bde2b4f