### PR TITLE
Add GetElements test coverage

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlParserExtensionsFileTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserExtensionsFileTests.cs
@@ -23,4 +23,19 @@ public class HtmlParserExtensionsFileTests {
         var elements = HtmlParserExtensions.GetElementsFromFile(path, tag: "form").ToArray();
         Assert.Equal(2, elements.Length);
     }
+
+    [Fact]
+    public void GetElementsFromFile_TempHtml_ReturnsExpectedCounts() {
+        const string html = "<div id='main' class='wrapper'><span class='item'>A</span><span class='item'>B</span><p id='para' name='para'>C</p></div>";
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".html");
+        File.WriteAllText(path, html);
+        try {
+            Assert.Equal(2, HtmlParserExtensions.GetElementsFromFile(path, tag: "span").Count());
+            Assert.Equal(2, HtmlParserExtensions.GetElementsFromFile(path, className: "item").Count());
+            Assert.Single(HtmlParserExtensions.GetElementsFromFile(path, id: "para"));
+            Assert.Single(HtmlParserExtensions.GetElementsFromFile(path, name: "para"));
+        } finally {
+            File.Delete(path);
+        }
+    }
 }

--- a/Sources/PSParseHTML.Tests/HtmlParserExtensionsTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserExtensionsTests.cs
@@ -34,4 +34,28 @@ public class HtmlParserExtensionsTests {
         var elements = HtmlParserExtensions.GetElements(html, tag: "em");
         Assert.NotEmpty(elements);
     }
+
+    [Fact]
+    public void GetElements_ById_ReturnsMatchingElement() {
+        const string html = "<div><span id='special'>A</span><span>B</span></div>";
+        var elements = HtmlParserExtensions.GetElements(html, id: "special").ToArray();
+        Assert.Single(elements);
+        Assert.Equal("A", elements[0].TextContent);
+    }
+
+    [Fact]
+    public void GetElements_ByName_ReturnsMatchingElement() {
+        const string html = "<form><input name='field1'/><input name='field2'/></form>";
+        var elements = HtmlParserExtensions.GetElements(html, name: "field1").ToArray();
+        Assert.Single(elements);
+    }
+
+    [Fact]
+    public void GetElements_ByClassTagIdName_CombinedCounts() {
+        const string html = "<div id='box' class='wrapper'><span class='wrapper' name='x'>T</span></div>";
+        Assert.Single(HtmlParserExtensions.GetElements(html, tag: "span"));
+        Assert.Equal(2, HtmlParserExtensions.GetElements(html, className: "wrapper").Count());
+        Assert.Single(HtmlParserExtensions.GetElements(html, id: "box"));
+        Assert.Single(HtmlParserExtensions.GetElements(html, name: "x"));
+    }
 }


### PR DESCRIPTION
## Summary
- extend HtmlParserExtensions test suite for id, name, and mixed queries
- verify element retrieval from a temporary HTML file

## Testing
- `dotnet test Sources/PSParseHTML.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68660aed23c4832e96817b9d3228de58