### PR TITLE
Refactor path normalization using built‑in helpers

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlOptimizerTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlOptimizerTests.cs
@@ -11,6 +11,7 @@ public class HtmlOptimizerTests {
         Assert.Equal("body{color:#f00}", result);
     }
 
+    [Fact]
     public void OptimizeHtml_MinifiesContent() {
         const string input = "<html><!--c--><body> <p>Hi</p></body></html>";
         string result = HtmlOptimizer.OptimizeHtml(input, false);
@@ -24,6 +25,7 @@ public class HtmlOptimizerTests {
         Assert.StartsWith("<!-- saved from url=(0014)about:internet -->", result);
     }
 
+    [Fact]
     public void OptimizeJavaScript_MinifiesInput() {
         const string formatted = "(function() {\n    function main() {\n        var tabButtons = [].slice.call(document.querySelectorAll('ul.tab-nav li a.buttonTab'));\n        tabButtons.map(function(button) {\n            button.addEventListener('click', function() {\n                document.querySelector('li a.active.buttonTab').classList.remove('active');\n                button.classList.add('active');\n                document.querySelector('.tab-pane.active').classList.remove('active');\n                document.querySelector(button.getAttribute('href')).classList.add('active');\n            });\n        });\n    }\n    if (document.readyState !== 'loading') {\n        main();\n    } else {\n        document.addEventListener('DOMContentLoaded', main);\n    }\n})();";
 

--- a/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
@@ -44,4 +44,39 @@ public class PreMailerClientFileHelpersTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public void MoveCssInlineFromFile_RelativePath()
+    {
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
+        File.WriteAllText(file, HtmlContent);
+        string relative = Path.GetRelativePath(Directory.GetCurrentDirectory(), file);
+        try
+        {
+            PreMailerResult result = PreMailerClient.MoveCssInlineFromFile(relative, null);
+            Assert.Contains("Hello", result.Html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void MoveCssInlineFromFile_EnvironmentVariablePath()
+    {
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
+        File.WriteAllText(file, HtmlContent);
+        Environment.SetEnvironmentVariable("HTML_FILE_TEST", file);
+        try
+        {
+            PreMailerResult result = PreMailerClient.MoveCssInlineFromFile("%HTML_FILE_TEST%", null);
+            Assert.Contains("Hello", result.Html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(file);
+            Environment.SetEnvironmentVariable("HTML_FILE_TEST", null);
+        }
+    }
 }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -399,7 +399,7 @@ public class PreMailerClient {
         {
             string[] segments = uri.AbsolutePath
                 .TrimStart('/')
-                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+                .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             string path = Path.Combine(segments);
             return Path.Combine(Path.DirectorySeparatorChar + uri.Host, path);
         }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -401,9 +401,22 @@ public class PreMailerClient {
                 .TrimStart('/')
                 .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             string path = Path.Combine(segments);
-            return Path.Combine(Path.DirectorySeparatorChar + uri.Host, path);
+
+            string prefix = Path.DirectorySeparatorChar == '\\'
+                ? new string(Path.DirectorySeparatorChar, 2) + uri.Host
+                : Path.DirectorySeparatorChar + uri.Host;
+
+            return Path.Combine(prefix, path);
         }
 
-        return uri.LocalPath;
+        string localPath = uri.LocalPath;
+        if (Path.DirectorySeparatorChar == '\\')
+        {
+            localPath = localPath.Length >= 2 && localPath[1] == ':'
+                ? localPath.Replace('/', '\\')
+                : "\\" + localPath.TrimStart('/').Replace('/', '\\');
+        }
+
+        return localPath;
     }
 }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -395,24 +395,15 @@ public class PreMailerClient {
 
     private static string NormalizeFileUriPath(Uri uri)
     {
-        string localPath = uri.LocalPath;
-        if (uri.IsUnc && Path.DirectorySeparatorChar == '/')
+        if (uri.IsUnc)
         {
-            // Convert UNC paths to POSIX style when running on Unix-like systems
-            localPath = "/" + localPath.TrimStart('\\').Replace('\\', '/');
+            string[] segments = uri.AbsolutePath
+                .TrimStart('/')
+                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+            string path = Path.Combine(segments);
+            return Path.Combine(Path.DirectorySeparatorChar + uri.Host, path);
         }
-        else if (!uri.IsUnc && Path.DirectorySeparatorChar == '\\')
-        {
-            // Normalize local file paths for Windows
-            if (localPath.Length >= 2 && localPath[1] == ':')
-            {
-                localPath = localPath.Replace('/', '\\');
-            }
-            else
-            {
-                localPath = "\\" + localPath.TrimStart('/').Replace('/', '\\');
-            }
-        }
-        return localPath;
+
+        return uri.LocalPath;
     }
 }


### PR DESCRIPTION
## Summary
- refactor `NormalizeFileUriPath` to build paths with `Path.Combine`
- add tests for relative and environment variable file paths

## Testing
- `dotnet test Sources/PSParseHTML.sln`

------
https://chatgpt.com/codex/tasks/task_e_68709467e69c832eb26d3820767116fe