### PR TITLE
Fix case-insensitive check for video output

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlVideoRecording.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -130,7 +131,7 @@ public sealed class CmdletStartHtmlVideoRecording : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        if (System.IO.Path.GetExtension(OutFile) != ".webm") {
+        if (!OutFile.EndsWith(".webm", StringComparison.OrdinalIgnoreCase)) {
             throw new PSArgumentException("Only .webm files are supported.", nameof(OutFile));
         }
         string target;

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -18,7 +19,7 @@ public sealed class CmdletStopHtmlVideoRecording : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        if (!string.IsNullOrEmpty(OutFile) && System.IO.Path.GetExtension(OutFile) != ".webm") {
+        if (!string.IsNullOrEmpty(OutFile) && !OutFile.EndsWith(".webm", StringComparison.OrdinalIgnoreCase)) {
             throw new PSArgumentException("Only .webm files are supported.", nameof(OutFile));
         }
 

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -55,4 +55,24 @@ describe 'HTML Video Recording' {
         [math]::Round($lat,0) | Should -Be 40
         $tz | Should -Be 'America/New_York'
     }
+
+    it 'Supports .WebM extension' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $out = Join-Path $TestDrive 'caps.WebM'
+        $session = Start-HTMLVideoRecording -Url $uri -OutFile $out -Width 320 -Height 240
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        Stop-HTMLVideoRecording -Session $session -OutFile $out
+        (Test-Path $out) | Should -BeTrue
+    }
+
+    it 'Supports .webm extension when stopping' {
+        $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
+        $uri = [System.Uri]::new($path).AbsoluteUri
+        $out = Join-Path $TestDrive 'lower.webm'
+        $session = Start-HTMLVideoRecording -Url $uri -OutFile $out -Width 320 -Height 240
+        Invoke-HTMLNavigation -Session $session -Url $uri
+        Stop-HTMLVideoRecording -Session $session -OutFile $out
+        (Test-Path $out) | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- ensure video recording commands validate `.webm` extension case-insensitively
- test Start-/Stop-HTMLVideoRecording with `.webm` and `.WebM`

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Debug --no-restore`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878c33c2dd8832eaf273dabc220b529