### PR TITLE
Add domain filtering for Get-HTMLCookie

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlCookie.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace PSParseHTML.PowerShell;
 
@@ -15,6 +16,10 @@ public sealed class CmdletGetHtmlCookie : AsyncPSCmdlet {
     [Parameter(Position = 0, ValueFromPipeline = true)]
     public HtmlBrowserSession? Session { get; set; }
 
+    /// <summary>Cookie domain filter.</summary>
+    [Parameter]
+    public string[]? Domain { get; set; }
+
     /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
@@ -26,6 +31,10 @@ public sealed class CmdletGetHtmlCookie : AsyncPSCmdlet {
         using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
         CancellationToken token = linkedCts.Token;
         List<HtmlCookie> cookies = await HtmlBrowser.GetCookiesAsync(session, token).ConfigureAwait(false);
+        if (Domain is { Length: > 0 }) {
+            var domainSet = new HashSet<string>(Domain, System.StringComparer.OrdinalIgnoreCase);
+            cookies = cookies.Where(c => c.Domain is not null && domainSet.Contains(c.Domain)).ToList();
+        }
         WriteObject(cookies, true);
     }
 }

--- a/Tests/GetSet-HTMLCookie.Tests.ps1
+++ b/Tests/GetSet-HTMLCookie.Tests.ps1
@@ -31,4 +31,28 @@ Describe 'HTML Cookie cmdlets' {
         { Set-HTMLCookie -Session $session -Cookie @() } | Should -Not -Throw
         Close-HTMLSession -Session $session
     }
+
+    It 'Filters cookies by domain' {
+        $url = 'about:blank'
+
+        $c1 = [PSParseHTML.HtmlCookie]::new()
+        $c1.Name = 'c1'
+        $c1.Value = 'val1'
+        $c1.Domain = 'example.com'
+        $c1.Path = '/'
+
+        $c2 = [PSParseHTML.HtmlCookie]::new()
+        $c2.Name = 'c2'
+        $c2.Value = 'val2'
+        $c2.Domain = 'other.com'
+        $c2.Path = '/'
+
+        $session = Invoke-HTMLRendering -Url $url -Session
+        Set-HTMLCookie -Session $session -Cookie ([PSParseHTML.HtmlCookie[]]@($c1, $c2))
+        $filtered = Get-HTMLCookie -Session $session -Domain 'example.com'
+        Close-HTMLSession -Session $session
+
+        $filtered.Count | Should -Be 1
+        $filtered[0].Name | Should -Be 'c1'
+    }
 }


### PR DESCRIPTION
## Summary
- extend `CmdletGetHtmlCookie` with `-Domain` parameter
- filter returned cookies when domains specified
- test domain filtering in Pester tests

## Testing
- `dotnet test Sources/PSParseHTML.sln --verbosity minimal`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878aa0e5290832eb15c2b478b82072f