### PR TITLE
Switch to WebKit enum casing

### DIFF
--- a/Examples/Example-Screenshot1.ps1
+++ b/Examples/Example-Screenshot1.ps1
@@ -8,7 +8,7 @@ if ($internetAvailable) {
     Save-HTMLScreenshot -Url 'https://evotec.xyz' -OutFile "$PSScriptRoot\Output\EvotecPageFull.png" -Full -Open -Browser Chromium
     Save-HTMLScreenshot -Url 'https://evotec.xyz/hub' -OutFile "$PSScriptRoot\Output\EvotecPageHub.png" -Full -Open -Browser Chromium
     Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser Firefox
-    Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser Webkit
+    Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Full -Open -Browser WebKit
     Save-HTMLScreenshot -Url 'https://evotec.xyz/powershell-modules/' -OutFile "$PSScriptRoot\Output\EvotecPageModules.png" -Open -Browser Chromium -X 100 -Y 100 -Width 500 -Height 500
 } else {
     $localPath = Join-Path $PSScriptRoot 'Input\Screenshot1.html'

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -148,7 +148,7 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 target = Session.Page.Url;
                 engine = Session.Browser.BrowserType.Name switch {
                     "firefox" => HtmlBrowserEngine.Firefox,
-                    "webkit" => HtmlBrowserEngine.Webkit,
+                    "webkit" => HtmlBrowserEngine.WebKit,
                     _ => HtmlBrowserEngine.Chromium
                 };
                 break;

--- a/Sources/PSParseHTML/Enums/HtmlBrowserEngine.cs
+++ b/Sources/PSParseHTML/Enums/HtmlBrowserEngine.cs
@@ -15,5 +15,4 @@ public enum HtmlBrowserEngine {
     /// <summary>
     /// WebKit browser engine, used by Safari and others.
     /// </summary>
-    Webkit,
-}
+    WebKit,}

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.Video.cs
@@ -90,7 +90,7 @@ public static partial class HtmlBrowser {
         string url = session.Page.Url;
         HtmlBrowserEngine engine = session.Browser.BrowserType.Name switch {
             "firefox" => HtmlBrowserEngine.Firefox,
-            "webkit" => HtmlBrowserEngine.Webkit,
+            "webkit" => HtmlBrowserEngine.WebKit,
             _ => HtmlBrowserEngine.Chromium
         };
 

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.cs
@@ -54,7 +54,7 @@ public static partial class HtmlBrowser {
             : await Playwright.CreateAsync();
         IBrowserType type = browser switch {
             HtmlBrowserEngine.Firefox => playwright.Firefox,
-            HtmlBrowserEngine.Webkit => playwright.Webkit,
+            HtmlBrowserEngine.WebKit => playwright.Webkit,
             _ => playwright.Chromium,
         };
 


### PR DESCRIPTION
## Summary
- rename `HtmlBrowserEngine.Webkit` to `WebKit`
- use new enum value in code and example

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --logger "console;verbosity=normal"` *(fails: NuGet.Config is not valid XML)*
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1` *(fails: commands not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee1e09ab4832ea3c72d281b1feff5