### PR TITLE
Fix Format-JavaScript output block

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -106,10 +106,6 @@ public sealed class CmdletFormatJavaScript : AsyncPSCmdlet {
         if (!string.IsNullOrEmpty(OutputFile)) {
             string outPath = HtmlUtilities.ResolvePath(OutputFile!);
 #if NETSTANDARD2_0 || NETFRAMEWORK
-#else
-            await System.IO.File.WriteAllTextAsync(outPath, formatted, CancelToken).ConfigureAwait(false);
-#endif
-#if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, formatted);
 #else
             await System.IO.File.WriteAllTextAsync(outPath, formatted, CancelToken).ConfigureAwait(false);
@@ -117,6 +113,5 @@ public sealed class CmdletFormatJavaScript : AsyncPSCmdlet {
         } else {
             WriteObject(formatted);
         }
-        await Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- simplify ProcessRecordAsync logic for Format-JavaScript

## Testing
- `dotnet test`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(failed: network restrictions prevented Playwright download)*

------
https://chatgpt.com/codex/tasks/task_e_6878a97dbb24832e93ecfd4c7a6c5aaa