### PR TITLE
Fix flaky tests for CI

### DIFF
--- a/Tests/Invoke-HTMLRendering.Tests.ps1
+++ b/Tests/Invoke-HTMLRendering.Tests.ps1
@@ -16,7 +16,8 @@ Describe 'Invoke-HTMLRendering' {
     It 'Applies custom browser context options' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
-        $session = Invoke-HTMLRendering -Url $uri -Session -UserAgent 'MyAgent' -ViewportWidth 123 -ViewportHeight 77 -DeviceScaleFactor 1.5
+        $scale = [double]::Parse('1.5', [System.Globalization.CultureInfo]::InvariantCulture)
+        $session = Invoke-HTMLRendering -Url $uri -Session -UserAgent 'MyAgent' -ViewportWidth 123 -ViewportHeight 77 -DeviceScaleFactor $scale
         $ua = $session.Page.EvaluateAsync('navigator.userAgent',$null).GetAwaiter().GetResult()
         $w = [int]($session.Page.EvaluateAsync('window.innerWidth',$null).GetAwaiter().GetResult().ToString())
         $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
@@ -29,7 +30,9 @@ Describe 'Invoke-HTMLRendering' {
     It 'Applies geolocation and timezone settings' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
-        $session = Invoke-HTMLRendering -Url $uri -Session -GeoLatitude 50.1 -GeoLongitude 19.9 -Timezone 'Europe/Warsaw'
+        $latVal = [double]::Parse('50.1', [System.Globalization.CultureInfo]::InvariantCulture)
+        $lngVal = [double]::Parse('19.9', [System.Globalization.CultureInfo]::InvariantCulture)
+        $session = Invoke-HTMLRendering -Url $uri -Session -GeoLatitude $latVal -GeoLongitude $lngVal -Timezone 'Europe/Warsaw'
         $lat = [double]($session.Page.EvaluateAsync('new Promise(r=>navigator.geolocation.getCurrentPosition(p=>r(p.coords.latitude)))',$null).GetAwaiter().GetResult().ToString())
         $tz = $session.Page.EvaluateAsync('Intl.DateTimeFormat().resolvedOptions().timeZone',$null).GetAwaiter().GetResult()
         Close-HTMLSession -Session $session

--- a/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
+++ b/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
@@ -1,5 +1,5 @@
 Describe 'Save-HTMLAttachment streaming' {
-    It 'Outputs file paths as downloads complete' {
+    It 'Outputs file paths as downloads complete' -Skip:(-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
         $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', '8010' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
         Start-Sleep -Seconds 1
         $timeout = [System.Diagnostics.Stopwatch]::StartNew()


### PR DESCRIPTION
## Summary
- normalize decimal values using invariant culture in tests
- skip streaming attachment test when `python3` isn't available

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Script ./Tests/Invoke-HTMLRendering.Tests.ps1 -Output Detailed"`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Script ./Tests/Save-HTMLAttachment.Streaming.Tests.ps1 -Output Detailed"`


------
https://chatgpt.com/codex/tasks/task_e_687a70b85ce0832e9e17f3cceab21c8b