### PR TITLE
Cache engine name in Start-HTMLVideoRecording

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -146,7 +146,8 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
                 Session ??= (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
                     ?? throw new PSInvalidOperationException("No session provided and no default session found.");
                 target = Session.Page.Url;
-                engine = Session.Browser.BrowserType.Name switch {
+                string browserType = Session.Browser.BrowserType.Name;
+                engine = browserType switch {
                     "firefox" => HtmlBrowserEngine.Firefox,
                     "webkit" => HtmlBrowserEngine.WebKit,
                     _ => HtmlBrowserEngine.Chromium


### PR DESCRIPTION
## Summary
- reduce property access when deriving video recording browser engine
- keep existing behavior

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln --no-build -c Release`
- `pwsh -NoLogo -NoProfile -File PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878aafd58e0832eb7a11cb9d4f44972