### PR TITLE
Fix video disposal logic

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -32,4 +32,31 @@ public class HtmlBrowserSessionDisposeTests {
         browser.Verify();
         context.Verify();
     }
+
+    [Fact]
+    public async Task DisposeAsync_SavesAndCleansVideo() {
+        string outFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString(), "video.webm");
+        string tempVideo = System.IO.Path.GetTempFileName();
+        System.IO.File.WriteAllText(tempVideo, "tmp");
+
+        var video = new Moq.Mock<IVideo>();
+        video.Setup(v => v.SaveAsAsync(It.IsAny<string>())).Returns(Task.CompletedTask).Verifiable();
+        video.Setup(v => v.PathAsync()).ReturnsAsync(tempVideo);
+
+        var playwright = new Moq.Mock<IPlaywright>();
+        var browser = new Moq.Mock<IBrowser>();
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var context = new Moq.Mock<IBrowserContext>();
+        context.Setup(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var page = new Moq.Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object, video.Object, outFile);
+
+        await session.DisposeAsync();
+
+        video.Verify(v => v.SaveAsAsync(HtmlUtilities.ResolvePath(outFile)), Moq.Times.Once);
+        Assert.False(System.IO.File.Exists(tempVideo));
+        browser.Verify();
+        context.Verify();
+    }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -130,27 +130,15 @@ public static partial class HtmlBrowser {
     /// <param name="path">Optional path where the video should be saved.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public static async Task StopVideoRecordingAsync(HtmlBrowserSession session, string? path = null, CancellationToken cancellationToken = default) {
-        string outFile = path ?? session.VideoPath ?? throw new System.ArgumentException("Output path required.");
-        IVideo? video = session.Video;
-        if (video != null) {
-            cancellationToken.ThrowIfCancellationRequested();
-            await session.Context.CloseAsync().ConfigureAwait(false);
-            string fullPath = HtmlUtilities.ResolvePath(outFile);
-            await video.SaveAsAsync(fullPath).ConfigureAwait(false);
-            try {
-                string tempPath = await video.PathAsync().ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(tempPath) &&
-                    !string.Equals(tempPath, fullPath, System.StringComparison.OrdinalIgnoreCase) &&
-                    System.IO.File.Exists(tempPath)) {
-                    System.IO.File.Delete(tempPath);
-                }
-            } catch {
-                // Ignore cleanup errors
-            }
-            await session.Browser.CloseAsync().ConfigureAwait(false);
-            session.Playwright.Dispose();
-        } else {
-            await session.DisposeAsync().ConfigureAwait(false);
+        if (path != null) {
+            session.VideoPath = path;
         }
+
+        if (session.Video != null && string.IsNullOrEmpty(session.VideoPath)) {
+            throw new System.ArgumentException("Output path required.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await session.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowserSession.cs
@@ -38,7 +38,7 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// <summary>
     /// Gets the path where the recorded video is stored.
     /// </summary>
-    public string? VideoPath { get; }
+    public string? VideoPath { get; internal set; }
     private readonly ConcurrentDictionary<IRequest, HtmlNetworkEntry> _network;
     private readonly ConcurrentQueue<HtmlConsoleEntry> _console = new();
     /// <summary>Captured network log entries.</summary>
@@ -94,6 +94,22 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
         if (Context != null) {
             await Context.CloseAsync().ConfigureAwait(false);
         }
+
+        if (Video != null && !string.IsNullOrEmpty(VideoPath)) {
+            string fullPath = HtmlUtilities.ResolvePath(VideoPath);
+            await Video.SaveAsAsync(fullPath).ConfigureAwait(false);
+            try {
+                string tempPath = await Video.PathAsync().ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(tempPath) &&
+                    !string.Equals(tempPath, fullPath, System.StringComparison.OrdinalIgnoreCase) &&
+                    System.IO.File.Exists(tempPath)) {
+                    System.IO.File.Delete(tempPath);
+                }
+            } catch {
+                // Ignore cleanup errors
+            }
+        }
+
         if (Browser != null) {
             await Browser.CloseAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary
- save video output when disposing HtmlBrowserSession
- simplify StopVideoRecordingAsync using new dispose logic
- test disposing video cleanup and saving

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ee1c76c68832eba349f271b01f9fd