### PR TITLE
Handle FromFile path in exception message

### DIFF
--- a/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
@@ -79,4 +79,13 @@ public class PreMailerClientFileHelpersTests
             Environment.SetEnvironmentVariable("HTML_FILE_TEST", null);
         }
     }
+
+    [Fact]
+    public void FromFile_MissingFile_ContainsAbsolutePathInMessage()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
+        string resolved = Path.GetFullPath(path);
+        FileNotFoundException ex = Assert.Throws<FileNotFoundException>(() => PreMailerClient.FromFile(path, null));
+        Assert.Contains(resolved, ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -32,7 +32,7 @@ public class PreMailerClient {
     public static PreMailerClient FromFile(string htmlFilePath, PreMailerOptions? options = null) {
         string path = HtmlUtilities.ResolvePath(htmlFilePath);
         if (!File.Exists(path)) {
-            throw new FileNotFoundException($"HTML file not found: {htmlFilePath}", path);
+            throw new FileNotFoundException($"HTML file not found: {path}", path);
         }
         string html = File.ReadAllText(path);
         return new PreMailerClient(html, options);


### PR DESCRIPTION
## Summary
- use resolved path when throwing `FileNotFoundException` in `PreMailerClient.FromFile`
- verify the exception message includes the absolute path

## Testing
- `dotnet test Sources/PSParseHTML.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878c31d5918832ea97218c60e669e9c