### PR TITLE
Add XML doc comments and generate docs

### DIFF
--- a/Sources/PSParseHTML/HtmlParser.cs
+++ b/Sources/PSParseHTML/HtmlParser.cs
@@ -295,7 +295,7 @@ public static class HtmlParser {
     }
 
     /// <summary>
-    /// Extracts <meta> tag information from HTML markup.
+    /// Extracts <c>&lt;meta&gt;</c> tag information from HTML markup.
     /// </summary>
     /// <param name="html">HTML content containing meta tags.</param>
     /// <returns>List of meta tag name/content pairs.</returns>
@@ -304,7 +304,7 @@ public static class HtmlParser {
     }
 
     /// <summary>
-    /// Extracts <meta> tag information from a web page.
+    /// Extracts <c>&lt;meta&gt;</c> tag information from a web page.
     /// </summary>
     /// <param name="url">URL of the page to download.</param>
     /// <param name="client">Optional HTTP client.</param>

--- a/Sources/PSParseHTML/HtmlParserFromMeta.cs
+++ b/Sources/PSParseHTML/HtmlParserFromMeta.cs
@@ -17,7 +17,7 @@ public static class HtmlParserFromMeta {
     /// <returns>List of meta tags.</returns>
     /// <example>
     /// <code>
-    /// var tags = HtmlParserFromMeta.ParseMetaTags("<meta name='a' content='b'>");
+    /// var tags = HtmlParserFromMeta.ParseMetaTags("&lt;meta name='a' content='b'&gt;");
     /// </code>
     /// </example>
     public static List<HtmlMetaTag> ParseMetaTags(string html) {

--- a/Sources/PSParseHTML/HtmlScriptRunner.cs
+++ b/Sources/PSParseHTML/HtmlScriptRunner.cs
@@ -19,7 +19,7 @@ public static class HtmlScriptRunner {
     /// <returns>Value returned by the script.</returns>
     /// <example>
     /// <code>
-    /// var result = await HtmlScriptRunner.RunAsync<int>("<div id='a'></div>",
+    /// var result = await HtmlScriptRunner.RunAsync&lt;int&gt;("&lt;div id='a'&gt;&lt;/div&gt;",
     ///     "document.getElementById('a').textContent = '1'; return 1;");
     /// </code>
     /// </example>

--- a/Sources/PSParseHTML/Models/HtmlResourceLink.cs
+++ b/Sources/PSParseHTML/Models/HtmlResourceLink.cs
@@ -10,9 +10,24 @@ namespace PSParseHTML;
 /// </summary>
 public enum HtmlResourceType
 {
+    /// <summary>
+    /// JavaScript code referenced via a <c>&lt;script&gt;</c> element.
+    /// </summary>
     Script,
+
+    /// <summary>
+    /// JavaScript code defined directly within the HTML document.
+    /// </summary>
     InlineScript,
+
+    /// <summary>
+    /// Cascading Style Sheet referenced via a <c>&lt;link&gt;</c> element.
+    /// </summary>
     Css,
+
+    /// <summary>
+    /// Cascading Style Sheet defined directly within the HTML document.
+    /// </summary>
     InlineCss
 }
 

--- a/Sources/PSParseHTML/PSParseHTML.csproj
+++ b/Sources/PSParseHTML/PSParseHTML.csproj
@@ -10,13 +10,14 @@
         <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.3.0" />
-        <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.154" />
-        <PackageReference Include="AngleSharp.Diffing" Version="1.0.0" />
-        <PackageReference Include="AngleSharp.Js" Version="1.0.0-beta.43" />
+  <ItemGroup>
+      <PackageReference Include="AngleSharp" Version="1.3.0" />
+      <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.154" />
+      <PackageReference Include="AngleSharp.Diffing" Version="1.0.0" />
+      <PackageReference Include="AngleSharp.Js" Version="1.0.0-beta.43" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
         <PackageReference Include="Jsbeautifier" Version="0.0.1" />
         <PackageReference Include="NUglify" Version="1.21.15" />
@@ -25,10 +26,13 @@
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
-        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
-        <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
-        <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
-    </ItemGroup>
+      <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
+      <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+      <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3">
+          <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <Using Include="System.Net.Http" />

--- a/Sources/PSParseHTML/PreMailer/PreMailerOptions.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerOptions.cs
@@ -10,7 +10,7 @@ public class PreMailerOptions {
     /// <summary>Base URL for resolving relative CSS links.</summary>
     public Uri? BaseUri { get; set; }
 
-    /// <summary>Removes <style> elements after inlining.</summary>
+    /// <summary>Removes <c>&lt;style&gt;</c> elements after inlining.</summary>
     public bool RemoveStyleElements { get; set; }
 
     /// <summary>CSS selector of elements to ignore when inlining.</summary>
@@ -38,7 +38,7 @@ public class PreMailerOptions {
     public bool UseEmailFormatter { get; set; }
 
     /// <summary>
-    /// When enabled, CSS from <link> tags will be downloaded and inlined.
+    /// When enabled, CSS from <c>&lt;link&gt;</c> tags will be downloaded and inlined.
     /// </summary>
     public bool DownloadRemoteCss { get; set; }
 


### PR DESCRIPTION
## Summary
- enable XML documentation build for main library
- document HtmlResourceType enum values
- fix invalid XML samples in HtmlParser, HtmlParserFromMeta and HtmlScriptRunner
- escape HTML element tags in PreMailerOptions examples

## Testing
- `dotnet build Sources/PSParseHTML.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6878d39cb790832e87fd0655475b8fb4