### PR TITLE
Fix Save-HTMLAttachment streaming test

### DIFF
--- a/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
+++ b/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
@@ -2,6 +2,20 @@ Describe 'Save-HTMLAttachment streaming' {
     It 'Outputs file paths as downloads complete' {
         $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', '8010' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
         Start-Sleep -Seconds 1
+        $timeout = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($true) {
+            try {
+                $socket = New-Object Net.Sockets.TcpClient
+                $socket.Connect('127.0.0.1', 8010)
+                $socket.Dispose()
+                break
+            } catch {
+                if ($timeout.Elapsed -gt [TimeSpan]::FromSeconds(10)) {
+                    throw 'HTTP server failed to start.'
+                }
+                Start-Sleep -Milliseconds 500
+            }
+        }
         try {
             $uri = 'http://localhost:8010/multi_download.html'
             $dest = Join-Path $TestDrive 'stream'


### PR DESCRIPTION
## Summary
- wait for local HTTP server in Save-HTMLAttachment streaming test

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release -v minimal`
- `dotnet test Sources/PSParseHTML.sln -c Release -v minimal --no-build`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Path 'Tests/Save-HTMLAttachment.Streaming.Tests.ps1' -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_e_6878dae2f510832eb24c23b125e73673