### PR TITLE
Add tests for PreMailer file-based helpers

### DIFF
--- a/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class PreMailerClientFileHelpersTests
+{
+    private const string HtmlContent = "<html><head><style>p{color:red}</style></head><body><p>Hello</p></body></html>";
+
+    [Fact]
+    public async Task MoveCssInlineFromFile_RemovesStyleElements()
+    {
+        var options = new PreMailerOptions { RemoveStyleElements = true };
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
+        File.WriteAllText(path, HtmlContent);
+        try
+        {
+            PreMailerResult result = await PreMailerClient.MoveCssInlineFromFile(path, options);
+            Assert.DoesNotContain("<style", result.Html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task MoveCssInlineFromFileAsync_BehavesSameAsSync()
+    {
+        var options = new PreMailerOptions { RemoveStyleElements = true };
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
+        File.WriteAllText(path, HtmlContent);
+        try
+        {
+            PreMailerResult syncResult = await PreMailerClient.MoveCssInlineFromFile(path, options);
+            PreMailerResult asyncResult = await PreMailerClient.MoveCssInlineFromFileAsync(path, options);
+            Assert.Equal(syncResult.Html, asyncResult.Html);
+            Assert.DoesNotContain("<style", asyncResult.Html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover `PreMailerClient.MoveCssInlineFromFile` with a new test
- verify async file helper behaves same as sync

## Testing
- `dotnet test PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68660ae14fc0832e9729efab6223fd37