### PR TITLE
Remove redundant CompletedTask awaits

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletCompareHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCompareHtml.cs
@@ -32,8 +32,6 @@ public sealed class CmdletCompareHtml : AsyncPSCmdlet {
         foreach (var diff in HtmlDiffer.Compare(referenceContent, differenceContent)) {
             WriteObject(diff);
         }
-
-        await Task.CompletedTask;
     }
 
     private static async Task<string> GetContentAsync(string input) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtml.cs
@@ -79,7 +79,5 @@ public sealed class CmdletConvertFromHtml : AsyncPSCmdlet {
             HtmlDocument doc = HtmlParser.ParseWithHtmlAgilityPack(Content);
             WriteObject(Raw.IsPresent ? doc : doc.DocumentNode);
         }
-
-        await Task.CompletedTask;
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
@@ -101,8 +101,6 @@ public sealed class CmdletConvertFromHtmlAttributes : AsyncPSCmdlet {
                 WriteObject(e.TextContent);
             }
         }
-
-        await Task.CompletedTask;
     }
 
     private async Task<string> DownloadHtmlAsync() {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlForm.cs
@@ -62,8 +62,6 @@ public sealed class CmdletConvertFromHtmlForm : AsyncPSCmdlet {
             }
             WriteObject(output.ToArray(), false);
         }
-
-        await Task.CompletedTask;
     }
 
     private PSObject CreateFormObject(HtmlFormResult result) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
@@ -110,7 +110,6 @@ public sealed class CmdletConvertFromHtmlList : AsyncPSCmdlet {
             }
         }
 
-        await Task.CompletedTask;
     }
 
     private PSObject[] ConvertItems(List<List<string>> items) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -109,8 +109,6 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
             foreach (var tableResult in tables) {
                 WriteObject(CreateTableObject(tableResult));
             }
-
-            await Task.CompletedTask;
         } else {
             // Use the detailed parsing methods but extract only the Data part
             List<HtmlTableResult> detailedTables;
@@ -145,8 +143,6 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
                 }
                 WriteObject(tableArrays.ToArray(), false);
             }
-
-            await Task.CompletedTask;
         }
     }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -88,7 +88,5 @@ public sealed class CmdletConvertHtmlToText : AsyncPSCmdlet {
         } else {
             WriteObject(text);
         }
-
-        await Task.CompletedTask;
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletExportHtmlOutline.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportHtmlOutline.cs
@@ -57,7 +57,6 @@ public sealed class CmdletExportHtmlOutline : AsyncPSCmdlet {
         string outPath = HtmlUtilities.ResolvePath(Path);
 #if NETSTANDARD2_0 || NETFRAMEWORK
         System.IO.File.WriteAllText(outPath, json);
-        await Task.CompletedTask;
 #else
         await System.IO.File.WriteAllTextAsync(outPath, json, CancelToken).ConfigureAwait(false);
 #endif

--- a/Sources/PSParseHTML.PowerShell/CmdletMeasureHtmlDocument.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletMeasureHtmlDocument.cs
@@ -55,6 +55,5 @@ public sealed class CmdletMeasureHtmlDocument : AsyncPSCmdlet {
         };
 
         WriteObject(stats);
-        await Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- clean up leftover `await Task.CompletedTask` lines at the end of `ProcessRecordAsync`

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: PlaywrightException)*

------
https://chatgpt.com/codex/tasks/task_e_6878c32558cc832eb1f3df29f87d7043