### PR TITLE
Add CI timeouts for long-running tests

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Run tests
         run: dotnet test Sources/PSParseHTML.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        timeout-minutes: 10
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -80,6 +81,7 @@ jobs:
 
       - name: Run tests
         run: dotnet test Sources/PSParseHTML.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        timeout-minutes: 10
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -112,6 +114,7 @@ jobs:
 
       - name: Run tests
         run: dotnet test Sources/PSParseHTML.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        timeout-minutes: 10
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/powershell-tests-5.yml
+++ b/.github/workflows/powershell-tests-5.yml
@@ -52,3 +52,4 @@ jobs:
       - name: Run PowerShell tests
         shell: powershell
         run: .\PSParseHTML.Tests.ps1
+        timeout-minutes: 10

--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: .\PSParseHTML.Tests.ps1
+        timeout-minutes: 10
 
   test-ubuntu:
     needs: refresh-psd1
@@ -138,6 +139,7 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: ./PSParseHTML.Tests.ps1
+        timeout-minutes: 10
 
   test-macos:
     needs: refresh-psd1
@@ -176,3 +178,4 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: ./PSParseHTML.Tests.ps1
+        timeout-minutes: 10

--- a/.github/workflows/powershell-tests-all.yml
+++ b/.github/workflows/powershell-tests-all.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run PowerShell tests
         shell: powershell
         run: .\PSParseHTML.Tests.ps1
+        timeout-minutes: 10
 
   test-windows-ps7:
     name: 'Windows PowerShell 7'
@@ -79,6 +80,7 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: .\PSParseHTML.Tests.ps1
+        timeout-minutes: 10
 
   test-ubuntu:
     name: 'Ubuntu PowerShell 7'
@@ -114,6 +116,7 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: ./PSParseHTML.Tests.ps1
+        timeout-minutes: 10
 
   test-macos:
     name: 'macOS PowerShell 7'

--- a/PSParseHTML.AzurePipelines.yml
+++ b/PSParseHTML.AzurePipelines.yml
@@ -58,6 +58,7 @@ stages:
           command: 'test'
           projects: 'Sources/PSParseHTML.sln'
           arguments: '--configuration $(buildConfiguration) --no-build --logger trx --collect:"XPlat Code Coverage"'
+        timeoutInMinutes: 10
 
       - task: PublishTestResults@2
         displayName: 'Publish .NET Test Results'
@@ -97,6 +98,7 @@ stages:
           command: 'test'
           projects: 'Sources/PSParseHTML.sln'
           arguments: '--configuration $(buildConfiguration) --no-build --logger trx'
+        timeoutInMinutes: 10
 
   - job: DotNet_MacOS
     displayName: '.NET Tests - macOS'
@@ -162,6 +164,7 @@ stages:
       - powershell: |
           .\PSParseHTML.Tests.ps1
         displayName: "Run PowerShell Tests (PS 5.1)"
+        timeoutInMinutes: 10
 
   - job: PowerShell_Windows_PS7
     displayName: 'PowerShell 7 - Windows'
@@ -190,6 +193,7 @@ stages:
       - pwsh: |
           .\PSParseHTML.Tests.ps1
         displayName: "Run PowerShell Tests (PS 7)"
+        timeoutInMinutes: 10
   - job: PowerShell_Ubuntu
     displayName: 'PowerShell 7 - Ubuntu'
     pool:
@@ -229,6 +233,7 @@ stages:
         inputs:
           targetType: 'filePath'
           filePath: './PSParseHTML.Tests.ps1'
+        timeoutInMinutes: 10
 
   - job: PowerShell_MacOS
     displayName: 'PowerShell 7 - macOS'


### PR DESCRIPTION
## Summary
- cancel GitHub Actions test steps after 10 minutes to keep CI short
- guard disabled Azure Pipelines configs with same timeout

## Testing
- `dotnet test Sources/PSParseHTML.sln --no-build --verbosity minimal --logger "trx"`
- `pwsh -NoProfile -Command ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6879312ab460832e9efc0e5520d08899