### PR TITLE
Add cancellation support to PreMailer

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeEmail.cs
@@ -145,10 +145,10 @@ public sealed class CmdletOptimizeEmail : AsyncPSCmdlet {
 
         PreMailerResult result = ParameterSetName == "File"
             ? await PreMailerClient
-                .MoveCssInlineFromFileAsync(Path, options)
+                .MoveCssInlineFromFileAsync(Path, options, CancelToken)
                 .ConfigureAwait(false)
             : await PreMailerClient
-                .MoveCssInlineAsync(Body, options)
+                .MoveCssInlineAsync(Body, options, CancelToken)
                 .ConfigureAwait(false);
 
         WriteObject(result.Html);

--- a/Sources/PSParseHTML.Tests/PreMailerClientAsyncTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientAsyncTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using PSParseHTML;
 using Xunit;
@@ -14,7 +15,7 @@ public class PreMailerClientAsyncTests
     public async Task MoveCssInlineAsync_RemovesStyleElements_WhenEnabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = true };
-        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options, CancellationToken.None);
         Assert.DoesNotContain("<style", result.Html, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -26,8 +27,35 @@ public class PreMailerClientAsyncTests
         await File.WriteAllTextAsync(path, HtmlWithMediaQuery);
         try
         {
-            PreMailerResult result = await PreMailerClient.MoveCssInlineFromFileAsync(path, options);
+            PreMailerResult result = await PreMailerClient.MoveCssInlineFromFileAsync(path, options, CancellationToken.None);
             Assert.DoesNotContain("<style", result.Html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task MoveCssInlineAsync_CanceledToken_Throws()
+    {
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, null, cts.Token));
+    }
+
+    [Fact]
+    public async Task MoveCssInlineFromFileAsync_CanceledToken_Throws()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".html");
+        await File.WriteAllTextAsync(path, HtmlWithMediaQuery);
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+        try
+        {
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => PreMailerClient.MoveCssInlineFromFileAsync(path, null, cts.Token));
         }
         finally
         {

--- a/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientFileHelpersTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -35,7 +36,7 @@ public class PreMailerClientFileHelpersTests
         try
         {
             PreMailerResult syncResult = PreMailerClient.MoveCssInlineFromFile(path, options);
-            PreMailerResult asyncResult = await PreMailerClient.MoveCssInlineFromFileAsync(path, options);
+            PreMailerResult asyncResult = await PreMailerClient.MoveCssInlineFromFileAsync(path, options, CancellationToken.None);
             Assert.Equal(syncResult.Html, asyncResult.Html);
             Assert.DoesNotContain("<style", asyncResult.Html, StringComparison.OrdinalIgnoreCase);
         }

--- a/Sources/PSParseHTML.Tests/PreMailerClientRemoteCssAnalyticsTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientRemoteCssAnalyticsTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -61,7 +62,7 @@ public class PreMailerClientRemoteCssAnalyticsTests
 
         try
         {
-            PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(html, options);
+            PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(html, options, CancellationToken.None);
             Assert.Contains("style=\"font-size: 42px\"", result.Html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("style=\"color: red\"", result.Html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("utm_source=newsletter", result.Html);

--- a/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientTests.cs
@@ -1,4 +1,5 @@
 using PSParseHTML;
+using System.Threading;
 using Xunit;
 
 namespace PSParseHTML.Tests;
@@ -11,7 +12,7 @@ public class PreMailerClientTests
     public async Task MoveCssInline_RemovesStyleElements_WhenEnabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = true };
-        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options, CancellationToken.None);
         Assert.DoesNotContain("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }
 
@@ -19,7 +20,7 @@ public class PreMailerClientTests
     public async Task MoveCssInline_PreservesStyleElements_WhenDisabled()
     {
         var options = new PreMailerOptions { RemoveStyleElements = false };
-        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options, CancellationToken.None);
         Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }
 
@@ -31,7 +32,7 @@ public class PreMailerClientTests
             RemoveStyleElements = true,
             PreserveMediaQueries = true
         };
-        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options);
+        PreMailerResult result = await PreMailerClient.MoveCssInlineAsync(HtmlWithMediaQuery, options, CancellationToken.None);
         Assert.Contains("@media", result.Html, System.StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<style", result.Html, System.StringComparison.OrdinalIgnoreCase);
     }

