### PR TITLE
Remove unused lock field

### DIFF
--- a/Sources/PSParseHTML/Logging/LoggingMessages.cs
+++ b/Sources/PSParseHTML/Logging/LoggingMessages.cs
@@ -37,5 +37,4 @@ public class LoggingMessages {
         set => Logger.IsDebug = value;
     }
 
-    internal static object _LockObject = new object();
 }


### PR DESCRIPTION
## Summary
- remove the `_LockObject` field from `LoggingMessages`

## Testing
- `dotnet test Sources/PSParseHTML.sln --configuration Release --verbosity minimal`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./PSParseHTML.Tests.ps1` *(fails: `Measure-HTMLDocument` cmdlet not found, Register-HTMLRoute timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686ee1b6cdb8832e823d34d206082979