### PR TITLE
Add HAR parsing tests

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlHarViewerTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlHarViewerTests.cs
@@ -10,10 +10,34 @@ public class HtmlHarViewerTests {
         return Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "Tests", "Documents", "sample.har"));
     }
 
+    private static string GetMinimalHarPath() {
+        var baseDir = AppContext.BaseDirectory;
+        return Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "Tests", "Documents", "minimal.har"));
+    }
+
     [Fact]
     public async Task BuildViewerHtml_ReturnsHtml() {
         Har har = await HtmlHarViewer.ReadHarAsync(GetHarPath());
         string html = HtmlHarViewer.BuildViewerHtml(har);
         Assert.Contains("<table>", html);
+    }
+
+    [Fact]
+    public async Task ReadHarAsync_PopulatesEntries() {
+        Har har = await HtmlHarViewer.ReadHarAsync(GetMinimalHarPath());
+        Assert.NotNull(har.Log);
+        Assert.NotNull(har.Log!.Entries);
+        Assert.NotEmpty(har.Log.Entries);
+    }
+
+    [Fact]
+    public async Task ReadHarAsync_InvalidJsonThrows() {
+        string path = Path.GetTempFileName();
+        try {
+            await File.WriteAllTextAsync(path, "{ invalid ");
+            await Assert.ThrowsAsync<InvalidDataException>(() => HtmlHarViewer.ReadHarAsync(path));
+        } finally {
+            File.Delete(path);
+        }
     }
 }

--- a/Sources/PSParseHTML/HtmlHarViewer.cs
+++ b/Sources/PSParseHTML/HtmlHarViewer.cs
@@ -81,8 +81,12 @@ public static class HtmlHarViewer
     {
         string json = await HtmlUtilities.ReadFileCheckedAsync(path).ConfigureAwait(false);
         var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        Har? har = JsonSerializer.Deserialize<Har>(json, opts);
-        return har ?? throw new InvalidDataException("Invalid HAR content");
+        try {
+            Har? har = JsonSerializer.Deserialize<Har>(json, opts);
+            return har ?? throw new InvalidDataException("Invalid HAR content");
+        } catch (JsonException e) {
+            throw new InvalidDataException("Invalid HAR content", e);
+        }
     }
 
     /// <summary>

--- a/Tests/Documents/minimal.har
+++ b/Tests/Documents/minimal.har
@@ -1,0 +1,13 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": { "name": "Test", "version": "1.0" },
+    "entries": [
+      {
+        "startedDateTime": "2024-01-02T03:04:05.000Z",
+        "request": { "method": "GET", "url": "https://example.com" },
+        "response": { "status": 200 }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `minimal.har` document
- extend HtmlHarViewer to throw `InvalidDataException` when JSON is malformed
- add tests that load HAR and validate entries
- test malformed data path

## Testing
- `dotnet test Sources/PSParseHTML.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68660e4c1738832ea25dda3a1c1012eb