### PR TITLE
Add HTML diff viewer

### DIFF
--- a/Sources/PSParseHTML.Examples/ShowHtmlDiffExample.cs
+++ b/Sources/PSParseHTML.Examples/ShowHtmlDiffExample.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+
+namespace PSParseHTML.Examples;
+
+/// <summary>
+/// Demonstrates generating an HTML viewer from diff results.
+/// </summary>
+public static class ShowHtmlDiffExample
+{
+    /// <summary>Executes the example logic.</summary>
+    public static void Run()
+    {
+        var diffs = HtmlDiffer.Compare("<p>a</p>", "<p>b</p>");
+        string html = HtmlDiffViewer.BuildViewerHtml(diffs);
+        string outFile = "diff_viewer.html";
+        File.WriteAllText(outFile, html);
+        Console.WriteLine($"Viewer written to {outFile}");
+    }
+}

--- a/Sources/PSParseHTML.Tests/HtmlDiffViewerTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlDiffViewerTests.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlDiffViewerTests
+{
+    [Fact]
+    public void BuildViewerHtml_ReturnsHtml()
+    {
+        var diffs = HtmlDiffer.Compare("<p>a</p>", "<p>b</p>");
+        string html = HtmlDiffViewer.BuildViewerHtml(diffs);
+        Assert.Contains("<table>", html);
+    }
+}

--- a/Sources/PSParseHTML/HtmlDiffViewer.cs
+++ b/Sources/PSParseHTML/HtmlDiffViewer.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngleSharp.Diffing.Core;
+
+namespace PSParseHTML;
+
+/// <summary>
+/// Utility methods for creating an HTML representation of <see cref="IDiff"/> objects.
+/// </summary>
+public static class HtmlDiffViewer
+{
+    /// <summary>
+    /// Builds HTML table markup for the provided differences.
+    /// </summary>
+    /// <param name="diffs">Collection of diff objects.</param>
+    /// <returns>HTML string.</returns>
+    public static string BuildViewerHtml(IEnumerable<IDiff> diffs)
+    {
+        if (diffs is null)
+        {
+            throw new ArgumentNullException(nameof(diffs));
+        }
+
+        string rows = string.Join(Environment.NewLine,
+            diffs.Select(d => $"<tr><td>{d.GetType().Name}</td><td>{d.Target}</td><td>{d.Result}</td></tr>"));
+
+        return $$"""
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8' />
+<title>Diff Viewer</title>
+<style>
+body { font-family: Arial, sans-serif; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+thead { background: #eee; }
+</style>
+</head>
+<body>
+<table>
+<thead>
+<tr><th>Type</th><th>Target</th><th>Result</th></tr>
+</thead>
+<tbody>
+{{rows}}
+</tbody>
+</table>
+</body>
+</html>
+""";
+    }
+}


### PR DESCRIPTION
## Summary
- provide `HtmlDiffViewer.BuildViewerHtml` to turn `IDiff` objects into simple HTML
- add `ShowHtmlDiffExample` in examples
- test generating HTML diff viewer

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln`

------
https://chatgpt.com/codex/tasks/task_e_68709518cf30832e826d8de3eb922569