### PR TITLE
Add CancellationToken support

### DIFF
--- a/Sources/PSParseHTML.Tests/HtmlUtilitiesHttpHandlerTests.cs
+++ b/Sources/PSParseHTML.Tests/HtmlUtilitiesHttpHandlerTests.cs
@@ -46,4 +46,13 @@ public class HtmlUtilitiesHttpHandlerTests
         string result = await HtmlUtilities.GetStringWithProperEncodingAsync(client, "http://localhost/");
         Assert.Equal("Hello", result);
     }
+
+    [Fact]
+    public async Task GetStringWithProperEncodingAsync_CanBeCancelled()
+    {
+        using HttpClient client = new(new StaticResponseHandler("Hello", "text/plain", "utf-8"), false);
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => HtmlUtilities.GetStringWithProperEncodingAsync(client, "http://localhost/", cts.Token));
+    }
 }

--- a/Sources/PSParseHTML/HtmlFormSubmitter.cs
+++ b/Sources/PSParseHTML/HtmlFormSubmitter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -47,7 +48,7 @@ public static class HtmlFormSubmitter {
     /// <param name="fields">Field values keyed by name.</param>
     /// <param name="client">Optional HttpClient instance.</param>
     /// <returns>Response body as string.</returns>
-    public static async Task<string> SubmitAsync(string actionUrl, string? method, IDictionary<string, string> fields, HttpClient? client = null) {
+    public static async Task<string> SubmitAsync(string actionUrl, string? method, IDictionary<string, string> fields, HttpClient? client = null, CancellationToken cancellationToken = default) {
         if (actionUrl == null) {
             throw new ArgumentNullException(nameof(actionUrl));
         }
@@ -60,12 +61,12 @@ public static class HtmlFormSubmitter {
         if (method.Equals("GET", StringComparison.OrdinalIgnoreCase)) {
             string query = string.Join("&", fields.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
             string url = actionUrl.Contains("?") ? $"{actionUrl}&{query}" : $"{actionUrl}?{query}";
-            using HttpResponseMessage response = await http.GetAsync(url).ConfigureAwait(false);
+            using HttpResponseMessage response = await http.GetAsync(url, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         } else {
             using var content = new FormUrlEncodedContent(fields);
-            using HttpResponseMessage response = await http.PostAsync(actionUrl, content).ConfigureAwait(false);
+            using HttpResponseMessage response = await http.PostAsync(actionUrl, content, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }

--- a/Sources/PSParseHTML/HtmlParser.cs
+++ b/Sources/PSParseHTML/HtmlParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -42,12 +43,12 @@ public static class HtmlParser {
     /// IDocument doc = await HtmlParser.ParseUrlWithAngleSharpAsync("https://example.com");
     /// </code>
     /// </example>
-    public static async Task<IDocument> ParseUrlWithAngleSharpAsync(string url, HttpClient? client = null) {
+    public static async Task<IDocument> ParseUrlWithAngleSharpAsync(string url, HttpClient? client = null, CancellationToken cancellationToken = default) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
-        string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
+        string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url, cancellationToken).ConfigureAwait(false);
         return ParseWithAngleSharp(content);
     }
 
@@ -70,12 +71,12 @@ public static class HtmlParser {
     /// </summary>
     /// <param name="url">URL of the page to download.</param>
     /// <returns>The parsed <see cref="HtmlDocument"/>.</returns>
-    public static async Task<HtmlDocument> ParseUrlWithHtmlAgilityPackAsync(string url, HttpClient? client = null) {
+    public static async Task<HtmlDocument> ParseUrlWithHtmlAgilityPackAsync(string url, HttpClient? client = null, CancellationToken cancellationToken = default) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
-        string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
+        string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url, cancellationToken).ConfigureAwait(false);
         return ParseWithHtmlAgilityPack(content);
     }
 

--- a/Sources/PSParseHTML/HtmlUtilities.cs
+++ b/Sources/PSParseHTML/HtmlUtilities.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PSParseHTML;
@@ -62,8 +63,8 @@ public static class HtmlUtilities {
     /// <param name="client">HttpClient to use for the request.</param>
     /// <param name="url">URL to download from.</param>
     /// <returns>Content as a string with proper encoding.</returns>
-    public static async Task<string> GetStringWithProperEncodingAsync(HttpClient client, string url) {
-        using var response = await client.GetAsync(url).ConfigureAwait(false);
+    public static async Task<string> GetStringWithProperEncodingAsync(HttpClient client, string url, CancellationToken cancellationToken = default) {
+        using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add `CancellationToken` parameter to `GetStringWithProperEncodingAsync`
- propagate token through `HtmlFormSubmitter` and `HtmlParser`
- cover cancellation with unit test

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release`
- `dotnet test Sources/PSParseHTML.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6878dba207d0832eb4ccca091e315408