### PR TITLE
Add missing test documentation

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserHarExportTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserHarExportTests.cs
@@ -11,9 +11,15 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Unit tests for exporting HAR files from <see cref="HtmlBrowser"/>.
+/// </summary>
 public class HtmlBrowserHarExportTests
 {
     [Fact]
+    /// <summary>
+    /// Ensures exported HAR data is correctly written to disk.
+    /// </summary>
     public async Task ExportHarAsync_WritesEntriesToFile()
     {
         string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/Sources/PSParseHTML.Tests/HtmlBrowserTableTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserTableTests.cs
@@ -3,6 +3,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests parsing of tables without header rows using <see cref="HtmlParser"/>.
+/// </summary>
 public class HtmlBrowserTableTests {
     private static string GetHtml() {
         var baseDir = AppContext.BaseDirectory;
@@ -11,6 +14,9 @@ public class HtmlBrowserTableTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Ensures tables without headers get default column names.
+    /// </summary>
     public void ParseHeadlessTable_AddsDefaultHeaders() {
         string html = GetHtml();
         var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, true);
@@ -20,6 +26,9 @@ public class HtmlBrowserTableTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Verifies detection of multiple tables on a page.
+    /// </summary>
     public void ParseHeadlessTable_DetectsAllTables() {
         string html = GetHtml();
         var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, true);

--- a/Sources/PSParseHTML.Tests/HtmlFormatterAsyncTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlFormatterAsyncTests.cs
@@ -4,8 +4,14 @@ using System.Threading.Tasks;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests asynchronous formatting helpers in <see cref="HtmlFormatter"/>.
+/// </summary>
 public class HtmlFormatterAsyncTests {
     [Fact]
+    /// <summary>
+    /// Ensures that minified HTML is expanded asynchronously.
+    /// </summary>
     public async Task FormatHtmlAsync_FormatsMinifiedHtml() {
         const string input = "<html><body><div><p>Test</p></div></body></html>";
         string result = await HtmlFormatter.FormatHtmlAsync(input);
@@ -14,6 +20,9 @@ public class HtmlFormatterAsyncTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Asynchronously formats minified CSS.
+    /// </summary>
     public async Task FormatCssAsync_FormatsMinifiedCss() {
         const string content = ".tabsWrapper{text-align:center;margin:10px auto;font-family:\"Roboto\", sans-serif!important}.tabs{margin-top:10px;font-size:15px;padding:0;list-style:none;background:rgba(255, 255, 255, 1);box-shadow:0 5px 20px rgba(0, 0, 0, 0.1);border-radius:4px;position:relative}.tabs .round{border-radius:4px}.tabs a{text-decoration:none;color:rgba(119, 119, 119, 1);text-transform:uppercase;padding:10px 20px;display:inline-block;position:relative;z-index:1;transition-duration:0.6s}.tabs a.active{color:rgba(255, 255, 255, 1)}.tabs a i{margin-right:5px}.tabs .selector{display:none;height:100%;position:absolute;left:0;top:0;right:0;bottom:0;z-index:1;border-radius:4px}.tabs-content{display:none}.tabs-content.active{display:block}";
         string result = await HtmlFormatter.FormatCssAsync(content);

--- a/Sources/PSParseHTML.Tests/HtmlFormatterFileTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlFormatterFileTests.cs
@@ -3,11 +3,17 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests for file-based formatting helpers in <see cref="HtmlFormatter"/>.
+/// </summary>
 public class HtmlFormatterFileTests
 {
     private static string GetPath(string name) => TestHelpers.GetDocumentPath(name);
 
     [Fact]
+    /// <summary>
+    /// Verifies that JavaScript files are properly formatted.
+    /// </summary>
     public void FormatJavaScriptFile_ReturnsFormattedScript()
     {
         string path = GetPath("sample_script.js");
@@ -17,6 +23,9 @@ public class HtmlFormatterFileTests
     }
 
     [Fact]
+    /// <summary>
+    /// Ensures that CSS files are formatted with expected spacing.
+    /// </summary>
     public void FormatCssFile_ReturnsFormattedCss()
     {
         string path = GetPath("sample_style.css");
@@ -26,6 +35,9 @@ public class HtmlFormatterFileTests
     }
 
     [Fact]
+    /// <summary>
+    /// Checks that HTML files are formatted with indentation.
+    /// </summary>
     public void FormatHtmlFile_ReturnsFormattedHtml()
     {
         string path = GetPath("sample_markup.html");

--- a/Sources/PSParseHTML.Tests/HtmlFormatterTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlFormatterTests.cs
@@ -4,8 +4,14 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests for in-memory formatting methods in <see cref="HtmlFormatter"/>.
+/// </summary>
 public class HtmlFormatterTests {
     [Fact]
+    /// <summary>
+    /// Formats JavaScript text using default options.
+    /// </summary>
     public void FormatJavaScript_ReturnsFormattedScript() {
         const string js =
             "(function(){function main(){var tabButtons = [].slice.call(document.querySelectorAll(\"ul.tab-nav li a.buttonTab\"));tabButtons.map(function(button){button.addEventListener(\"click\",function(){document .querySelector(\"li a.active.buttonTab\") .classList.remove(\"active\");button.classList.add(\"active\");document .querySelector(\".tab-pane.active\") .classList.remove(\"active\");document .querySelector(button.getAttribute(\"href\")) .classList.add(\"active\")})})}if(document.readyState!== \"loading\"){main()}else{document.addEventListener(\"DOMContentLoaded\",main)}})();";
@@ -17,6 +23,9 @@ public class HtmlFormatterTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Formats JavaScript using custom <see cref="BeautifierOptions"/>.
+    /// </summary>
     public void FormatJavaScript_RespectsOptions() {
         const string js = "function x(){return 1;};";
         BeautifierOptions opts = new() { IndentSize = 2, BraceStyle = BraceStyle.Expand };
@@ -26,6 +35,10 @@ public class HtmlFormatterTests {
         TestHelpers.EqualIgnoringLineEndings(expected, result);
     }
 
+    [Fact]
+    /// <summary>
+    /// Formats minified CSS text.
+    /// </summary>
     public void FormatCss_FormatsMinifiedCss() {
         const string content = ".tabsWrapper{text-align:center;margin:10px auto;font-family:\"Roboto\", sans-serif!important}.tabs{margin-top:10px;font-size:15px;padding:0;list-style:none;background:rgba(255, 255, 255, 1);box-shadow:0 5px 20px rgba(0, 0, 0, 0.1);border-radius:4px;position:relative}.tabs .round{border-radius:4px}.tabs a{text-decoration:none;color:rgba(119, 119, 119, 1);text-transform:uppercase;padding:10px 20px;display:inline-block;position:relative;z-index:1;transition-duration:0.6s}.tabs a.active{color:rgba(255, 255, 255, 1)}.tabs a i{margin-right:5px}.tabs .selector{display:none;height:100%;position:absolute;left:0;top:0;right:0;bottom:0;z-index:1;border-radius:4px}.tabs-content{display:none}.tabs-content.active{display:block}";
         string expected = string.Join("\n", new[] {
@@ -45,6 +58,9 @@ public class HtmlFormatterTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Formats minified HTML markup.
+    /// </summary>
     public void FormatHtml_FormatsMinifiedHtml() {
         const string input = "<html><body><div><p>Test</p></div></body></html>";
         const string expected = "<html>\n    <body>\n        <div>\n            <p>Test</p>\n        </div>\n    </body>\n</html>";

--- a/Sources/PSParseHTML.Tests/HtmlHarViewerTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlHarViewerTests.cs
@@ -4,6 +4,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests for <see cref="HtmlHarViewer"/> helper methods.
+/// </summary>
 public class HtmlHarViewerTests {
     private static string GetHarPath() {
         var baseDir = AppContext.BaseDirectory;
@@ -16,6 +19,9 @@ public class HtmlHarViewerTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Generates HTML viewer content from a HAR file.
+    /// </summary>
     public async Task BuildViewerHtml_ReturnsHtml() {
         Har har = await HtmlHarViewer.ReadHarAsync(GetHarPath());
         string html = HtmlHarViewer.BuildViewerHtml(har);
@@ -23,6 +29,9 @@ public class HtmlHarViewerTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Reads a minimal HAR file and populates entries.
+    /// </summary>
     public async Task ReadHarAsync_PopulatesEntries() {
         Har har = await HtmlHarViewer.ReadHarAsync(GetMinimalHarPath());
         Assert.NotNull(har.Log);
@@ -31,6 +40,9 @@ public class HtmlHarViewerTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Verifies invalid JSON causes <see cref="InvalidDataException"/>.
+    /// </summary>
     public async Task ReadHarAsync_InvalidJsonThrows() {
         string path = Path.GetTempFileName();
         try {

--- a/Sources/PSParseHTML.Tests/HtmlOptimizerFileAsyncTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlOptimizerFileAsyncTests.cs
@@ -5,8 +5,14 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests asynchronous optimization routines on files.
+/// </summary>
 public class HtmlOptimizerFileAsyncTests {
     [Fact]
+    /// <summary>
+    /// Ensures that CSS files are minified asynchronously.
+    /// </summary>
     public async Task OptimizeCssFileAsync_MinifiesContent() {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".css");
         await File.WriteAllTextAsync(path, "body { color: red; }");
@@ -19,6 +25,9 @@ public class HtmlOptimizerFileAsyncTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Asynchronously minifies HTML files.
+    /// </summary>
     public async Task OptimizeHtmlFileAsync_MinifiesContent() {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".html");
         await File.WriteAllTextAsync(path, "<html><!--c--><body> <p>Hi</p></body></html>");
@@ -31,6 +40,9 @@ public class HtmlOptimizerFileAsyncTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Asynchronously minifies JavaScript files.
+    /// </summary>
     public async Task OptimizeJavaScriptFileAsync_MinifiesInput() {
         const string formatted = "(function() {\n    function main() {\n        var tabButtons = [].slice.call(document.querySelectorAll('ul.tab-nav li a.buttonTab'));\n        tabButtons.map(function(button) {\n            button.addEventListener('click', function() {\n                document.querySelector('li a.active.buttonTab').classList.remove('active');\n                button.classList.add('active');\n                document.querySelector('.tab-pane.active').classList.remove('active');\n                document.querySelector(button.getAttribute('href')).classList.add('active');\n            });\n        });\n    }\n    if (document.readyState !== 'loading') {\n        main();\n    } else {\n        document.addEventListener('DOMContentLoaded', main);\n    }\n})();";
         const string expected = "(function(){function n(){var n=[].slice.call(document.querySelectorAll(\"ul.tab-nav li a.buttonTab\"));n.map(function(n){n.addEventListener(\"click\",function(){document.querySelector(\"li a.active.buttonTab\").classList.remove(\"active\");n.classList.add(\"active\");document.querySelector(\".tab-pane.active\").classList.remove(\"active\");document.querySelector(n.getAttribute(\"href\")).classList.add(\"active\")})})}document.readyState!==\"loading\"?n():document.addEventListener(\"DOMContentLoaded\",n)})()";

--- a/Sources/PSParseHTML.Tests/HtmlOptimizerFileTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlOptimizerFileTests.cs
@@ -4,8 +4,14 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests synchronous optimization methods on files.
+/// </summary>
 public class HtmlOptimizerFileTests {
     [Fact]
+    /// <summary>
+    /// Minifies CSS content read from a file.
+    /// </summary>
     public void OptimizeCssFile_MinifiesContent() {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".css");
         File.WriteAllText(path, "body { color: red; }");
@@ -18,6 +24,9 @@ public class HtmlOptimizerFileTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Minifies HTML markup read from a file.
+    /// </summary>
     public void OptimizeHtmlFile_MinifiesContent() {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".html");
         File.WriteAllText(path, "<html><!--c--><body> <p>Hi</p></body></html>");
@@ -30,6 +39,9 @@ public class HtmlOptimizerFileTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Minifies JavaScript content read from a file.
+    /// </summary>
     public void OptimizeJavaScriptFile_MinifiesInput() {
         const string formatted = "(function() {\n    function main() {\n        var tabButtons = [].slice.call(document.querySelectorAll('ul.tab-nav li a.buttonTab'));\n        tabButtons.map(function(button) {\n            button.addEventListener('click', function() {\n                document.querySelector('li a.active.buttonTab').classList.remove('active');\n                button.classList.add('active');\n                document.querySelector('.tab-pane.active').classList.remove('active');\n                document.querySelector(button.getAttribute('href')).classList.add('active');\n            });\n        });\n    }\n    if (document.readyState !== 'loading') {\n        main();\n    } else {\n        document.addEventListener('DOMContentLoaded', main);\n    }\n})();";
         const string expected = "(function(){function n(){var n=[].slice.call(document.querySelectorAll(\"ul.tab-nav li a.buttonTab\"));n.map(function(n){n.addEventListener(\"click\",function(){document.querySelector(\"li a.active.buttonTab\").classList.remove(\"active\");n.classList.add(\"active\");document.querySelector(\".tab-pane.active\").classList.remove(\"active\");document.querySelector(n.getAttribute(\"href\")).classList.add(\"active\")})})}document.readyState!==\"loading\"?n():document.addEventListener(\"DOMContentLoaded\",n)})()";

--- a/Sources/PSParseHTML.Tests/HtmlParserExtensionsTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserExtensionsTests.cs
@@ -7,8 +7,14 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests extension methods for <see cref="HtmlParser"/>.
+/// </summary>
 public class HtmlParserExtensionsTests {
     [Fact]
+    /// <summary>
+    /// Retrieves elements filtered by tag name.
+    /// </summary>
     public void GetElements_ByTag_ReturnsMatchingElements() {
         const string html = "<html><body><p>First</p><p>Second</p></body></html>";
         var elements = HtmlParserExtensions.GetElements(html, tag: "p").ToArray();
@@ -17,6 +23,9 @@ public class HtmlParserExtensionsTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Retrieves elements filtered by CSS class.
+    /// </summary>
     public void GetElements_ByClass_ReturnsMatchingElements() {
         const string html = "<div><span class='info'>A</span><span>B</span></div>";
         var elements = HtmlParserExtensions.GetElements(html, className: "info").ToArray();
@@ -25,6 +34,9 @@ public class HtmlParserExtensionsTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Downloads a page and selects elements by tag.
+    /// </summary>
     public async Task GetElements_FromUrl_ByTag() {
         using var client = new HttpClient();
         string html = await HtmlUtilities.GetStringWithProperEncodingAsync(
@@ -36,6 +48,9 @@ public class HtmlParserExtensionsTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Retrieves an element using its id attribute.
+    /// </summary>
     public void GetElements_ById_ReturnsMatchingElement() {
         const string html = "<div><span id='special'>A</span><span>B</span></div>";
         var elements = HtmlParserExtensions.GetElements(html, id: "special").ToArray();
@@ -44,6 +59,9 @@ public class HtmlParserExtensionsTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Retrieves an element using its name attribute.
+    /// </summary>
     public void GetElements_ByName_ReturnsMatchingElement() {
         const string html = "<form><input name='field1'/><input name='field2'/></form>";
         var elements = HtmlParserExtensions.GetElements(html, name: "field1").ToArray();
@@ -51,6 +69,9 @@ public class HtmlParserExtensionsTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Validates combined selection filters produce correct counts.
+    /// </summary>
     public void GetElements_ByClassTagIdName_CombinedCounts() {
         const string html = "<div id='box' class='wrapper'><span class='wrapper' name='x'>T</span></div>";
         Assert.Single(HtmlParserExtensions.GetElements(html, tag: "span"));

--- a/Sources/PSParseHTML.Tests/HtmlParserFormTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserFormTests.cs
@@ -3,6 +3,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests parsing of HTML forms using <see cref="HtmlParser"/>.
+/// </summary>
 public class HtmlParserFormTests {
     private static string GetSampleFormHtml() {
         var baseDir = AppContext.BaseDirectory;
@@ -11,6 +14,9 @@ public class HtmlParserFormTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Validates that form parsing returns expected metadata.
+    /// </summary>
     public void ParseFormsWithAngleSharp_ReturnsForms() {
         string html = GetSampleFormHtml();
         var forms = HtmlParser.ParseFormsWithAngleSharp(html);

--- a/Sources/PSParseHTML.Tests/HtmlParserHeaderCollisionTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserHeaderCollisionTests.cs
@@ -2,10 +2,16 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests header collision handling when parsing tables.
+/// </summary>
 public class HtmlParserHeaderCollisionTests {
     private const string DuplicateHeaders = "<table><tr><th>A*</th><th>A#</th><th>A!</th><th>B</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td></tr></table>";
 
     [Fact]
+    /// <summary>
+    /// Ensures duplicate headers are made unique when using AngleSharp.
+    /// </summary>
     public void ParseTablesWithAngleSharpDetailed_UniqueHeaders() {
         var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(DuplicateHeaders, null, null, true, false, true, null);
         var result = tables[0];
@@ -18,6 +24,9 @@ public class HtmlParserHeaderCollisionTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Ensures duplicate headers are made unique when using HtmlAgilityPack.
+    /// </summary>
     public void ParseTablesWithHtmlAgilityPackDetailed_UniqueHeaders() {
         var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(DuplicateHeaders, false, null, null, true, false, true, null);
         var result = tables[0];

--- a/Sources/PSParseHTML.Tests/HtmlParserListTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserListTests.cs
@@ -3,6 +3,9 @@ using Xunit;
 
 namespace PSParseHTML.Tests;
 
+/// <summary>
+/// Tests list parsing functionality in <see cref="HtmlParser"/>.
+/// </summary>
 public class HtmlParserListTests {
     private static string GetSampleListHtml() {
         var baseDir = AppContext.BaseDirectory;
@@ -11,6 +14,9 @@ public class HtmlParserListTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Parses simple lists using AngleSharp.
+    /// </summary>
     public void ParseListsWithAngleSharp_ReturnsItems() {
         string html = GetSampleListHtml();
         var lists = HtmlParser.ParseListsWithAngleSharp(html, " ");
@@ -20,6 +26,9 @@ public class HtmlParserListTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Parses lists using HtmlAgilityPack.
+    /// </summary>
     public void ParseListsWithHtmlAgilityPack_ReturnsItems() {
         string html = GetSampleListHtml();
         var lists = HtmlParser.ParseListsWithHtmlAgilityPack(html, " ");
@@ -29,6 +38,9 @@ public class HtmlParserListTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Parses lists with AngleSharp and returns metadata.
+    /// </summary>
     public void ParseListsWithAngleSharpDetailed_ReturnsMetadata() {
         string html = GetSampleListHtml();
         var lists = HtmlParser.ParseListsWithAngleSharpDetailed(html, " ");
@@ -38,6 +50,9 @@ public class HtmlParserListTests {
     }
 
     [Fact]
+    /// <summary>
+    /// Parses lists with HtmlAgilityPack and returns metadata.
+    /// </summary>
     public void ParseListsWithHtmlAgilityPackDetailed_ReturnsMetadata() {
         string html = GetSampleListHtml();
         var lists = HtmlParser.ParseListsWithHtmlAgilityPackDetailed(html, " ");


### PR DESCRIPTION
## Summary
- document HtmlFormatterFileTests
- document HtmlOptimizerFileAsyncTests
- document HtmlParserHeaderCollisionTests
- document HtmlBrowserHarExportTests
- document HtmlParserFormTests
- document HtmlBrowserTableTests
- document HtmlFormatterAsyncTests
- document HtmlParserExtensionsTests
- document HtmlOptimizerFileTests
- document HtmlParserListTests
- document HtmlHarViewerTests
- document HtmlFormatterTests

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln --no-build` *(fails: The argument PSParseHTML.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686b74195a0c832eb8d56e733191b67e