### PR TITLE
Add synchronous MoveCssInline API

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -145,10 +145,10 @@ public sealed class CmdletOptimizeEmail : AsyncPSCmdlet {
 
         PreMailerResult result = ParameterSetName == "File"
             ? await PreMailerClient
-                .MoveCssInlineFromFile(Path, options)
+                .MoveCssInlineFromFileAsync(Path, options)
                 .ConfigureAwait(false)
             : await PreMailerClient
-                .MoveCssInline(Body, options)
+                .MoveCssInlineAsync(Body, options)
                 .ConfigureAwait(false);
 
         WriteObject(result.Html);

--- a/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
@@ -10,14 +10,14 @@ public class PreMailerClientFileHelpersTests
     private const string HtmlContent = "<html><head><style>p{color:red}</style></head><body><p>Hello</p></body></html>";
 
     [Fact]
-    public async Task MoveCssInlineFromFile_RemovesStyleElements()
+    public void MoveCssInlineFromFile_RemovesStyleElements()
     {
         var options = new PreMailerOptions { RemoveStyleElements = true };
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
         File.WriteAllText(path, HtmlContent);
         try
         {
-            PreMailerResult result = await PreMailerClient.MoveCssInlineFromFile(path, options);
+            PreMailerResult result = PreMailerClient.MoveCssInlineFromFile(path, options);
             Assert.DoesNotContain("<style", result.Html, StringComparison.OrdinalIgnoreCase);
         }
         finally
@@ -34,7 +34,7 @@ public class PreMailerClientFileHelpersTests
         File.WriteAllText(path, HtmlContent);
         try
         {
-            PreMailerResult syncResult = await PreMailerClient.MoveCssInlineFromFile(path, options);
+            PreMailerResult syncResult = PreMailerClient.MoveCssInlineFromFile(path, options);
             PreMailerResult asyncResult = await PreMailerClient.MoveCssInlineFromFileAsync(path, options);
             Assert.Equal(syncResult.Html, asyncResult.Html);
             Assert.DoesNotContain("<style", asyncResult.Html, StringComparison.OrdinalIgnoreCase);

--- a/Sources/PSParseHTML.Tests/PreMailerClientRemoteCssAnalyticsTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientRemoteCssAnalyticsTests.cs
@@ -61,7 +61,7 @@ public class PreMailerClientRemoteCssAnalyticsTests
 
         try
         {
-            PreMailerResult result = await PreMailerClient.MoveCssInline(html, options);
+            PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(html, options);
             Assert.Contains("style=\"font-size: 42px\"", result.Html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("style=\"color: red\"", result.Html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("utm_source=newsletter", result.Html);

--- a/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
@@ -11,7 +11,7 @@ public class PreMailerClientTests
     public async Task MoveCssInline_RemovesStyleElements_WhenEnabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = true };
-        PreMailerResult result = await PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
         Assert.DoesNotContain("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }
 
@@ -19,7 +19,7 @@ public class PreMailerClientTests
     public async Task MoveCssInline_PreservesStyleElements_WhenDisabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = false };
-        PreMailerResult result = await PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
         Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }
 
@@ -31,7 +31,7 @@ public class PreMailerClientTests
             RemoveStyleElements = true,
             PreserveMediaQueries = true
         };
-        PreMailerResult result = await PreMailerClient.MoveCssInline(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
         Assert.Contains("@media", result.Html, System.StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -48,9 +48,9 @@ public class PreMailerClient {
     }
 
     /// <summary>
-    /// Processes the HTML and returns the result.
+    /// Processes the HTML synchronously and returns the result.
     /// </summary>
-    public async Task<PreMailerResult> MoveCssInline() {
+    public PreMailerResult MoveCssInline() {
         try {
             string cssContent = Options.Css ?? string.Empty;
             string htmlToProcess = _html;
@@ -69,40 +69,33 @@ public class PreMailerClient {
                     continue;
                 }
 
-                    if (Options.DownloadRemoteCss && href != null) {
-                        try {
-                            Uri uri = new Uri(href, UriKind.RelativeOrAbsolute);
-                            if (!uri.IsAbsoluteUri && Options.BaseUri != null) {
-                                uri = new Uri(Options.BaseUri, uri);
-                            }
-
-                            if (uri.IsFile)
-                            {
-                                string localPath = NormalizeFileUriPath(uri);
-                                cssContent += await HtmlUtilities
-                                    .ReadFileCheckedAsync(localPath)
-                                    .ConfigureAwait(false);
-                            }
-                            else if (uri.IsAbsoluteUri)
-                            {
-                                using HttpClient client = new();
-                                cssContent += HtmlUtilities
-                                    .GetStringWithProperEncodingAsync(client, uri.ToString())
-                                    .GetAwaiter().GetResult();
-                            }
-                        } catch (Exception ex) {
-                            LoggingMessages.Logger.WriteError("Failed to download CSS from {0}: {1}", href, ex.Message);
+                if (Options.DownloadRemoteCss && href != null) {
+                    try {
+                        Uri uri = new Uri(href, UriKind.RelativeOrAbsolute);
+                        if (!uri.IsAbsoluteUri && Options.BaseUri != null) {
+                            uri = new Uri(Options.BaseUri, uri);
                         }
+
+                        if (uri.IsFile) {
+                            string localPath = NormalizeFileUriPath(uri);
+                            cssContent += HtmlUtilities.ReadFileChecked(localPath);
+                        } else if (uri.IsAbsoluteUri) {
+                            using HttpClient client = new();
+                            cssContent += HtmlUtilities
+                                .GetStringWithProperEncodingAsync(client, uri.ToString())
+                                .GetAwaiter().GetResult();
+                        }
+                    } catch (Exception ex) {
+                        LoggingMessages.Logger.WriteError("Failed to download CSS from {0}: {1}", href, ex.Message);
                     }
+                }
 
                     link.Remove();
                 }
 
             htmlToProcess = document.DocumentElement.OuterHtml;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
-                cssContent += await HtmlUtilities
-                    .ReadFileCheckedAsync(Options.CssFilePath!)
-                    .ConfigureAwait(false);
+                cssContent += HtmlUtilities.ReadFileChecked(Options.CssFilePath!);
             }
 
             PreMailer.Net.PreMailer preMailer = Options.BaseUri != null
@@ -241,7 +234,7 @@ public class PreMailerClient {
     /// </summary>
     /// <param name="html">HTML markup to process.</param>
     /// <param name="options">Optional processing options.</param>
-    public static Task<PreMailerResult> MoveCssInline(string html, PreMailerOptions? options = null) {
+    public static PreMailerResult MoveCssInline(string html, PreMailerOptions? options = null) {
         return FromHtml(html, options).MoveCssInline();
     }
 
@@ -250,7 +243,7 @@ public class PreMailerClient {
     /// </summary>
     /// <param name="htmlFilePath">Path to the HTML file.</param>
     /// <param name="options">Optional processing options.</param>
-    public static Task<PreMailerResult> MoveCssInlineFromFile(string htmlFilePath, PreMailerOptions? options = null) {
+    public static PreMailerResult MoveCssInlineFromFile(string htmlFilePath, PreMailerOptions? options = null) {
         return FromFile(htmlFilePath, options).MoveCssInline();
     }
 
@@ -293,7 +286,7 @@ public class PreMailerClient {
     /// <param name="analyticsCampaign">UTM campaign parameter.</param>
     /// <param name="analyticsContent">UTM content parameter.</param>
     /// <param name="analyticsDomain">Domain used when constructing analytics links.</param>
-    public static Task<PreMailerResult> MoveCssInline(
+    public static PreMailerResult MoveCssInline(
         string html,
         Uri? baseUri = null,
         bool removeStyleElements = false,
@@ -357,7 +350,7 @@ public class PreMailerClient {
     /// <param name="analyticsCampaign">UTM campaign parameter.</param>
     /// <param name="analyticsContent">UTM content parameter.</param>
     /// <param name="analyticsDomain">Domain used when constructing analytics links.</param>
-    public static Task<PreMailerResult> MoveCssInlineFromFile(
+    public static PreMailerResult MoveCssInlineFromFile(
         string htmlFilePath,
         Uri? baseUri = null,
         bool removeStyleElements = false,


### PR DESCRIPTION
## Summary
- add `MoveCssInline` synchronous API
- update call sites and tests to use `MoveCssInlineAsync`

## Testing
- `dotnet test Sources/PSParseHTML.sln -c Release`
- `dotnet build Sources/PSParseHTML.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686ee419834c832e9c1376a9adb79ca7