### PR TITLE
Add proxy credential validation

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtml.cs
@@ -60,6 +60,7 @@ public sealed class CmdletConvertFromHtml : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);
             if (Engine == HtmlParserEngine.AngleSharp) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
@@ -76,6 +76,7 @@ public sealed class CmdletConvertFromHtmlAttributes : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         IEnumerable<IElement> elements = ParameterSetName switch {
             ParameterSetUrl => HtmlParserExtensions.GetElements(
                 await DownloadHtmlAsync().ConfigureAwait(false),

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlForm.cs
@@ -41,6 +41,7 @@ public sealed class CmdletConvertFromHtmlForm : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlFormResult> forms;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlList.cs
@@ -59,6 +59,7 @@ public sealed class CmdletConvertFromHtmlList : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlListResult> results;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
@@ -36,6 +36,7 @@ public sealed class CmdletConvertFromHtmlMeta : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlMetaTag> tags;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
@@ -36,6 +36,7 @@ public sealed class CmdletConvertFromHtmlMicrodata : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlMicrodataItem> items;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlOpenGraph.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlOpenGraph.cs
@@ -36,6 +36,7 @@ public sealed class CmdletConvertFromHtmlOpenGraph : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         HtmlOpenGraph graph;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -87,6 +87,7 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         if (IncludeMetadata.IsPresent) {
             List<HtmlTableResult> tables;
             if (ParameterSetName == ParameterSetUrl) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -69,6 +69,7 @@ public sealed class CmdletConvertHtmlToText : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         string text = ParameterSetName switch {
             ParameterSetFile => HtmlParserToText.ConvertFileToText(HtmlUtilities.ResolvePath(Path)),
             ParameterSetUrl => HtmlParserToText.ConvertToText(

--- a/Sources/PSParseHTML.PowerShell/CmdletExportHtmlOutline.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportHtmlOutline.cs
@@ -44,6 +44,7 @@ public sealed class CmdletExportHtmlOutline : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlOutlineItem> outline;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlFormField.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlFormField.cs
@@ -33,6 +33,7 @@ public sealed class CmdletGetHtmlFormField : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlFormField> fields;
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlInteractable.cs
@@ -113,6 +113,7 @@ public sealed class CmdletGetHtmlInteractable : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlInteractableInfo> list;
         string? pUser = ProxyCredential?.UserName;
         string? pPass = ProxyCredential?.GetNetworkCredential().Password;

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlLoginForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlLoginForm.cs
@@ -68,6 +68,7 @@ public sealed class CmdletGetHtmlLoginForm : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         HtmlFormLogin? result;
         string? pUser = ProxyCredential?.UserName;
         string? pPass = ProxyCredential?.GetNetworkCredential().Password;

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlResource.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlResource.cs
@@ -61,6 +61,7 @@ public sealed class CmdletGetHtmlResource : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         List<HtmlResourceLink> links;
         HttpClient? client = null;
         switch (ParameterSetName) {

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -136,6 +136,7 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         string? user = Credential?.UserName ?? Username;
         string? pass = Credential?.GetNetworkCredential().Password ?? Password;
         string? pUser = ProxyCredential?.UserName;

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlScreenshot.cs
@@ -138,6 +138,7 @@ public sealed class CmdletSaveHtmlScreenshot : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
         string? pUser = ProxyCredential?.UserName;
         string? pPass = ProxyCredential?.GetNetworkCredential().Password;

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlHttpClientOption.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlHttpClientOption.cs
@@ -33,6 +33,7 @@ public sealed class CmdletSetHtmlHttpClientOption : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         if (TimeoutSeconds < -1) {
             ThrowTerminatingError(new ErrorRecord(
                 new PSArgumentOutOfRangeException(nameof(TimeoutSeconds), TimeoutSeconds, "TimeoutSeconds cannot be less than -1."),

--- a/Sources/PSParseHTML.PowerShell/CmdletSubmitHtmlForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSubmitHtmlForm.cs
@@ -48,6 +48,7 @@ public sealed class CmdletSubmitHtmlForm : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        ValidateProxy(Proxy, ProxyCredential);
         string action = Form.Properties["Action"]?.Value as string ?? string.Empty;
         string? method = Form.Properties["Method"]?.Value as string;
 

--- a/Sources/PSParseHTML.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/Sources/PSParseHTML.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -226,6 +226,23 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     }
 
     /// <summary>
+    /// Validates proxy parameters.
+    /// Throws a terminating error if <paramref name="proxyCredential"/> is provided
+    /// without specifying <paramref name="proxy"/>.
+    /// </summary>
+    /// <param name="proxy">Proxy server address.</param>
+    /// <param name="proxyCredential">Credential for the proxy.</param>
+    protected void ValidateProxy(string? proxy, PSCredential? proxyCredential) {
+        if (proxyCredential != null && string.IsNullOrWhiteSpace(proxy)) {
+            ThrowTerminatingError(new ErrorRecord(
+                new PSArgumentException("ProxyCredential requires Proxy to be specified."),
+                "ProxyCredentialWithoutProxy",
+                ErrorCategory.InvalidArgument,
+                proxyCredential));
+        }
+    }
+
+    /// <summary>
     /// Throws a <see cref="PipelineStoppedException"/> if the cmdlet has been stopped.
     /// </summary>
     internal void ThrowIfStopped() {

--- a/Tests/Proxy.Tests.ps1
+++ b/Tests/Proxy.Tests.ps1
@@ -7,5 +7,12 @@ Describe 'Proxy parameters' {
             $params | Should -Contain 'ProxyCredential'
         }
     }
+
+    It 'Throws when ProxyCredential used without Proxy' {
+        $cred = New-Object PSCredential('u',(ConvertTo-SecureString 'p' -AsPlainText -Force))
+        { Invoke-HTMLRendering -Url 'http://example.com' -ProxyCredential $cred } | Should -Throw
+        { Get-HTMLInteractable -Url 'http://example.com' -ProxyCredential $cred } | Should -Throw
+        { Set-HTMLHttpClientOption -ProxyCredential $cred } | Should -Throw
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure proxy credential is only accepted with a proxy
- test validation in `Proxy.Tests.ps1`

## Testing
- `dotnet build Sources/PSParseHTML.sln -c Release` *(fails: unable to restore packages)*
- `dotnet test Sources/PSParseHTML.sln` *(fails: unable to resolve packages)*
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: many tests not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dbac59cc832e91257a76ff9f3a22