### PR TITLE
Fix tests using offline HTML

### DIFF
--- a/Tests/ConvertFrom-HtmlAttributes.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlAttributes.Tests.ps1
@@ -1,8 +1,11 @@
 Describe -Name 'ConvertFrom-HTMLAttributes' {
     It -Name 'Given a valid URL - Should return the content of the tag' {
-        $Content = ConvertFrom-HTMLAttributes -Tag 'em' -Url "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em"
-        $Content | Should -Contain '<em>'
-        $Content = ConvertFrom-HTMLAttributes -Tag 'em' -Url "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em"
-        $Content | Should -Match '<em>'
+        $Path = Join-Path $PSScriptRoot 'Documents/em_sample.html'
+        $Html = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+
+        $Content = ConvertFrom-HTMLAttributes -Content $Html -Tag 'em'
+        $Content | Should -Be 'awesome'
+        $Content = ConvertFrom-HTMLAttributes -Content $Html -Tag 'em'
+        $Content | Should -Be 'awesome'
     }
 }

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -77,7 +77,9 @@
     }
 
     It 'ConvertFrom-HTML cmdlet parses example.com' {
-        $doc = ConvertFrom-HTML -Url 'https://example.com'
+        $Path = Join-Path $PSScriptRoot 'Documents/em_sample.html'
+        $Html = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+        $doc = ConvertFrom-HTML -Content $Html
         $doc | Should -Not -BeNullOrEmpty
     }
 

--- a/Tests/ConvertFrom-HtmlTag.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTag.Tests.ps1
@@ -1,13 +1,18 @@
 Describe -Name 'ConvertFrom-HTMLTag' {
     It -Name 'Given a valid URL - Should return the content of the tag' {
-        $Content = ConvertFrom-HTMLTag -Tag 'em' -Url "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em"
-        $Content | Should -Contain '<em>'
-        $Content = ConvertFrom-HTMLTag -Tag 'em' -Url "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em"
-        $Content | Should -Match '<em>'
+        $Path = Join-Path $PSScriptRoot 'Documents/em_sample.html'
+        $Html = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+
+        $Content = ConvertFrom-HTMLTag -Content $Html -Tag 'em'
+        $Content | Should -Be 'awesome'
+        $Content = ConvertFrom-HTMLTag -Content $Html -Tag 'em'
+        $Content | Should -Be 'awesome'
     }
 
     It 'ConvertFrom-HTML cmdlet works' {
-        $doc = ConvertFrom-HTML -Url 'https://example.com'
+        $Path = Join-Path $PSScriptRoot 'Documents/em_sample.html'
+        $Html = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+        $doc = ConvertFrom-HTML -Content $Html
         $doc | Should -Not -BeNullOrEmpty
     }
 }

--- a/Tests/Documents/em_sample.html
+++ b/Tests/Documents/em_sample.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>PowerShell is <em>awesome</em>!</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add local HTML file with em tag
- update tag and attribute tests to use local file
- avoid network request in HTML table test

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Path Tests/ConvertFrom-HtmlTag.Tests.ps1 -Output Detailed"`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Path Tests/ConvertFrom-HtmlAttributes.Tests.ps1 -Output Detailed"`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Path Tests/ConvertFrom-HtmlTable.Tests.ps1 -Output Detailed"`


------
https://chatgpt.com/codex/tasks/task_e_6878c78b8bbc832e9273b62462de1593