### PR TITLE
Fix selector escaping for quotes

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlBrowserLoginDetectionTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlBrowserLoginDetectionTests.cs
@@ -59,4 +59,19 @@ public class HtmlBrowserLoginDetectionTests {
         Assert.NotNull(form);
         Assert.Equal("input#p", form!.PasswordSelector);
     }
+
+    [Fact]
+    public void DetectLoginForm_EscapesQuotesInAttributes() {
+        string html = "<form>" +
+            "<input type='text' name=\"user'name\"/>" +
+            "<input type='password' id='p\"ass'/>" +
+            "<button id='login'></button>" +
+            "</form>";
+
+        HtmlFormLogin? form = HtmlLoginParser.Detect(html, "https://example.com/login");
+
+        Assert.NotNull(form);
+        Assert.Equal("input[name='user\\'name']", form!.UsernameSelector);
+        Assert.Equal("input#p\\\"ass", form.PasswordSelector);
+    }
 }

--- a/Sources/PSParseHTML/Playwright/HtmlBrowser.LoginParser.cs
+++ b/Sources/PSParseHTML/Playwright/HtmlBrowser.LoginParser.cs
@@ -58,7 +58,7 @@ public static class HtmlLoginParser {
 
         string? name = el.GetAttribute("name");
         if (!string.IsNullOrEmpty(name)) {
-            return $"{sel}[name='{name.Replace("'", "\\'")}']";
+            return $"{sel}[name='{CssStringEscape(name)}']";
         }
 
         string cls = el.ClassName ?? string.Empty;
@@ -102,4 +102,10 @@ public static class HtmlLoginParser {
         }
         return sb.ToString();
     }
+
+    private static string CssStringEscape(string value) =>
+        value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("'", "\\'");
 }


### PR DESCRIPTION
## Summary
- handle single/double quotes in selector generation
- test login detection when attributes contain quotes

## Testing
- `dotnet build Sources/PSParseHTML.sln --no-restore --verbosity minimal`
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6878c342a784832e9da9f879fe89e71c