--- a/Sources/PSParseHTML/HtmlUtilities.cs
+++ b/Sources/PSParseHTML/HtmlUtilities.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -44,15 +45,15 @@ public static class HtmlUtilities {
     /// <param name="path">Path to the file.</param>
     /// <returns>File contents.</returns>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
-    public static async Task<string> ReadFileCheckedAsync(string path) {
+    public static async Task<string> ReadFileCheckedAsync(string path, CancellationToken cancellationToken = default) {
         string fullPath = ResolvePath(path);
         if (!File.Exists(fullPath)) {
             throw new FileNotFoundException($"File not found: {path}", fullPath);
         }
 #if NETSTANDARD2_0 || NETFRAMEWORK
-        return await Task.Run(() => File.ReadAllText(fullPath)).ConfigureAwait(false);
+        return await Task.Run(() => File.ReadAllText(fullPath), cancellationToken).ConfigureAwait(false);
 #else
-        return await File.ReadAllTextAsync(fullPath).ConfigureAwait(false);
+        return await File.ReadAllTextAsync(fullPath, cancellationToken).ConfigureAwait(false);
 #endif
     }
 
@@ -62,11 +63,12 @@ public static class HtmlUtilities {
     /// <param name="client">HttpClient to use for the request.</param>
     /// <param name="url">URL to download from.</param>
     /// <returns>Content as a string with proper encoding.</returns>
-    public static async Task<string> GetStringWithProperEncodingAsync(HttpClient client, string url) {
-        using var response = await client.GetAsync(url).ConfigureAwait(false);
+    public static async Task<string> GetStringWithProperEncodingAsync(HttpClient client, string url, CancellationToken cancellationToken = default) {
+        using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Try to get encoding from Content-Type header
         var contentType = response.Content.Headers.ContentType;

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using PreMailer.Net;
@@ -139,7 +140,7 @@ public class PreMailerClient {
     /// <summary>
     /// Asynchronously processes the HTML and returns the result.
     /// </summary>
-    public async Task<PreMailerResult> MoveCssInlineAsync() {
+    public async Task<PreMailerResult> MoveCssInlineAsync(CancellationToken cancellationToken = default) {
         try {
             string cssContent = Options.Css ?? string.Empty;
             string htmlToProcess = _html;
@@ -168,14 +169,14 @@ public class PreMailerClient {
                         if (uri.IsFile) {
                             string localPath = NormalizeFileUriPath(uri);
 #if NETSTANDARD2_0 || NETFRAMEWORK
-                            cssContent += await Task.Run(() => File.ReadAllText(localPath)).ConfigureAwait(false);
+                            cssContent += await Task.Run(() => File.ReadAllText(localPath), cancellationToken).ConfigureAwait(false);
 #else
-                            cssContent += await File.ReadAllTextAsync(localPath).ConfigureAwait(false);
+                            cssContent += await File.ReadAllTextAsync(localPath, cancellationToken).ConfigureAwait(false);
 #endif
                         } else if (uri.IsAbsoluteUri) {
                             using HttpClient client = new();
                             cssContent += await HtmlUtilities
-                                .GetStringWithProperEncodingAsync(client, uri.ToString())
+                                .GetStringWithProperEncodingAsync(client, uri.ToString(), cancellationToken)
                                 .ConfigureAwait(false);
                         }
                     } catch (Exception ex) {
@@ -188,7 +189,7 @@ public class PreMailerClient {
 
             htmlToProcess = document.DocumentElement.OuterHtml;
             if (!string.IsNullOrEmpty(Options.CssFilePath)) {
-                cssContent += await HtmlUtilities.ReadFileCheckedAsync(Options.CssFilePath!).ConfigureAwait(false);
+                cssContent += await HtmlUtilities.ReadFileCheckedAsync(Options.CssFilePath!, cancellationToken).ConfigureAwait(false);
             }
 
             PreMailer.Net.PreMailer preMailer = Options.BaseUri != null
@@ -252,17 +253,17 @@ public class PreMailerClient {
     /// </summary>
     /// <param name="html">HTML markup to process.</param>
     /// <param name="options">Optional processing options.</param>
-    public static Task<PreMailerResult> MoveCssInlineAsync(string html, PreMailerOptions? options = null)
-        => FromHtml(html, options).MoveCssInlineAsync();
+    public static Task<PreMailerResult> MoveCssInlineAsync(string html, PreMailerOptions? options = null, CancellationToken cancellationToken = default)
+        => FromHtml(html, options).MoveCssInlineAsync(cancellationToken);
 
     /// <summary>
     /// Asynchronously processes a HTML file using the provided options.
     /// </summary>
     /// <param name="htmlFilePath">Path to the HTML file.</param>
     /// <param name="options">Optional processing options.</param>
-    public static async Task<PreMailerResult> MoveCssInlineFromFileAsync(string htmlFilePath, PreMailerOptions? options = null) {
-        string html = await HtmlUtilities.ReadFileCheckedAsync(htmlFilePath).ConfigureAwait(false);
-        return await MoveCssInlineAsync(html, options).ConfigureAwait(false);
+    public static async Task<PreMailerResult> MoveCssInlineFromFileAsync(string htmlFilePath, PreMailerOptions? options = null, CancellationToken cancellationToken = default) {
+        string html = await HtmlUtilities.ReadFileCheckedAsync(htmlFilePath, cancellationToken).ConfigureAwait(false);
+        return await MoveCssInlineAsync(html, options, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- let PreMailer client async methods take a `CancellationToken`
- propagate cancellation token through file reads and HTTP requests
- forward cmdlet cancellation token to PreMailer client
- test cancellation behaviour

## Testing
- `dotnet test Sources/PSParseHTML.Tests/PSParseHTML.Tests.csproj` *(fails: unable to restore packages)*
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6878db99b784832ea6561cd6422432d1