### PR TITLE
Add HtmlBrowser route registration tests

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserRoutesTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserRoutesTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlBrowserRoutesTests {
+    [Fact]
+    public async Task RegisterRouteAsync_PageInvokesRouteAsync() {
+        var page = new Mock<IPage>();
+        Func<IRoute, Task> handler = _ => Task.CompletedTask;
+        const string pattern = "**/data.json";
+        page.Setup(p => p.RouteAsync(pattern, handler, null)).Returns(Task.CompletedTask).Verifiable();
+
+        await HtmlBrowser.RegisterRouteAsync(page.Object, pattern, handler);
+
+        page.Verify();
+    }
+
+    [Fact]
+    public async Task RegisterRouteAsync_SessionInvokesRouteAsync() {
+        var page = new Mock<IPage>();
+        Func<IRoute, Task> handler = _ => Task.CompletedTask;
+        const string pattern = "**/data.json";
+        page.Setup(p => p.RouteAsync(pattern, handler, null)).Returns(Task.CompletedTask).Verifiable();
+        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        typeof(HtmlBrowserSession)
+            .GetField("<Page>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(session, page.Object);
+
+        await HtmlBrowser.RegisterRouteAsync(session, pattern, handler);
+
+        page.Verify();
+    }
+
+    [Fact]
+    public async Task UnregisterRouteAsync_PageInvokesUnrouteAsyncWithoutHandler() {
+        var page = new Mock<IPage>();
+        const string pattern = "**/data.json";
+        Action<IRoute>? captured = null;
+        page.Setup(p => p.UnrouteAsync(pattern, It.IsAny<Action<IRoute>>()))
+            .Callback<string, Action<IRoute>>((_, h) => captured = h)
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        await HtmlBrowser.UnregisterRouteAsync(page.Object, pattern);
+
+        page.Verify();
+        Assert.Null(captured);
+    }
+
+    [Fact]
+    public async Task UnregisterRouteAsync_PageInvokesUnrouteAsyncWithHandler() {
+        var page = new Mock<IPage>();
+        Func<IRoute, Task> handler = _ => Task.CompletedTask;
+        const string pattern = "**/data.json";
+        page.Setup(p => p.UnrouteAsync(pattern, handler)).Returns(Task.CompletedTask).Verifiable();
+
+        await HtmlBrowser.UnregisterRouteAsync(page.Object, pattern, handler);
+
+        page.Verify();
+    }
+
+    [Fact]
+    public async Task UnregisterRouteAsync_SessionInvokesUnrouteAsyncWithoutHandler() {
+        var page = new Mock<IPage>();
+        const string pattern = "**/data.json";
+        Action<IRoute>? captured = null;
+        page.Setup(p => p.UnrouteAsync(pattern, It.IsAny<Action<IRoute>>()))
+            .Callback<string, Action<IRoute>>((_, h) => captured = h)
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        typeof(HtmlBrowserSession)
+            .GetField("<Page>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(session, page.Object);
+
+        await HtmlBrowser.UnregisterRouteAsync(session, pattern);
+
+        page.Verify();
+        Assert.Null(captured);
+    }
+
+    [Fact]
+    public async Task UnregisterRouteAsync_SessionInvokesUnrouteAsyncWithHandler() {
+        var page = new Mock<IPage>();
+        Func<IRoute, Task> handler = _ => Task.CompletedTask;
+        const string pattern = "**/data.json";
+        page.Setup(p => p.UnrouteAsync(pattern, handler)).Returns(Task.CompletedTask).Verifiable();
+        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        typeof(HtmlBrowserSession)
+            .GetField("<Page>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(session, page.Object);
+
+        await HtmlBrowser.UnregisterRouteAsync(session, pattern, handler);
+
+        page.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add HtmlBrowserRoutesTests covering route registration and unregistration

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68660e3317b4832ebfe78f913931155c