### PR TITLE
Fix HtmlBrowserEngine enum formatting

### DIFF
--- a/Sources/PSParseHTML/Enums/HtmlBrowserEngine.cs
+++ b/Sources/PSParseHTML/Enums/HtmlBrowserEngine.cs
@@ -15,4 +15,5 @@ public enum HtmlBrowserEngine {
     /// <summary>
     /// WebKit browser engine, used by Safari and others.
     /// </summary>
-    WebKit,}
+    WebKit
+}


### PR DESCRIPTION
## Summary
- trim enum entry list for HtmlBrowserEngine
- ensure file ends with a newline

## Testing
- `dotnet restore Sources/PSParseHTML.sln`
- `dotnet build Sources/PSParseHTML.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6878ab2f9e04832eaa15d5780398be56