### PR TITLE
Add missing examples

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCloseHtmlSession.cs
@@ -7,6 +7,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that disposes an existing browser session.
 /// </summary>
+/// <example>
+/// <code>Close-HTMLSession -Session $session</code>
+/// </example>
 [Cmdlet(VerbsCommon.Close, "HTMLSession")]
 [Alias("Stop-HTMLSession")]
 public sealed class CmdletCloseHtmlSession : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletCompareHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCompareHtml.cs
@@ -10,6 +10,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that compares HTML content and returns differences.
 /// </summary>
+/// <example>
+/// <code>Compare-HTML -Reference $file1 -Difference $file2</code>
+/// </example>
 [Cmdlet(VerbsData.Compare, "HTML")]
 [OutputType(typeof(IDiff))]
 public sealed class CmdletCompareHtml : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlForm.cs
@@ -9,6 +9,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Extracts HTML form information into PowerShell objects.
 /// </summary>
+/// <example>
+/// <code>ConvertFrom-HtmlForm -Url https://example.com</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlForm", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(PSObject))]
 public sealed class CmdletConvertFromHtmlForm : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
@@ -9,6 +9,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Converts HTML lists into PowerShell objects by default.
 /// </summary>
+/// <example>
+/// <code>ConvertFrom-HtmlList -Content $html</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlList", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(PSObject[]))]
 public sealed class CmdletConvertFromHtmlList : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
@@ -8,6 +8,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Parses &lt;meta&gt; tags from HTML content or a URL.
 /// </summary>
+/// <example>
+/// <code>ConvertFrom-HtmlMeta -Url https://example.com</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlMeta", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(PSObject))]
 public sealed class CmdletConvertFromHtmlMeta : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
@@ -8,6 +8,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Extracts microdata items from HTML content or a URL.
 /// </summary>
+/// <example>
+/// <code>ConvertFrom-HtmlMicrodata -Content $html</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlMicrodata", DefaultParameterSetName = ParameterSetContent)]
 [OutputType(typeof(PSObject))]
 public sealed class CmdletConvertFromHtmlMicrodata : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletExportBrowserState.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportBrowserState.cs
@@ -7,6 +7,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that saves cookies and storage state of a browser session to disk.
 /// </summary>
+/// <example>
+/// <code>Export-BrowserState -Session $session -Path state.json</code>
+/// </example>
 [Cmdlet(VerbsData.Export, "BrowserState")]
 public sealed class CmdletExportBrowserState : AsyncPSCmdlet {
     /// <summary>Browser session to export.</summary>

--- a/Sources/PSParseHTML.PowerShell/CmdletExportHtmlSession.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportHtmlSession.cs
@@ -7,6 +7,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that saves cookies and storage state of a browser session to disk.
 /// </summary>
+/// <example>
+/// <code>Export-HTMLSession -Session $session -Path session.json</code>
+/// </example>
 [Cmdlet(VerbsData.Export, "HTMLSession")]
 public sealed class CmdletExportHtmlSession : AsyncPSCmdlet {
     /// <summary>Browser session to export.</summary>

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -8,6 +8,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that formats JavaScript code using JsBeautifier.
 /// </summary>
+/// <example>
+/// <code>Format-JavaScript -Path script.js</code>
+/// </example>
 [Cmdlet(VerbsCommon.Format, "JavaScript", DefaultParameterSetName = ParameterSetContent)]
 [Alias("Format-JS")]
 [OutputType(typeof(string))]

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlConsoleLog.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlConsoleLog.cs
@@ -7,6 +7,9 @@ namespace PSParseHTML.PowerShell;
 /// <summary>
 /// Cmdlet that retrieves captured console log entries from a session.
 /// </summary>
+/// <example>
+/// <code>Get-HTMLConsoleLog -Session $session</code>
+/// </example>
 [Cmdlet(VerbsCommon.Get, "HTMLConsoleLog")]
 [OutputType(typeof(HtmlConsoleEntry))]
 public sealed class CmdletGetHtmlConsoleLog : AsyncPSCmdlet {


### PR DESCRIPTION
## Summary
- add example usage to Close-HTMLSession cmdlet
- add example usage to Compare-HTML cmdlet
- add example usage to ConvertFrom-HtmlForm cmdlet
- add example usage to ConvertFrom-HtmlList cmdlet
- add example usage to ConvertFrom-HtmlMeta cmdlet
- add example usage to ConvertFrom-HtmlMicrodata cmdlet
- add example usage to Export-BrowserState cmdlet
- add example usage to Export-HTMLSession cmdlet
- add example usage to Format-JavaScript cmdlet
- add example usage to Get-HTMLConsoleLog cmdlet

## Testing
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1`
- `dotnet build Sources/PSParseHTML.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b6c24f398832ea7a62667b9f6e318