### PR TITLE
Fix nullable warnings

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
@@ -20,8 +20,8 @@ public class HtmlFormSubmitterTests {
                 app.UseEndpoints(endpoints => {
                     endpoints.MapPost("/login", async context => {
                         var form = await context.Request.ReadFormAsync();
-                        string user = form["user"];
-                        string pass = form["pass"];
+                        string user = form["user"].ToString();
+                        string pass = form["pass"].ToString();
                         await context.Response.WriteAsync($"{user}:{pass}");
                     });
                 });

--- a/Sources/HtmlTinkerX.Tests/HtmlHttpClientFactoryTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHttpClientFactoryTests.cs
@@ -41,7 +41,7 @@ public class HtmlHttpClientFactoryTests {
         var cred = new NetworkCredential("u", "p");
         using HttpClient client = HtmlHttpClientFactory.Create("http://localhost:1234", cred);
         HttpClientHandler handler = GetHandler(client);
-        Assert.Equal("http://localhost:1234/", handler.Proxy?.GetProxy(new System.Uri("http://localhost")).ToString());
+        Assert.Equal("http://localhost:1234/", handler.Proxy?.GetProxy(new System.Uri("http://localhost"))?.ToString());
         Assert.Same(cred, handler.Proxy?.Credentials);
     }
 }

