### PR TITLE
Ensure Save-HTMLAttachment directory exists

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlAttachment.cs
@@ -64,15 +64,18 @@ public sealed class CmdletSaveHtmlAttachment : AsyncPSCmdlet {
         using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(CancelToken, CancellationToken);
         CancellationToken token = linkedCts.Token;
 
+        string dir = HtmlUtilities.ResolvePath(Path);
+        Directory.CreateDirectory(dir);
+
         IAsyncEnumerable<string> files = ParameterSetName switch {
             ParameterSetSession => HtmlBrowser.SavePageDownloadsAsync(
                 (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                HtmlUtilities.ResolvePath(Path),
+                dir,
                 Filter,
                 token),
             _ => HtmlBrowser.SavePageDownloadsAsync(
                 Url,
-                HtmlUtilities.ResolvePath(Path),
+                dir,
                 Browser,
                 Clean.IsPresent,
                 Filter,

--- a/Tests/Save-HTMLAttachment.Directory.Tests.ps1
+++ b/Tests/Save-HTMLAttachment.Directory.Tests.ps1
@@ -1,0 +1,21 @@
+Describe 'Save-HTMLAttachment path creation' {
+    It 'Creates destination directory when missing' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/download.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $dest = Join-Path $TestDrive 'missing' 'dl'
+        [array] $files = Save-HTMLAttachment -Url $uri -Path $dest
+        Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
+        Test-Path $dest | Should -BeTrue
+        $files | Should -Contain (Join-Path $dest 'download.txt')
+    }
+
+    It 'Creates destination directory when missing for session input' {
+        $pagePath = Join-Path $PSScriptRoot 'Documents/download.html'
+        $uri = [System.Uri]::new($pagePath).AbsoluteUri
+        $dest = Join-Path $TestDrive 'missing' 'session'
+        Invoke-HTMLRendering -Url $uri -Session |
+            Save-HTMLAttachment -Path $dest
+        Test-Path (Join-Path $dest 'download.txt') | Should -BeTrue
+        Test-Path $dest | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- create destination directory in `CmdletSaveHtmlAttachment`
- add tests for folder creation

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Script ./Tests/Save-HTMLAttachment.Directory.Tests.ps1 -Output Detailed"` *(fails: Playwright download)*

------
https://chatgpt.com/codex/tasks/task_e_6878c34c34f8832ea48b02841e09b2a0