### PR TITLE
Handle screenshot outfile extensions

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -7,7 +7,7 @@ using PSParseHTML;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>
-/// Cmdlet that captures a screenshot of a web page using a headless browser.
+/// Cmdlet that captures a screenshot of a web page using a headless browser. If <c>OutFile</c> has no extension, one is added based on <see cref="Format"/>.
 /// </summary>
 /// <example>
 /// <code>Save-HTMLScreenshot -Url https://example.com -OutFile page.png</code>
@@ -153,6 +153,16 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
                     null));
                 return;
             }
+        }
+
+        if (!System.IO.Path.HasExtension(OutFile)) {
+            string ext = Format switch {
+                ImageFormat.Jpeg => ".jpg",
+                ImageFormat.Bmp => ".bmp",
+                ImageFormat.Gif => ".gif",
+                _ => ".png"
+            };
+            OutFile += ext;
         }
 
         if (ParameterSetName.EndsWith("Clip", System.StringComparison.OrdinalIgnoreCase)) {

--- a/Tests/Save-HTMLScreenshot.Tests.ps1
+++ b/Tests/Save-HTMLScreenshot.Tests.ps1
@@ -64,6 +64,14 @@ Describe 'Save-HTMLScreenshot' {
         (Test-Path $outfile) | Should -BeTrue
     }
 
+    It 'Adds extension when OutFile has none' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $base = Join-Path $TestDrive 'noext'
+        Save-HTMLScreenshot -Url $uri -OutFile $base -Selector '#loaded' -Format Jpeg
+        (Test-Path "$base.jpg") | Should -BeTrue
+    }
+
     It 'Validates clip parameter range' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri


### PR DESCRIPTION
## Summary
- auto-append extension in `Save-HTMLScreenshot` when `OutFile` has none
- document this behavior in the cmdlet
- test extension auto-addition

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `pwsh -NoProfile -File run_pester.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878ab197268832e9887ac7559e8c7e8