--- a/Sources/HtmlTinkerX/HtmlOutlineBuilder.cs
+++ b/Sources/HtmlTinkerX/HtmlOutlineBuilder.cs
@@ -76,8 +76,8 @@ public static class HtmlOutlineBuilder {
         if (nodes != null) {
             foreach (var node in nodes) {
                 int level = int.Parse(node.Name.Substring(1));
-                string title = HtmlEntity.DeEntitize(node.InnerText).Trim();
-                string id = node.Id;
+                string title = HtmlEntity.DeEntitize(node.InnerText ?? string.Empty).Trim();
+                string? id = node.Id;
                 headings.Add((level, title, id));
             }
         }

--- a/Sources/HtmlTinkerX/HtmlParserFromList.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromList.cs
@@ -175,7 +175,7 @@ public static class HtmlParserFromList {
 
         static void CollectSegments(HtmlNode node, List<string> list) {
             if (node.NodeType == HtmlNodeType.Text) {
-                string text = HtmlEntity.DeEntitize(node.InnerText).Trim();
+                string text = HtmlEntity.DeEntitize(node.InnerText ?? string.Empty).Trim();
                 if (!string.IsNullOrWhiteSpace(text)) {
                     list.Add(text);
                 }

--- a/Sources/HtmlTinkerX/HtmlParserFromOpenGraph.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromOpenGraph.cs
@@ -34,7 +34,7 @@ public static class HtmlParserFromOpenGraph {
             if (string.IsNullOrEmpty(property)) {
                 continue;
             }
-            string key = property.Substring(3); // remove "og:" prefix
+            string key = property!.Substring(3); // remove "og:" prefix
             string content = node.GetAttribute("content") ?? string.Empty;
             if (!result.Properties.TryGetValue(key, out var list)) {
                 list = new List<string>();

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -432,13 +432,13 @@ public static class HtmlParserFromTable {
                     if (cells == null || cells.Count == 0) {
                         continue;
                     }
-                    string header = HtmlEntity.DeEntitize(cells![0].InnerText).Trim();
+                    string header = HtmlEntity.DeEntitize(cells![0].InnerText ?? string.Empty).Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
                             header = header.Replace(kv.Key, kv.Value);
                         }
                     }
-                    string value = cells.Count > 1 ? HtmlEntity.DeEntitize(cells[1].InnerText).Trim() : string.Empty;
+                    string value = cells.Count > 1 ? HtmlEntity.DeEntitize(cells[1].InnerText ?? string.Empty).Trim() : string.Empty;
                     if (replaceContent != null) {
                         foreach (var kv in replaceContent) {
                             value = value.Replace(kv.Key, kv.Value);
@@ -477,7 +477,7 @@ public static class HtmlParserFromTable {
             List<string> headers = new();
             if (hasHeader) {
                 foreach (var cell in headerCells) {
-                    string header = HtmlEntity.DeEntitize(cell.InnerText).Trim();
+                    string header = HtmlEntity.DeEntitize(cell.InnerText ?? string.Empty).Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
                             header = header.Replace(kv.Key, kv.Value);
@@ -529,7 +529,7 @@ public static class HtmlParserFromTable {
 
                     if (cellIndex < cells.Count) {
                         var cell = cells[cellIndex++];
-                        string value = HtmlEntity.DeEntitize(cell.InnerText).Trim();
+                        string value = HtmlEntity.DeEntitize(cell.InnerText ?? string.Empty).Trim();
                         if (replaceContent != null) {
                             foreach (var kv in replaceContent) {
                                 value = value.Replace(kv.Key, kv.Value);
@@ -618,13 +618,13 @@ public static class HtmlParserFromTable {
                     if (cells == null || cells.Count == 0) {
                         continue;
                     }
-                    string header = HtmlEntity.DeEntitize(cells![0].InnerText).Trim();
+                    string header = HtmlEntity.DeEntitize(cells![0].InnerText ?? string.Empty).Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
                             header = header.Replace(kv.Key, kv.Value);
                         }
                     }
-                    string value = cells.Count > 1 ? HtmlEntity.DeEntitize(cells![1].InnerText).Trim() : string.Empty;
+                    string value = cells.Count > 1 ? HtmlEntity.DeEntitize(cells![1].InnerText ?? string.Empty).Trim() : string.Empty;
                     if (replaceContent != null) {
                         foreach (var kv in replaceContent) {
                             value = value.Replace(kv.Key, kv.Value);
@@ -659,7 +659,7 @@ public static class HtmlParserFromTable {
             List<string> headers = new();
             if (hasHeader) {
                 foreach (var cell in headerCells) {
-                    string header = HtmlEntity.DeEntitize(cell.InnerText).Trim();
+                    string header = HtmlEntity.DeEntitize(cell.InnerText ?? string.Empty).Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
                             header = header.Replace(kv.Key, kv.Value);
@@ -704,7 +704,7 @@ public static class HtmlParserFromTable {
 
                     if (cellIndex < cells.Count) {
                         var cell = cells[cellIndex++];
-                        string value = HtmlEntity.DeEntitize(cell.InnerText).Trim();
+                        string value = HtmlEntity.DeEntitize(cell.InnerText ?? string.Empty).Trim();
                         if (replaceContent != null) {
                             foreach (var kv in replaceContent) {
                                 value = value.Replace(kv.Key, kv.Value);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.LoginParser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.LoginParser.cs
@@ -51,7 +51,7 @@ public static class HtmlLoginParser {
         }
 
         string sel = el.TagName.ToLowerInvariant();
-        string id = el.Id;
+        string? id = el.Id;
         if (!string.IsNullOrEmpty(id)) {
             return sel + "#" + CssEscape(id);
         }
@@ -82,7 +82,7 @@ public static class HtmlLoginParser {
 
         string? style = el.GetAttribute("style");
         if (!string.IsNullOrEmpty(style)) {
-            style = style.ToLowerInvariant();
+            style = style!.ToLowerInvariant();
             if (style.Contains("display:none") || style.Contains("visibility:hidden") || style.Contains("opacity:0")) {
                 return true;
             }

--- a/Sources/HtmlTinkerX/PreMailer/PreMailerClient.cs
+++ b/Sources/HtmlTinkerX/PreMailer/PreMailerClient.cs
@@ -155,7 +155,7 @@ public class PreMailerClient {
 
                 bool isCss = false;
                 if (!string.IsNullOrEmpty(href)) {
-                    isCss = href.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
+                    isCss = href!.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
                         (rel != null && rel.Equals("stylesheet", StringComparison.OrdinalIgnoreCase));
                 }
                 if (!isCss) {

--- a/Sources/PSParseHTML.PowerShell/CmdletMeasureHtmlDocument.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletMeasureHtmlDocument.cs
@@ -37,7 +37,7 @@ public sealed class CmdletMeasureHtmlDocument : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         string html = ParameterSetName == ParameterSetFile
 #if NETSTANDARD2_0 || NETFRAMEWORK
-            ? File.ReadAllText(HtmlUtilities.ResolvePath(Path))
+            ? await Task.Run(() => File.ReadAllText(HtmlUtilities.ResolvePath(Path)), CancelToken).ConfigureAwait(false)
 #else
             ? await File.ReadAllTextAsync(HtmlUtilities.ResolvePath(Path), CancelToken).ConfigureAwait(false)
 #endif

--- a/Sources/PSParseHTML.PowerShell/CmdletSetHtmlHttpClientOption.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSetHtmlHttpClientOption.cs
@@ -54,7 +54,9 @@ public sealed class CmdletSetHtmlHttpClientOption : AsyncPSCmdlet {
 
         if (Header != null) {
             foreach (DictionaryEntry entry in Header) {
-                HtmlHttpClientFactory.DefaultHeaders[entry.Key.ToString()!] = entry.Value.ToString()!;
+                if (entry.Key != null && entry.Value != null) {
+                    HtmlHttpClientFactory.DefaultHeaders[entry.Key.ToString()!] = entry.Value.ToString()!;
+                }
             }
             HtmlHttpClientFactory.ResetShared();
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStopHtmlVideoRecording.cs
@@ -20,7 +20,7 @@ public sealed class CmdletStopHtmlVideoRecording : AsyncPSCmdlet {
 
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
-        if (!string.IsNullOrEmpty(OutFile) && !OutFile.EndsWith(".webm", StringComparison.OrdinalIgnoreCase)) {
+        if (!string.IsNullOrEmpty(OutFile) && !OutFile!.EndsWith(".webm", StringComparison.OrdinalIgnoreCase)) {
             throw new PSArgumentException("Only .webm files are supported.", nameof(OutFile));
         }
 


### PR DESCRIPTION
## Summary
- address CS8602 and CS8600 warnings by adding explicit null checks
- ensure async code paths to remove CS1998 warning
- improve test helpers to handle nullable values

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Tests -CI"` *(fails: Tests Passed: 113, Failed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_687a7a7b4bc4832e9cc8f4266cfc8605