### PR TITLE
Fix Get-HTMLNetworkLog test

### DIFF
--- a/Tests/Get-HTMLNetworkLog.Tests.ps1
+++ b/Tests/Get-HTMLNetworkLog.Tests.ps1
@@ -1,9 +1,20 @@
 Describe 'Get-HTMLNetworkLog' {
     It 'Captures network traffic from a session' {
-        $path = Join-Path $PSScriptRoot 'Documents/route_page.html'
-        $uri = [System.Uri]::new($path).AbsoluteUri
-        $session = Invoke-HTMLRendering -Url $uri -Session
+        $pagePath = Join-Path $PSScriptRoot 'Documents/route_page.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+
+        $session = Invoke-HTMLRendering -Url 'about:blank' -Session
+        Register-HTMLRoute -Session $session -Pattern '**/data.json' -ScriptBlock {
+            param($route)
+            $route.FulfillAsync([Microsoft.Playwright.RouteFulfillOptions]@{
+                Status = 200
+                ContentType = 'application/json'
+                Body = '{"message":"mock"}'
+            }) | Out-Null
+        }
+        Invoke-HTMLNavigation -Session $session -Url $uri
         Start-Sleep -Milliseconds 500
+
         $log = Get-HTMLNetworkLog -Session $session
         Close-HTMLSession -Session $session
 


### PR DESCRIPTION
## Summary
- intercept route in Get-HTMLNetworkLog.Tests to avoid timeouts

## Testing
- `dotnet restore`
- `dotnet build Sources/PSParseHTML.sln --configuration Release --no-restore`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: downloading Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878bc09785c832e827a43e2478872a6