### PR TITLE
Stream downloads via async enumerable

### DIFF
--- a/Examples/Example-DownloadItemsStreaming.ps1
+++ b/Examples/Example-DownloadItemsStreaming.ps1
@@ -1,0 +1,6 @@
+Import-Module ..\PSParseHTML.psd1 -Force
+
+# Stream downloads as they complete
+foreach ($file in Save-HTMLAttachment -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$PSScriptRoot\Output\Streaming" -Filter '.zip') {
+    Write-Host "Downloaded $file"
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -15,7 +15,7 @@ namespace PSParseHTML.PowerShell;
 /// </example>
 [Cmdlet(VerbsData.Save, "HTMLAttachment", DefaultParameterSetName = ParameterSetDefault)]
 [Alias("Save-HTMLDownload")]
-[OutputType(typeof(string[]))]
+[OutputType(typeof(string))]
 public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
     private const string ParameterSetDefault = "Default";
     private const string ParameterSetSession = "Session";
@@ -64,13 +64,13 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
         using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
         CancellationToken token = linkedCts.Token;
 
-        List<string> files = ParameterSetName switch {
-            ParameterSetSession => await HtmlBrowser.SavePageDownloadsAsync(
+        IAsyncEnumerable<string> files = ParameterSetName switch {
+            ParameterSetSession => HtmlBrowser.SavePageDownloadsAsync(
                 (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
                 HtmlUtilities.ResolvePath(Path),
                 Filter,
-                token).ConfigureAwait(false),
-            _ => await HtmlBrowser.SavePageDownloadsAsync(
+                token),
+            _ => HtmlBrowser.SavePageDownloadsAsync(
                 Url,
                 HtmlUtilities.ResolvePath(Path),
                 Browser,
@@ -78,9 +78,11 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
                 Filter,
                 headless: !Visible.IsPresent,
                 slowMo: SlowMo,
-                cancellationToken: token).ConfigureAwait(false)
+                cancellationToken: token)
         };
 
-        WriteObject(files.ToArray(), true);
+        await foreach (string file in files.WithCancellation(token).ConfigureAwait(false)) {
+            WriteObject(file);
+        }
     }
 }

--- a/Sources/PSParseHTML.Tests/HtmlBrowserDownloadFilterTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserDownloadFilterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Moq;
@@ -40,7 +41,10 @@ public class HtmlBrowserDownloadFilterTests {
         page.Setup(p => p.WaitForLoadStateAsync(It.IsAny<LoadState>(), It.IsAny<PageWaitForLoadStateOptions?>()))
             .Returns(Task.CompletedTask);
 
-        var files = await HtmlBrowser.SavePageDownloadsAsync(page.Object, dir, "file1");
+        var files = new List<string>();
+        await foreach (string f in HtmlBrowser.SavePageDownloadsAsync(page.Object, dir, "file1")) {
+            files.Add(f);
+        }
 
         string path1 = Path.Combine(dir, "file1.txt");
         string path2 = Path.Combine(dir, "other.bin");

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Playwright;
 
 namespace PSParseHTML;
@@ -20,7 +21,7 @@ public static partial class HtmlBrowser {
     /// <param name="clean">Reinstall the browser runtime.</param>
     /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
     /// <returns>Paths of downloaded files.</returns>
-    public static async Task<List<string>> SavePageDownloadsAsync(string url, string directory, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? filter = null, bool headless = true, int slowMo = 0, CancellationToken cancellationToken = default) {
+    public static async IAsyncEnumerable<string> SavePageDownloadsAsync(string url, string directory, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? filter = null, bool headless = true, int slowMo = 0, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
             url,
             browser,
@@ -34,18 +35,20 @@ public static partial class HtmlBrowser {
             cancellationToken: cancellationToken).ConfigureAwait(false);
         var page = session.Page;
         string dir = HtmlUtilities.ResolvePath(directory);
-        return await SavePageDownloadsAsync(page, dir, filter, cancellationToken).ConfigureAwait(false);
+        await foreach (string file in SavePageDownloadsAsync(page, dir, filter, cancellationToken).ConfigureAwait(false)) {
+            yield return file;
+        }
     }
 
     /// <summary>
     /// Saves files downloaded from an already loaded page.
     /// </summary>
-    public static async Task<List<string>> SavePageDownloadsAsync(IPage page, string directory, string? filter = null, CancellationToken cancellationToken = default) {
+    public static async IAsyncEnumerable<string> SavePageDownloadsAsync(IPage page, string directory, string? filter = null, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
         string dir = HtmlUtilities.ResolvePath(directory);
         Directory.CreateDirectory(dir);
         List<string> downloads = new();
-        List<Task> saves = new();
+        List<Task<string>> saves = new();
         object sync = new();
         page.Download += (_, dl) => {
             bool match = string.IsNullOrEmpty(filter) ||
@@ -60,7 +63,7 @@ public static partial class HtmlBrowser {
                 save = !downloads.Contains(filePath);
                 if (save) {
                     downloads.Add(filePath);
-                    saves.Add(dl.SaveAsAsync(filePath));
+                    saves.Add(dl.SaveAsAsync(filePath).ContinueWith(_ => filePath, TaskScheduler.Default));
                 }
             }
         };
@@ -80,7 +83,9 @@ public static partial class HtmlBrowser {
             cancellationToken.ThrowIfCancellationRequested();
             await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync());
         }
-        await Task.WhenAll(saves).ConfigureAwait(false);
-        return downloads;
+        foreach (Task<string> save in saves) {
+            string path = await save.ConfigureAwait(false);
+            yield return path;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow HtmlBrowser.SavePageDownloadsAsync to stream paths with `yield return`
- update Save-HTMLAttachment cmdlet to handle asynchronous enumerables
- adapt download tests
- add streaming download example

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj -c Release`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: ConvertFrom-HtmlOpenGraph command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709488004c832e95e59689fd95a029