### PR TITLE
Fix cancellation handling in PreMailer client

### DIFF
--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -141,7 +141,9 @@ public class PreMailerClient {
     /// Asynchronously processes the HTML and returns the result.
     /// </summary>
     public async Task<PreMailerResult> MoveCssInlineAsync(CancellationToken cancellationToken = default) {
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested) {
+            return await Task.FromCanceled<PreMailerResult>(cancellationToken).ConfigureAwait(false);
+        }
         try {
             string cssContent = Options.Css ?? string.Empty;
             string htmlToProcess = _html;

--- a/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
+++ b/Sources/PSParseHTML/PreMailer/PreMailerClient.cs
@@ -141,6 +141,7 @@ public class PreMailerClient {
     /// Asynchronously processes the HTML and returns the result.
     /// </summary>
     public async Task<PreMailerResult> MoveCssInlineAsync(CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
         try {
             string cssContent = Options.Css ?? string.Empty;
             string htmlToProcess = _html;


### PR DESCRIPTION
## Summary
- ensure `MoveCssInlineAsync` observes a cancelled token

## Testing
- `dotnet test Sources/PSParseHTML.sln --verbosity minimal` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_68793633cb34832e8e6261581135f3e5