### PR TITLE
Fix directory creation for Save-HTMLPdf

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlPdf.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Management.Automation;
 using System.Threading.Tasks;
+using System.IO;
+using PSParseHTML;
 
 namespace PSParseHTML.PowerShell;
 
@@ -134,11 +136,16 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
+        string outPath = HtmlUtilities.ResolvePath(OutFile);
+        string? dir = System.IO.Path.GetDirectoryName(outPath);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
         switch (ParameterSetName) {
             case ParameterSetSession:
                 await HtmlBrowser.SavePagePdfAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    OutFile,
+                    outPath,
                     Delay,
                     Selector,
                     Landscape.IsPresent,
@@ -162,7 +169,7 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
             case ParameterSetFile:
                 await HtmlBrowser.SavePagePdfAsync(
                     new System.Uri(System.IO.Path.GetFullPath(Path!)).AbsoluteUri,
-                    OutFile,
+                    outPath,
                     Browser,
                     Clean.IsPresent,
                     Delay,
@@ -190,7 +197,7 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
             default:
                 await HtmlBrowser.SavePagePdfAsync(
                     Url,
-                    OutFile,
+                    outPath,
                     Browser,
                     Clean.IsPresent,
                     Delay,
@@ -219,7 +226,7 @@ public sealed class CmdletSaveHtmlPdf : AsyncPSCmdlet {
 
         if (Open.IsPresent) {
             Process.Start(new ProcessStartInfo {
-                FileName = OutFile,
+                FileName = outPath,
                 UseShellExecute = true,
             });
         }

--- a/Tests/Save-HTMLPdf.Tests.ps1
+++ b/Tests/Save-HTMLPdf.Tests.ps1
@@ -22,4 +22,14 @@ Describe 'Save-HTMLPdf' {
         Save-HTMLPdf -Url $uri -OutFile $outfile -Selector '#loaded' -Landscape -PrintBackground -Format A4 -MarginTop "0.5in" -MarginBottom "0.5in"
         (Test-Path $outfile) | Should -BeTrue
     }
+
+    It 'Creates a PDF file in a new directory' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $folder = Join-Path $TestDrive 'newdir'
+        $outfile = Join-Path $folder 'nested.pdf'
+        Save-HTMLPdf -Url $uri -OutFile $outfile -Selector '#loaded'
+        (Test-Path $outfile) | Should -BeTrue
+        (Test-Path $folder) | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- create output directory before saving PDFs in Save-HTMLPdf cmdlet
- test saving PDFs into new folders

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln -c Release --no-build`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878a9a1b88c832ea8529b57883df101