### PR TITLE
Add microdata schema validation

### DIFF
--- a/Examples/Example-MicrodataSchemaValidation.ps1
+++ b/Examples/Example-MicrodataSchemaValidation.ps1
@@ -1,0 +1,5 @@
+# Demonstrates validating microdata items with schema definitions
+$markup = '<div itemscope itemtype="https://schema.org/Person"><span itemprop="foo">bar</span></div>'
+$items = ConvertFrom-HtmlMicrodata -Content $markup
+$mismatches = [PSParseHTML.HtmlParser]::ValidateMicrodataItems($items)
+$mismatches | Format-Table

--- a/Sources/PSParseHTML.Tests/HtmlMicrodataTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlMicrodataTests.cs
@@ -11,4 +11,14 @@ public class HtmlMicrodataTests {
         Assert.Equal("https://schema.org/Person", items[0].Type);
         Assert.Equal("Jane Doe", items[0].Properties["name"][0]);
     }
+
+    [Fact]
+    public void ValidateMicrodataItems_ReturnsMismatches() {
+        const string html = "<div itemscope itemtype=\"https://schema.org/Person\"><span itemprop=\"foo\">bar</span></div>";
+        var items = HtmlParser.ParseMicrodataItems(html);
+        var mismatches = HtmlParser.ValidateMicrodataItems(items);
+        Assert.Single(mismatches);
+        Assert.Equal("https://schema.org/Person", mismatches[0].Type);
+        Assert.Contains("foo", mismatches[0].Properties);
+    }
 }

--- a/Sources/PSParseHTML/HtmlParser.cs
+++ b/Sources/PSParseHTML/HtmlParser.cs
@@ -341,6 +341,14 @@ public static class HtmlParser {
         return await HtmlParserFromMicrodata.ParseUrlMicrodataItemsAsync(url, client).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Compares microdata items with built-in schema definitions and returns mismatches.
+    /// </summary>
+    /// <param name="items">Microdata items to validate.</param>
+    /// <returns>List of mismatches found.</returns>
+    public static List<MicrodataSchemaMismatch> ValidateMicrodataItems(List<HtmlMicrodataItem> items) {
+        return MicrodataSchemaValidator.Validate(items);
+    }
 
 
     /// <summary>

--- a/Sources/PSParseHTML/MicrodataSchemaValidator.cs
+++ b/Sources/PSParseHTML/MicrodataSchemaValidator.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Provides validation helpers for microdata items against simple schema definitions.
+/// </summary>
+public static class MicrodataSchemaValidator {
+    private static readonly Dictionary<string, HashSet<string>> Schema = new() {
+        ["https://schema.org/Person"] = new(new[] { "name", "jobTitle", "url" }),
+        ["https://schema.org/Product"] = new(new[] { "name", "description", "image", "brand", "sku" })
+    };
+
+    /// <summary>
+    /// Compares parsed microdata items with built-in schema definitions and returns mismatched properties.
+    /// </summary>
+    /// <param name="items">Microdata items to validate.</param>
+    /// <returns>List of mismatches found.</returns>
+    public static List<MicrodataSchemaMismatch> Validate(List<HtmlMicrodataItem> items) {
+        List<MicrodataSchemaMismatch> mismatches = new();
+        foreach (var item in items) {
+            if (item.Type == null || !Schema.TryGetValue(item.Type, out var allowed)) {
+                continue;
+            }
+
+            List<string> unknown = new();
+            foreach (var property in item.Properties.Keys) {
+                if (!allowed.Contains(property)) {
+                    unknown.Add(property);
+                }
+            }
+
+            if (unknown.Count > 0) {
+                mismatches.Add(new MicrodataSchemaMismatch(item.Type, unknown));
+            }
+        }
+        return mismatches;
+    }
+}
+/// <summary>
+/// Represents mismatched properties for a particular microdata item type.
+/// </summary>
+public sealed class MicrodataSchemaMismatch {
+    public MicrodataSchemaMismatch(string type, List<string> properties) {
+        Type = type;
+        Properties = properties;
+    }
+
+    public string Type { get; }
+    public List<string> Properties { get; }
+}


### PR DESCRIPTION
## Summary
- add `MicrodataSchemaValidator` for checking parsed microdata against schema definitions
- expose `ValidateMicrodataItems` via `HtmlParser`
- test new validation feature
- add example script demonstrating validation

## Testing
- `dotnet build Sources/PSParseHTML/PSParseHTML.csproj -c Release`
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj -c Release`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1; Invoke-Pester -Output Detailed"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_687095059f64832e94c3202437858009