### PR TITLE
Add disposal verification for HtmlBrowserSession

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -1,7 +1,9 @@
 using System.Runtime.Serialization;
-using PSParseHTML;
 using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
 using Xunit;
+using PSParseHTML;
 
 namespace PSParseHTML.Tests;
 
@@ -10,5 +12,24 @@ public class HtmlBrowserSessionDisposeTests {
     public async Task DisposeAsync_AllowsNullProperties() {
         var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
         await session.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesAllPlaywrightObjects() {
+        var playwright = new Mock<IPlaywright>();
+        playwright.Setup(p => p.Dispose()).Verifiable();
+        var browser = new Mock<IBrowser>();
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var context = new Mock<IBrowserContext>();
+        context.Setup(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var page = new Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        await session.DisposeAsync();
+
+        playwright.Verify();
+        browser.Verify();
+        context.Verify();
     }
 }


### PR DESCRIPTION
## Summary
- extend HtmlBrowserSessionDisposeTests to ensure Playwright objects are disposed

## Testing
- `dotnet test Sources/PSParseHTML.sln -c Debug --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68660ad89a58832ebf6b3752837a1e77