### PR TITLE
Add XML docs to tests and examples

### DIFF
--- a/Sources/PSParseHTML.Examples/Program.cs
+++ b/Sources/PSParseHTML.Examples/Program.cs
@@ -2,9 +2,14 @@ using System.Threading.Tasks;
 
 namespace PSParseHTML.Examples;
 
+/// <summary>
+/// Entry point for the examples application.
+/// </summary>
 public static class Program
 {
-    public static Task Main()
-        => ConsoleLogExample.RunAsync();
+    /// <summary>
+    /// Executes the <see cref="ConsoleLogExample"/>.
+    /// </summary>
+    public static Task Main() => ConsoleLogExample.RunAsync();
 }
 

--- a/Sources/PSParseHTML.Tests/CleanHeaderNameTests.cs
+++ b/Sources/PSParseHTML.Tests/CleanHeaderNameTests.cs
@@ -2,6 +2,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Unit tests for <see cref="HtmlUtilities.CleanHeaderName"/>.
+/// </summary>
 public class CleanHeaderNameTests {
     [Theory]
     [InlineData("Header-Name", "HeaderName")]

--- a/Sources/PSParseHTML.Tests/HtmlBrowserFileSavingTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserFileSavingTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests file saving operations performed by <see cref="HtmlBrowser"/>.
+/// </summary>
 public class HtmlBrowserFileSavingTests {
     [Fact]
     public async Task CaptureScreenshotAsync_CreatesDirectoryAndFile() {

--- a/Sources/PSParseHTML.Tests/HtmlBrowserNetworkLogTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserNetworkLogTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests capturing network log entries with <see cref="HtmlBrowser"/>.
+/// </summary>
 public class HtmlBrowserNetworkLogTests
 {
     [Fact]

--- a/Sources/PSParseHTML.Tests/HtmlBrowserRoutesTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserRoutesTests.cs
@@ -8,6 +8,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests for <see cref="HtmlBrowser.RegisterRouteAsync"/> and related methods.
+/// </summary>
 public class HtmlBrowserRoutesTests {
     [Fact]
     public async Task RegisterRouteAsync_PageInvokesRouteAsync() {

--- a/Sources/PSParseHTML.Tests/HtmlBrowserVideoRecordingTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserVideoRecordingTests.cs
@@ -8,6 +8,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests video recording capabilities of <see cref="HtmlBrowser"/>.
+/// </summary>
 public class HtmlBrowserVideoRecordingTests {
     [Theory]
     [InlineData(false)]

--- a/Sources/PSParseHTML.Tests/HtmlOptimizerAsyncTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlOptimizerAsyncTests.cs
@@ -4,6 +4,9 @@ using System.Threading.Tasks;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests asynchronous methods of <see cref="HtmlOptimizer"/>.
+/// </summary>
 public class HtmlOptimizerAsyncTests {
     [Fact]
     public async Task OptimizeHtmlAsync_MinifiesContent() {

--- a/Sources/PSParseHTML.Tests/HtmlParserExtensionsFileTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserExtensionsFileTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests extension methods of <see cref="HtmlParser"/> that work with files.
+/// </summary>
 public class HtmlParserExtensionsFileTests {
     private static string GetPath(string name) => TestHelpers.GetDocumentPath(name);
 

--- a/Sources/PSParseHTML.Tests/HtmlParserFormAsyncTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserFormAsyncTests.cs
@@ -9,6 +9,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests asynchronous form parsing using <see cref="HtmlParser"/>.
+/// </summary>
 public class HtmlParserFormAsyncTests {
     private static TestServer CreateServer() {
         var builder = new WebHostBuilder()

--- a/Sources/PSParseHTML.Tests/HtmlParserUrlDocumentTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserUrlDocumentTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests for parsing HTML documents retrieved from a URL.
+/// </summary>
 public class HtmlParserUrlDocumentTests {
     private static TestServer CreateServer() {
         var builder = new WebHostBuilder()

--- a/Sources/PSParseHTML.Tests/InternalLoggerTests.cs
+++ b/Sources/PSParseHTML.Tests/InternalLoggerTests.cs
@@ -5,6 +5,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests the <see cref="InternalLogger"/> utility.
+/// </summary>
 public class InternalLoggerTests {
     [Fact]
     public void Events_AreRaisedAndMessagesWritten() {


### PR DESCRIPTION
## Summary
- add example docs for Program entry point
- document multiple test classes to satisfy documentation requirements

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b661f443c832e827363c695490d08