### PR TITLE
Fix CSS formatting test line endings

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlFormatterTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlFormatterTests.cs
@@ -26,6 +26,7 @@ public class HtmlFormatterTests {
         TestHelpers.EqualIgnoringLineEndings(expected, result);
     }
 
+    [Fact]
     public void FormatCss_FormatsMinifiedCss() {
         const string content = ".tabsWrapper{text-align:center;margin:10px auto;font-family:\"Roboto\", sans-serif!important}.tabs{margin-top:10px;font-size:15px;padding:0;list-style:none;background:rgba(255, 255, 255, 1);box-shadow:0 5px 20px rgba(0, 0, 0, 0.1);border-radius:4px;position:relative}.tabs .round{border-radius:4px}.tabs a{text-decoration:none;color:rgba(119, 119, 119, 1);text-transform:uppercase;padding:10px 20px;display:inline-block;position:relative;z-index:1;transition-duration:0.6s}.tabs a.active{color:rgba(255, 255, 255, 1)}.tabs a i{margin-right:5px}.tabs .selector{display:none;height:100%;position:absolute;left:0;top:0;right:0;bottom:0;z-index:1;border-radius:4px}.tabs-content{display:none}.tabs-content.active{display:block}";
         string expected = string.Join("\n", new[] {
@@ -41,7 +42,7 @@ public class HtmlFormatterTests {
         });
 
         string result = HtmlFormatter.FormatCss(content);
-        Assert.Equal(expected, result);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- mark CSS formatter test with `[Fact]`
- normalize newlines when asserting CSS formatting

## Testing
- `dotnet test PSParseHTML.Tests/PSParseHTML.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686b7bd4bcb4832e972395f5f0351c42