### PR TITLE
Fix NormalizeFileUriPath handling of slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Examples/Output/*
 Lib/*
 dotnet-install.sh
 packages-microsoft-prod.deb
+.dotnet/

--- a/Sources/PSParseHTML.Tests/PreMailerClientPathTests.cs
+++ b/Sources/PSParseHTML.Tests/PreMailerClientPathTests.cs
@@ -42,4 +42,34 @@ public class PreMailerClientPathTests
             Assert.Equal(@"\tmp\test.css", normalized);
         }
     }
+
+    [Fact]
+    public void NormalizeFileUriPath_UncPaths_TrailingSlash()
+    {
+        Uri uri = new("file:////server/share/folder/");
+        string normalized = InvokeNormalize(uri);
+        if (Path.DirectorySeparatorChar == '/')
+        {
+            Assert.Equal("/server/share/folder/", normalized);
+        }
+        else
+        {
+            Assert.Equal(@"\\server\share\folder\", normalized);
+        }
+    }
+
+    [Fact]
+    public void NormalizeFileUriPath_LocalPaths_TrailingSlash()
+    {
+        Uri uri = new("file:///tmp/folder/");
+        string normalized = InvokeNormalize(uri);
+        if (Path.DirectorySeparatorChar == '/')
+        {
+            Assert.Equal("/tmp/folder/", normalized);
+        }
+        else
+        {
+            Assert.Equal(@"\tmp\folder\", normalized);
+        }
+    }
 }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -416,7 +416,7 @@ public class PreMailerClient {
 
         // Preserve trailing slash if present in the original URI
         bool endsWithSlash = uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
-        if (endsWithSlash && !path.EndsWith(desired))
+        if (endsWithSlash && !path.EndsWith(desired.ToString()))
         {
             path += desired;
         }

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -395,28 +395,32 @@ public class PreMailerClient {
 
     private static string NormalizeFileUriPath(Uri uri)
     {
-        if (uri.IsUnc)
+        if (!uri.IsFile)
         {
-            string[] segments = uri.AbsolutePath
-                .TrimStart('/')
-                .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-            string path = Path.Combine(segments);
-
-            string prefix = Path.DirectorySeparatorChar == '\\'
-                ? new string(Path.DirectorySeparatorChar, 2) + uri.Host
-                : Path.DirectorySeparatorChar + uri.Host;
-
-            return Path.Combine(prefix, path);
+            throw new ArgumentException("URI must be a file path", nameof(uri));
         }
 
-        string localPath = uri.LocalPath;
-        if (Path.DirectorySeparatorChar == '\\')
+        string path = uri.LocalPath;
+
+        // Normalize directory separators
+        char desired = Path.DirectorySeparatorChar;
+        char alt = desired == '/' ? '\\' : '/';
+        path = path.Replace(alt, desired);
+
+        // UNC paths need special handling on Unix where LocalPath starts with
+        // double separators
+        if (uri.IsUnc && desired == '/')
         {
-            localPath = localPath.Length >= 2 && localPath[1] == ':'
-                ? localPath.Replace('/', '\\')
-                : "\\" + localPath.TrimStart('/').Replace('/', '\\');
+            path = "/" + path.TrimStart(desired);
         }
 
-        return localPath;
+        // Preserve trailing slash if present in the original URI
+        bool endsWithSlash = uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+        if (endsWithSlash && !path.EndsWith(desired))
+        {
+            path += desired;
+        }
+
+        return path;
     }
 }


### PR DESCRIPTION
## Summary
- improve normalization logic for file URIs
- verify UNC and local paths with trailing slashes

## Testing
- `dotnet test Sources/PSParseHTML.sln`
- `pwsh -File PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878dba7cf24832eb7f0dac7dbe28d57