### PR TITLE
Streamed downloads for resource saving

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlResourceDownloadTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlResourceDownloadTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlResourceDownloadTests {
+    private static TestServer CreateServer() {
+        var builder = new WebHostBuilder()
+            .Configure(app => app.Run(async ctx => {
+                string content = ctx.Request.Path.Value switch {
+                    "/file1.txt" => "file1",
+                    "/file2.js" => "file2",
+                    _ => string.Empty
+                };
+                await ctx.Response.Body.WriteAsync(System.Text.Encoding.UTF8.GetBytes(content));
+            }));
+        return new TestServer(builder);
+    }
+
+    [Fact]
+    public async Task SaveAsync_DownloadsFile() {
+        using var server = CreateServer();
+        using HttpClient client = server.CreateClient();
+        HtmlResourceLink link = new() { Source = server.BaseAddress + "file1.txt" };
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        string path = await link.SaveAsync(dir, client: client);
+
+        Assert.True(File.Exists(path));
+        Assert.Equal("file1", File.ReadAllText(path));
+        Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public async Task DownloadResourcesAsync_DownloadsAllFiles() {
+        using var server = CreateServer();
+        using HttpClient client = server.CreateClient();
+        var links = new List<HtmlResourceLink> {
+            new() { Source = "file1.txt" },
+            new() { Source = "file2.js" }
+        };
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        List<string> paths = await HtmlResourceParser.DownloadResourcesAsync(links, server.BaseAddress!, dir, client);
+
+        Assert.Equal(2, paths.Count);
+        foreach (string path in paths) {
+            Assert.True(File.Exists(path));
+        }
+        string c1 = File.ReadAllText(Path.Combine(dir, "file1.txt"));
+        string c2 = File.ReadAllText(Path.Combine(dir, "file2.js"));
+        Assert.Equal("file1", c1);
+        Assert.Equal("file2", c2);
+        Directory.Delete(dir, true);
+    }
+}

--- a/Sources/PSParseHTML/HtmlResourceParser.cs
+++ b/Sources/PSParseHTML/HtmlResourceParser.cs
@@ -136,13 +136,25 @@ public static class HtmlResourceParser
         foreach (var link in links.Where(l => !string.IsNullOrEmpty(l.Source)))
         {
             Uri srcUri = Uri.TryCreate(link.Source, UriKind.Absolute, out var abs) ? abs : new Uri(baseUri, link.Source);
-            byte[] bytes = await http.GetByteArrayAsync(srcUri).ConfigureAwait(false);
 #if NETSTANDARD2_0 || NETFRAMEWORK
-            await Task.Run(() => File.WriteAllBytes(Path.Combine(dir, Path.GetFileName(srcUri.LocalPath)), bytes)).ConfigureAwait(false);
+            using (HttpResponseMessage response = await http.GetAsync(srcUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                string filePath = Path.Combine(dir, Path.GetFileName(srcUri.LocalPath));
+                using FileStream fileStream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                await contentStream.CopyToAsync(fileStream).ConfigureAwait(false);
+                paths.Add(filePath);
+            }
 #else
-            await File.WriteAllBytesAsync(Path.Combine(dir, Path.GetFileName(srcUri.LocalPath)), bytes).ConfigureAwait(false);
+            using HttpResponseMessage response = await http.GetAsync(srcUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            await using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            string filePath = Path.Combine(dir, Path.GetFileName(srcUri.LocalPath));
+            await using FileStream fileStream = new(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await contentStream.CopyToAsync(fileStream).ConfigureAwait(false);
+            paths.Add(filePath);
 #endif
-            paths.Add(Path.Combine(dir, Path.GetFileName(srcUri.LocalPath)));
         }
 
         return paths;

--- a/Sources/PSParseHTML/Models/HtmlResourceLink.cs
+++ b/Sources/PSParseHTML/Models/HtmlResourceLink.cs
@@ -93,11 +93,20 @@ public sealed class HtmlResourceLink
         }
 
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
-        byte[] bytes = await http.GetByteArrayAsync(srcUri).ConfigureAwait(false);
 #if NETSTANDARD2_0 || NETFRAMEWORK
-        await Task.Run(() => File.WriteAllBytes(resolved, bytes)).ConfigureAwait(false);
+        using (HttpResponseMessage response = await http.GetAsync(srcUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
+        {
+            response.EnsureSuccessStatusCode();
+            using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using FileStream fileStream = new(resolved, FileMode.Create, FileAccess.Write, FileShare.None);
+            await contentStream.CopyToAsync(fileStream).ConfigureAwait(false);
+        }
 #else
-        await File.WriteAllBytesAsync(resolved, bytes).ConfigureAwait(false);
+        using HttpResponseMessage response = await http.GetAsync(srcUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        await using Stream contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        await using FileStream fileStream = new(resolved, FileMode.Create, FileAccess.Write, FileShare.None);
+        await contentStream.CopyToAsync(fileStream).ConfigureAwait(false);
 #endif
         return resolved;
     }


### PR DESCRIPTION
## Summary
- use streaming APIs when saving HTML resources
- test downloading resources using a test server

## Testing
- `dotnet test Sources/PSParseHTML.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687095239708832ea6d9b986d0ae4e38