### PR TITLE
Add server-based tests for HTML parser URLs

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlParserUrlDocumentTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserUrlDocumentTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlParserUrlDocumentTests {
+    private static TestServer CreateServer() {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.Run(async ctx => {
+                const string html = "<!DOCTYPE html><html><head><title>Server Page</title></head><body><p>Hello world</p></body></html>";
+                await ctx.Response.WriteAsync(html);
+            }));
+        return new TestServer(builder);
+    }
+
+    [Fact]
+    public async Task ParseUrlWithAngleSharpAsync_ReturnsExpectedElements() {
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+
+        var doc = await HtmlParser.ParseUrlWithAngleSharpAsync(server.BaseAddress.ToString(), client);
+
+        Assert.Equal("Server Page", doc.Title);
+        Assert.Equal("Hello world", doc.QuerySelector("p")?.TextContent);
+    }
+
+    [Fact]
+    public async Task ParseUrlWithHtmlAgilityPackAsync_ReturnsExpectedElements() {
+        using var server = CreateServer();
+        using var client = server.CreateClient();
+
+        var doc = await HtmlParser.ParseUrlWithHtmlAgilityPackAsync(server.BaseAddress.ToString(), client);
+        var paragraph = doc.DocumentNode.SelectSingleNode("//p");
+        var title = doc.DocumentNode.SelectSingleNode("//title");
+
+        Assert.Equal("Server Page", title?.InnerText);
+        Assert.Equal("Hello world", paragraph?.InnerText);
+    }
+}


### PR DESCRIPTION
## Summary
- add new tests verifying that URL parsing methods retrieve expected HTML elements using a TestServer

## Testing
- `dotnet test PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal` *(fails: Unable to resolve NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_68660e510dc8832e8ce50792e8ab695e