### PR TITLE
Ignore hidden password fields in login detection

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserLoginDetectionTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserLoginDetectionTests.cs
@@ -44,4 +44,19 @@ public class HtmlBrowserLoginDetectionTests {
         Assert.Equal("input#p", form.PasswordSelector);
         Assert.Equal("button#s", form.SubmitSelector);
     }
+
+    [Fact]
+    public void DetectLoginForm_IgnoresHiddenPassword() {
+        string html = "<form>" +
+            "<input type='text' id='u'/>" +
+            "<input type='password' id='hidden' style='display:none'/>" +
+            "<input type='password' id='p'/>" +
+            "<button id='s'></button>" +
+            "</form>";
+
+        HtmlFormLogin? form = HtmlLoginParser.Detect(html, "https://example.com/login");
+
+        Assert.NotNull(form);
+        Assert.Equal("input#p", form!.PasswordSelector);
+    }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.LoginParser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.LoginParser.cs
@@ -22,7 +22,9 @@ public static class HtmlLoginParser {
 
         var parser = new global::AngleSharp.Html.Parser.HtmlParser();
         IDocument doc = parser.ParseDocument(html);
-        IElement? pwd = doc.QuerySelector("input[type='password']");
+        IElement? pwd = doc
+            .QuerySelectorAll("input[type='password']")
+            .FirstOrDefault(p => !IsHidden(p));
         if (pwd is null) {
             return null;
         }
@@ -66,6 +68,27 @@ public static class HtmlLoginParser {
         }
 
         return sel;
+    }
+
+    private static bool IsHidden(IElement el) {
+        if (el.HasAttribute("hidden")) {
+            return true;
+        }
+
+        string? aria = el.GetAttribute("aria-hidden");
+        if (string.Equals(aria, "true", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        string? style = el.GetAttribute("style");
+        if (!string.IsNullOrEmpty(style)) {
+            style = style.ToLowerInvariant();
+            if (style.Contains("display:none") || style.Contains("visibility:hidden") || style.Contains("opacity:0")) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string CssEscape(string value) {


### PR DESCRIPTION
## Summary
- skip hidden password inputs when detecting login forms
- test login detection with an extra hidden password field

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878ab0429a0832e81d84a933dd1d933