### PR TITLE
Add unit test for session disposal

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserCloseSessionTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserCloseSessionTests.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class HtmlBrowserCloseSessionTests
+{
+    [Fact]
+    public async Task CloseSessionAsync_DisposesBrowserObjects()
+    {
+        var playwright = new Mock<IPlaywright>();
+        playwright.Setup(p => p.Dispose()).Verifiable();
+        var browser = new Mock<IBrowser>();
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>()))
+            .Returns(Task.CompletedTask).Verifiable();
+        var context = new Mock<IBrowserContext>();
+        context.Setup(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>()))
+            .Returns(Task.CompletedTask).Verifiable();
+        var page = new Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        await HtmlBrowser.CloseSessionAsync(session, CancellationToken.None);
+
+        playwright.Verify();
+        browser.Verify();
+        context.Verify();
+    }
+}


### PR DESCRIPTION
## Summary
- add `HtmlBrowserCloseSessionTests` to confirm disposing Playwright objects when closing a session

## Testing
- `dotnet test Sources/PSParseHTML.sln -c Release --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878c35675e0832eb02eaf039ee366f0