### PR TITLE
Fix XML documentation warnings

### DIFF
--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -112,7 +112,7 @@ public static class HtmlParser {
     /// <param name="html">HTML content containing tables.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
-    /// <param name="clientFactory">Factory used to create a temporary <see cref="HttpClient"/> when one is not supplied.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static List<List<Dictionary<string, string?>>> ParseTablesWithAngleSharp(
         string html,
@@ -128,6 +128,8 @@ public static class HtmlParser {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="client">Optional HTTP client used for downloading the page.</param>
     /// <param name="clientFactory">Factory used to create a temporary <see cref="HttpClient"/> when one is not supplied.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static async Task<List<List<Dictionary<string, string?>>>> ParseUrlTablesWithAngleSharpAsync(
@@ -171,6 +173,7 @@ public static class HtmlParser {
     /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static List<List<Dictionary<string, string?>>> ParseTablesWithHtmlAgilityPack(
         string html,
@@ -188,6 +191,9 @@ public static class HtmlParser {
     /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="client">Optional HTTP client used for downloading the page.</param>
+    /// <param name="clientFactory">Factory used to create a temporary <see cref="HttpClient"/> when one is not supplied.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static async Task<List<List<Dictionary<string, string?>>>> ParseUrlTablesWithHtmlAgilityPackAsync(
         string url,
@@ -216,6 +222,7 @@ public static class HtmlParser {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with item texts.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<List<string>>> ParseUrlListsWithAngleSharpAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         return await HtmlParserFromList.ParseUrlListsWithAngleSharpAsync(url, tagPlaceholder, client);
     }
@@ -236,6 +243,7 @@ public static class HtmlParser {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with item texts.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<List<string>>> ParseUrlListsWithHtmlAgilityPackAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         return await HtmlParserFromList.ParseUrlListsWithHtmlAgilityPackAsync(url, tagPlaceholder, client);
     }
@@ -256,6 +264,7 @@ public static class HtmlParser {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<HtmlListResult>> ParseUrlListsWithAngleSharpDetailedAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         return await HtmlParserFromList.ParseUrlListsWithAngleSharpDetailedAsync(url, tagPlaceholder, client);
     }
@@ -276,6 +285,7 @@ public static class HtmlParser {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<HtmlListResult>> ParseUrlListsWithHtmlAgilityPackDetailedAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         return await HtmlParserFromList.ParseUrlListsWithHtmlAgilityPackDetailedAsync(url, tagPlaceholder, client);
     }

--- a/Sources/HtmlTinkerX/HtmlParserFromList.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromList.cs
@@ -94,6 +94,7 @@ public static class HtmlParserFromList {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<HtmlListResult>> ParseUrlListsWithAngleSharpDetailedAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
@@ -109,6 +110,7 @@ public static class HtmlParserFromList {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with joined item texts.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<List<string>>> ParseUrlListsWithAngleSharpAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         var detailed = await ParseUrlListsWithAngleSharpDetailedAsync(url, tagPlaceholder, client).ConfigureAwait(false);
         List<List<string>> result = new();
@@ -208,6 +210,7 @@ public static class HtmlParserFromList {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<HtmlListResult>> ParseUrlListsWithHtmlAgilityPackDetailedAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
@@ -223,6 +226,7 @@ public static class HtmlParserFromList {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with joined item texts.</returns>
+    /// <param name="client">Optional HTTP client.</param>
     public static async Task<List<List<string>>> ParseUrlListsWithHtmlAgilityPackAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
         var detailed = await ParseUrlListsWithHtmlAgilityPackDetailedAsync(url, tagPlaceholder, client).ConfigureAwait(false);
         List<List<string>> result = new();

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -198,7 +198,7 @@ public static class HtmlParserFromTable {
     /// <param name="html">HTML content containing tables.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
-    /// <param name="clientFactory">Factory used to create a temporary <see cref="HttpClient"/> when one is not supplied.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static List<List<Dictionary<string, string?>>> ParseTablesWithAngleSharp(
         string html,
@@ -327,6 +327,8 @@ public static class HtmlParserFromTable {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="client">Optional HTTP client used for downloading the page.</param>
     /// <param name="clientFactory">Factory used to create a temporary <see cref="HttpClient"/> when one is not supplied.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static async Task<List<List<Dictionary<string, string?>>>> ParseUrlTablesWithAngleSharpAsync(
@@ -586,6 +588,7 @@ public static class HtmlParserFromTable {
     /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static List<List<Dictionary<string, string?>>> ParseTablesWithHtmlAgilityPack(
         string html,
@@ -757,6 +760,9 @@ public static class HtmlParserFromTable {
     /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
     /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
     /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="client">Optional HTTP client used for downloading the page.</param>
+    /// <param name="clientFactory">Factory used to create a temporary <see cref="HttpClient"/> when one is not supplied.</param>
     /// <returns>List of tables with rows represented as dictionaries.</returns>
     public static async Task<List<List<Dictionary<string, string?>>>> ParseUrlTablesWithHtmlAgilityPackAsync(
         string url,

--- a/Sources/HtmlTinkerX/HtmlUtilities.cs
+++ b/Sources/HtmlTinkerX/HtmlUtilities.cs
@@ -43,6 +43,7 @@ public static class HtmlUtilities {
     /// Asynchronously reads the contents of a file after verifying that it exists.
     /// </summary>
     /// <param name="path">Path to the file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>File contents.</returns>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     public static async Task<string> ReadFileCheckedAsync(string path, CancellationToken cancellationToken = default) {
@@ -62,6 +63,7 @@ public static class HtmlUtilities {
     /// </summary>
     /// <param name="client">HttpClient to use for the request.</param>
     /// <param name="url">URL to download from.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Content as a string with proper encoding.</returns>
     public static async Task<string> GetStringWithProperEncodingAsync(HttpClient client, string url, CancellationToken cancellationToken = default) {
         using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- correct parameter names in XML comments for `HtmlParser`
- add missing parameter docs for list and table parsing helpers
- document `cancellationToken` in `HtmlUtilities`

## Testing
- `dotnet build Sources/HtmlTinkerX.sln --no-incremental`

------
https://chatgpt.com/codex/tasks/task_e_687a7a07a8f8832ea1abdb791be6c647