### PR TITLE
Fix duplicate screenshot parameter docs

### DIFF
--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Screenshot.cs
@@ -34,8 +34,6 @@ public static partial class HtmlBrowser {
     /// <param name="delayMs">Additional wait time in milliseconds after the page is loaded.</param>
     /// <param name="format">Image file format.</param>
     /// <param name="quality">Encoder quality for JPEG output.</param>
-    /// <param name="format">Image file format.</param>
-    /// <param name="quality">Encoder quality for JPEG output.</param>
     /// <param name="selector">Optional CSS selector to wait for before capturing.</param>
     /// <param name="elementSelector">CSS selector of an element to capture.</param>
     /// <param name="clipX">Optional clip region X coordinate.</param>


### PR DESCRIPTION
## Summary
- remove duplicate `<param>` tags for `format` and `quality`

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686ee1ce6c5c832e9b025fdef7eeef4b