### PR TITLE
Fix footer filtering in HTML table parser

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlParserTableSkipFooterTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlParserTableSkipFooterTests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlParserTableSkipFooterTests {
+    [Fact]
+    public void ParseTablesWithAngleSharpDetailed_SkipFooter_OmitsTfootRows() {
+        const string html = "<table><tr><th>A</th></tr><tr><td>1</td></tr><tfoot><tr><td>2</td></tr></tfoot></table>";
+        var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(html, null, null, false, true, false, null);
+        Assert.Single(tables);
+        var table = tables[0];
+        Assert.Single(table.Data);
+        Assert.Equal("1", table.Data[0]["A"]);
+    }
+
+    [Fact]
+    public void ParseTablesWithHtmlAgilityPackDetailed_SkipFooter_OmitsTfootRows() {
+        const string html = "<table><tr><th>A</th></tr><tr><td>1</td></tr><tfoot><tr><td>2</td></tr></tfoot></table>";
+        var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, false, true, false, null);
+        Assert.Single(tables);
+        var table = tables[0];
+        Assert.Single(table.Data);
+        Assert.Equal("1", table.Data[0]["A"]);
+    }
+}

--- a/Sources/PSParseHTML/HtmlParserFromTable.cs
+++ b/Sources/PSParseHTML/HtmlParserFromTable.cs
@@ -65,9 +65,10 @@ public static class HtmlParserFromTable {
             var containsDisplaySpaceNone = style.IndexOf("display: none", StringComparison.OrdinalIgnoreCase) >= 0;
             metadata.IsVisible = !(containsDisplayNone || containsDisplaySpaceNone);
 
-            var rows = skipFooter ?
-                table.QuerySelectorAll("tr:not(tfoot tr)") :
-                table.QuerySelectorAll("tr");
+            IElement[] rows = table.QuerySelectorAll("tr").ToArray();
+            if (skipFooter) {
+                rows = rows.Where(row => row.Closest("tfoot") is null).ToArray();
+            }
             metadata.RowCount = rows.Length;
 
             if (rows.Length == 0) {


### PR DESCRIPTION
## Summary
- fix skipFooter logic in HtmlParserFromTable
- add tests confirming `<tfoot>` rows are skipped

## Testing
- `dotnet test Sources/PSParseHTML.sln -v minimal`
- `dotnet build Sources/PSParseHTML.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878a984bc18832e82fccc486eb20b2f