### PR TITLE
Fix flaky route test

### DIFF
--- a/Tests/Register-HTMLRoute.Tests.ps1
+++ b/Tests/Register-HTMLRoute.Tests.ps1
@@ -2,7 +2,7 @@ Describe 'Register-HTMLRoute' {
     It 'Blocks a request to data.json' {
         $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
         $uri = [System.Uri]::new($pagePath).AbsoluteUri
-        $session = Invoke-HTMLRendering -Url $uri -Session
+        $session = Invoke-HTMLRendering -Url 'about:blank' -Session
         Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock { param($route) $route.AbortAsync() | Out-Null }
         Invoke-HTMLNavigation -Session $session -Url $uri
         $text = Get-HTMLContent -Session $session -Selector '#result' -AsText
@@ -13,7 +13,7 @@ Describe 'Register-HTMLRoute' {
     It 'Rewrites request to data.json' {
         $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
         $uri = [System.Uri]::new($pagePath).AbsoluteUri
-        $session = Invoke-HTMLRendering -Url $uri -Session
+        $session = Invoke-HTMLRendering -Url 'about:blank' -Session
         Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock {
             param($route)
             $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{


### PR DESCRIPTION
## Summary
- stabilize `Register-HTMLRoute` tests by opening a blank page before routing

## Testing
- `dotnet test`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Measure-HTMLDocument not found)*
- `pwsh -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Script ./Tests/Register-HTMLRoute.Tests.ps1 -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_e_686f72ef205c832ea956e5005b877fe9