### PR TITLE
Fix XML documentation for several methods

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Moq;
@@ -15,7 +16,7 @@ public class HtmlBrowserCookiesTests
     public async Task GetCookiesAsync_ReturnsMappedCookies()
     {
         var context = new Mock<IBrowserContext>();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(session, context.Object);
@@ -54,7 +55,7 @@ public class HtmlBrowserCookiesTests
     public async Task SetCookiesAsync_ForwardsCookiesToAddCookiesAsync()
     {
         var context = new Mock<IBrowserContext>();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(session, context.Object);
@@ -97,7 +98,7 @@ public class HtmlBrowserCookiesTests
     public async Task GetCookiesAsync_FiltersByDomain()
     {
         var context = new Mock<IBrowserContext>();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(session, context.Object);

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserHarExportTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserHarExportTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -44,7 +45,7 @@ public class HtmlBrowserHarExportTests
             Status = 201,
             ResponseHeaders = new Dictionary<string, string> { ["D"] = "4" }
         };
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("_network", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(session, network);

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserRoutesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserRoutesTests.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Moq;
@@ -31,7 +32,7 @@ public class HtmlBrowserRoutesTests {
         Func<IRoute, Task> handler = _ => Task.CompletedTask;
         const string pattern = "**/data.json";
         page.Setup(p => p.RouteAsync(pattern, handler, null)).Returns(Task.CompletedTask).Verifiable();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Page>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(session, page.Object);
@@ -78,7 +79,7 @@ public class HtmlBrowserRoutesTests {
             .Callback<string, Action<IRoute>>((_, h) => captured = h)
             .Returns(Task.CompletedTask)
             .Verifiable();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Page>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(session, page.Object);
@@ -95,7 +96,7 @@ public class HtmlBrowserRoutesTests {
         Func<IRoute, Task> handler = _ => Task.CompletedTask;
         const string pattern = "**/data.json";
         page.Setup(p => p.UnrouteAsync(pattern, handler)).Returns(Task.CompletedTask).Verifiable();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Page>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(session, page.Object);

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Moq;
@@ -10,7 +11,7 @@ namespace PSParseHTML.Tests;
 public class HtmlBrowserSessionDisposeTests {
     [Fact]
     public async Task DisposeAsync_AllowsNullProperties() {
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         await session.DisposeAsync();
     }
 

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserStateTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserStateTests.cs
@@ -1,6 +1,7 @@
 using HtmlTinkerX;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Moq;
@@ -16,7 +17,7 @@ public class HtmlBrowserStateTests {
         var context = new Mock<IBrowserContext>();
         context.Setup(c => c.StorageStateAsync(It.Is<BrowserContextStorageStateOptions>(o => o.Path == file)))
             .ReturnsAsync("{}").Verifiable();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(session, context.Object);

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserTracingTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserTracingTests.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using System;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Moq;
@@ -23,7 +24,7 @@ public class HtmlBrowserTracingTests {
                .Verifiable();
         var context = new Mock<IBrowserContext>();
         context.SetupGet(c => c.Tracing).Returns(tracing.Object).Verifiable();
-        var session = (HtmlBrowserSession)FormatterServices.GetUninitializedObject(typeof(HtmlBrowserSession));
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
         typeof(HtmlBrowserSession)
             .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(session, context.Object);

--- a/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
@@ -47,6 +47,7 @@ public static class HtmlFormSubmitter {
     /// <param name="method">Submission method (GET or POST).</param>
     /// <param name="fields">Field values keyed by name.</param>
     /// <param name="client">Optional HttpClient instance.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Response body as string.</returns>
     public static async Task<string> SubmitAsync(string actionUrl, string? method, IDictionary<string, string> fields, HttpClient? client = null, CancellationToken cancellationToken = default) {
         if (actionUrl == null) {

--- a/Sources/HtmlTinkerX/HtmlFormatter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormatter.cs
@@ -61,6 +61,7 @@ public static class HtmlFormatter {
     /// Formats JavaScript code from a file using default JsBeautifier options.
     /// </summary>
     /// <param name="filePath">Path to the JavaScript file.</param>
+    /// <param name="options">Optional Beautifier options object.</param>
     /// <returns>Formatted JavaScript string.</returns>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     public static string FormatJavaScriptFile(string filePath, BeautifierOptions? options = null) {

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -43,6 +43,8 @@ public static class HtmlParser {
     /// IDocument doc = await HtmlParser.ParseUrlWithAngleSharpAsync("https://example.com");
     /// </code>
     /// </example>
+    /// <param name="client">Optional HTTP client used for downloading the page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task<IDocument> ParseUrlWithAngleSharpAsync(string url, HttpClient? client = null, CancellationToken cancellationToken = default) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
@@ -70,6 +72,8 @@ public static class HtmlParser {
     /// Downloads and parses HTML markup from a URL using HtmlAgilityPack.
     /// </summary>
     /// <param name="url">URL of the page to download.</param>
+    /// <param name="client">Optional HTTP client used for downloading the page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The parsed <see cref="HtmlDocument"/>.</returns>
     public static async Task<HtmlDocument> ParseUrlWithHtmlAgilityPackAsync(string url, HttpClient? client = null, CancellationToken cancellationToken = default) {
         if (url == null) {

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Evaluate.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Evaluate.cs
@@ -13,6 +13,7 @@ public static partial class HtmlBrowser {
     /// <typeparam name="T">Expected return type.</typeparam>
     /// <param name="session">Browser session.</param>
     /// <param name="script">JavaScript code to execute.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Value returned by the script.</returns>
     public static Task<T?> EvaluateAsync<T>(HtmlBrowserSession session, string script, CancellationToken cancellationToken = default)
     {

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -20,6 +20,9 @@ public static partial class HtmlBrowser {
     /// <param name="browser">Browser engine to use.</param>
     /// <param name="clean">Reinstall the browser runtime.</param>
     /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
+    /// <param name="headless">Run browser in headless mode.</param>
+    /// <param name="slowMo">Slow motion delay in milliseconds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Paths of downloaded files.</returns>
     public static async IAsyncEnumerable<string> SavePageDownloadsAsync(string url, string directory, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? filter = null, bool headless = true, int slowMo = 0, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
@@ -43,6 +46,10 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Saves files downloaded from an already loaded page.
     /// </summary>
+    /// <param name="page">Playwright page instance.</param>
+    /// <param name="directory">Directory where downloads should be saved.</param>
+    /// <param name="filter">Optional substring filter applied to download URLs or file names.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async IAsyncEnumerable<string> SavePageDownloadsAsync(IPage page, string directory, string? filter = null, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
         string dir = HtmlUtilities.ResolvePath(directory);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
@@ -40,6 +40,17 @@ public static partial class HtmlBrowser {
     /// <param name="clipY">Optional clip region Y coordinate.</param>
     /// <param name="clipWidth">Optional clip region width.</param>
     /// <param name="clipHeight">Optional clip region height.</param>
+    /// <param name="highlightSelectors">Selectors to highlight in the screenshot.</param>
+    /// <param name="overlayText">Text to overlay on the image.</param>
+    /// <param name="username">Username for authentication.</param>
+    /// <param name="password">Password for authentication.</param>
+    /// <param name="formLogin">Form based login parameters.</param>
+    /// <param name="headless">Run browser in headless mode.</param>
+    /// <param name="slowMo">Slow motion delay in milliseconds.</param>
+    /// <param name="proxy">Proxy server URL.</param>
+    /// <param name="proxyUsername">Proxy username.</param>
+    /// <param name="proxyPassword">Proxy password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task CaptureScreenshotAsync(
         string url,
         string path,
@@ -118,6 +129,9 @@ public static partial class HtmlBrowser {
     /// <param name="clipY">Optional clip region Y coordinate.</param>
     /// <param name="clipWidth">Optional clip region width.</param>
     /// <param name="clipHeight">Optional clip region height.</param>
+    /// <param name="highlightSelectors">Selectors to highlight in the screenshot.</param>
+    /// <param name="overlayText">Text to overlay on the image.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task CaptureScreenshotAsync(
         IPage page,
         string path,

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SessionState.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SessionState.cs
@@ -14,6 +14,7 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="session">Browser session to export.</param>
     /// <param name="path">File path where the session state should be stored.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static Task ExportSessionAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         string fullPath = HtmlUtilities.ResolvePath(path);
         string? dir = Path.GetDirectoryName(fullPath);
@@ -36,6 +37,22 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to navigate to.</param>
     /// <param name="statePath">Path to the previously exported session state.</param>
+    /// <param name="browser">Browser engine to use.</param>
+    /// <param name="clean">Force re-download of browser runtimes.</param>
+    /// <param name="headless">Run browser in headless mode.</param>
+    /// <param name="slowMo">Slow motion delay in milliseconds.</param>
+    /// <param name="userAgent">Custom user agent string.</param>
+    /// <param name="viewportWidth">Viewport width in pixels.</param>
+    /// <param name="viewportHeight">Viewport height in pixels.</param>
+    /// <param name="deviceScaleFactor">Device scale factor.</param>
+    /// <param name="proxy">Proxy server URL.</param>
+    /// <param name="proxyUsername">Proxy username.</param>
+    /// <param name="proxyPassword">Proxy password.</param>
+    /// <param name="geoLatitude">Latitude for geolocation.</param>
+    /// <param name="geoLongitude">Longitude for geolocation.</param>
+    /// <param name="timezone">Timezone identifier.</param>
+    /// <param name="timeout">Navigation timeout in milliseconds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static Task<HtmlBrowserSession> ImportSessionAsync(
         string url,
         string statePath,

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
@@ -191,6 +191,25 @@ public static partial class HtmlBrowser {
     /// Retrieves the fully rendered HTML from the specified URL after executing JavaScript.
     /// </summary>
     /// <param name="url">The URL to load.</param>
+    /// <param name="browser">Browser engine to use.</param>
+    /// <param name="clean">Force re-download of browser runtimes.</param>
+    /// <param name="username">Username for authentication.</param>
+    /// <param name="password">Password for authentication.</param>
+    /// <param name="formLogin">Form based login parameters.</param>
+    /// <param name="headless">Run browser in headless mode.</param>
+    /// <param name="slowMo">Slow motion delay in milliseconds.</param>
+    /// <param name="userAgent">Custom user agent string.</param>
+    /// <param name="viewportWidth">Viewport width in pixels.</param>
+    /// <param name="viewportHeight">Viewport height in pixels.</param>
+    /// <param name="deviceScaleFactor">Device scale factor.</param>
+    /// <param name="proxy">Proxy server URL.</param>
+    /// <param name="proxyUsername">Proxy username.</param>
+    /// <param name="proxyPassword">Proxy password.</param>
+    /// <param name="geoLatitude">Latitude for geolocation.</param>
+    /// <param name="geoLongitude">Longitude for geolocation.</param>
+    /// <param name="timezone">Timezone identifier.</param>
+    /// <param name="timeout">Navigation timeout in milliseconds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The rendered HTML markup.</returns>
     public static async Task<string> GetPageContentAsync(string url, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000, CancellationToken cancellationToken = default) {
         await using HtmlBrowserSession session = await OpenSessionAsync(
@@ -227,6 +246,25 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <param name="url">URL to load.</param>
     /// <param name="path">File path to write.</param>
+    /// <param name="browser">Browser engine to use.</param>
+    /// <param name="clean">Force re-download of browser runtimes.</param>
+    /// <param name="username">Username for authentication.</param>
+    /// <param name="password">Password for authentication.</param>
+    /// <param name="formLogin">Form based login parameters.</param>
+    /// <param name="headless">Run browser in headless mode.</param>
+    /// <param name="slowMo">Slow motion delay in milliseconds.</param>
+    /// <param name="userAgent">Custom user agent string.</param>
+    /// <param name="viewportWidth">Viewport width in pixels.</param>
+    /// <param name="viewportHeight">Viewport height in pixels.</param>
+    /// <param name="deviceScaleFactor">Device scale factor.</param>
+    /// <param name="proxy">Proxy server URL.</param>
+    /// <param name="proxyUsername">Proxy username.</param>
+    /// <param name="proxyPassword">Proxy password.</param>
+    /// <param name="geoLatitude">Latitude for geolocation.</param>
+    /// <param name="geoLongitude">Longitude for geolocation.</param>
+    /// <param name="timezone">Timezone identifier.</param>
+    /// <param name="timeout">Navigation timeout in milliseconds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000, CancellationToken cancellationToken = default) {
         string fullPath = HtmlUtilities.ResolvePath(path);
         string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout, cancellationToken).ConfigureAwait(false);
@@ -244,6 +282,7 @@ public static partial class HtmlBrowser {
     /// <param name="selector">Optional CSS selector for the element.</param>
     /// <param name="innerHtml">Return inner HTML instead of outer HTML.</param>
     /// <param name="asText">Return text content instead of markup.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Extracted markup or text.</returns>
     public static async Task<string> GetContentAsync(IPage page, string? selector = null, bool innerHtml = false, bool asText = false, CancellationToken cancellationToken = default) {
         if (string.IsNullOrEmpty(selector)) {
@@ -272,6 +311,7 @@ public static partial class HtmlBrowser {
     /// Retrieves a list of elements that can be interacted with (links, buttons, etc.).
     /// </summary>
     /// <param name="page">Playwright page instance.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of interactable element descriptions.</returns>
     public static async Task<List<HtmlInteractableInfo>> GetInteractablesAsync(IPage page, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();

--- a/Sources/HtmlTinkerX/PreMailer/PreMailerClient.cs
+++ b/Sources/HtmlTinkerX/PreMailer/PreMailerClient.cs
@@ -256,6 +256,7 @@ public class PreMailerClient {
     /// </summary>
     /// <param name="html">HTML markup to process.</param>
     /// <param name="options">Optional processing options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static Task<PreMailerResult> MoveCssInlineAsync(string html, PreMailerOptions? options = null, CancellationToken cancellationToken = default)
         => FromHtml(html, options).MoveCssInlineAsync(cancellationToken);
 
@@ -264,6 +265,7 @@ public class PreMailerClient {
     /// </summary>
     /// <param name="htmlFilePath">Path to the HTML file.</param>
     /// <param name="options">Optional processing options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task<PreMailerResult> MoveCssInlineFromFileAsync(string htmlFilePath, PreMailerOptions? options = null, CancellationToken cancellationToken = default) {
         string html = await HtmlUtilities.ReadFileCheckedAsync(htmlFilePath, cancellationToken).ConfigureAwait(false);
         return await MoveCssInlineAsync(html, options, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add missing XML doc comments across API surface
- replace obsolete `FormatterServices.GetUninitializedObject` with `RuntimeHelpers.GetUninitializedObject`

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687a02fd8ac8832e9253eef648f54929