### PR TITLE
Add HtmlPlatform enum and refactor installer

### DIFF
--- a/Sources/HtmlTinkerX.Tests/PlatformExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/PlatformExtensionsTests.cs
@@ -1,0 +1,17 @@
+using HtmlTinkerX;
+using Xunit;
+
+namespace PSParseHTML.Tests;
+
+public class PlatformExtensionsTests {
+    [Theory]
+    [InlineData(HtmlPlatform.WindowsX64, "win32_x64", "win32_x64")]
+    [InlineData(HtmlPlatform.Mac, "darwin-x64", "mac")]
+    [InlineData(HtmlPlatform.MacArm64, "darwin-arm64", "mac-arm64")]
+    [InlineData(HtmlPlatform.LinuxX64, "linux-x64", "linux")]
+    [InlineData(HtmlPlatform.LinuxArm64, "linux-arm64", "linux-arm64")]
+    public void PlatformConversions_ReturnExpected(HtmlPlatform platform, string platformId, string downloadId) {
+        Assert.Equal(platformId, platform.ToPlatformId());
+        Assert.Equal(downloadId, platform.ToDownloadPlatformId());
+    }
+}

--- a/Sources/HtmlTinkerX/Enums/HtmlPlatform.cs
+++ b/Sources/HtmlTinkerX/Enums/HtmlPlatform.cs
@@ -1,0 +1,17 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Platforms supported for Playwright driver installation.
+/// </summary>
+public enum HtmlPlatform {
+    /// <summary>Windows x64 platform.</summary>
+    WindowsX64,
+    /// <summary>macOS x64 platform.</summary>
+    Mac,
+    /// <summary>macOS Arm64 platform.</summary>
+    MacArm64,
+    /// <summary>Linux x64 platform.</summary>
+    LinuxX64,
+    /// <summary>Linux Arm64 platform.</summary>
+    LinuxArm64
+}

--- a/Sources/HtmlTinkerX/PlatformExtensions.cs
+++ b/Sources/HtmlTinkerX/PlatformExtensions.cs
@@ -1,0 +1,36 @@
+using System.Runtime.InteropServices;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Helper methods for working with <see cref="HtmlPlatform"/> values.
+/// </summary>
+internal static class PlatformExtensions {
+    public static HtmlPlatform GetCurrentPlatform() {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return HtmlPlatform.WindowsX64;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return RuntimeInformation.OSArchitecture == Architecture.Arm64
+                ? HtmlPlatform.MacArm64
+                : HtmlPlatform.Mac;
+        return RuntimeInformation.OSArchitecture == Architecture.Arm64
+            ? HtmlPlatform.LinuxArm64
+            : HtmlPlatform.LinuxX64;
+    }
+
+    public static string ToPlatformId(this HtmlPlatform platform) => platform switch {
+        HtmlPlatform.WindowsX64 => "win32_x64",
+        HtmlPlatform.Mac => "darwin-x64",
+        HtmlPlatform.MacArm64 => "darwin-arm64",
+        HtmlPlatform.LinuxArm64 => "linux-arm64",
+        _ => "linux-x64"
+    };
+
+    public static string ToDownloadPlatformId(this HtmlPlatform platform) => platform switch {
+        HtmlPlatform.WindowsX64 => "win32_x64",
+        HtmlPlatform.Mac => "mac",
+        HtmlPlatform.MacArm64 => "mac-arm64",
+        HtmlPlatform.LinuxArm64 => "linux-arm64",
+        _ => "linux"
+    };
+}

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
@@ -21,36 +21,17 @@ public static partial class HtmlBrowser {
     /// <summary>
     /// Gets the platform identifier for the Playwright driver.
     /// </summary>
-    private static string PlatformId {
-        get {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return "win32_x64";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return RuntimeInformation.OSArchitecture == Architecture.Arm64
-                    ? "darwin-arm64"
-                    : "darwin-x64";
-            if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
-                return "linux-arm64";
-            return "linux-x64";
-        }
-    }
+    private static string PlatformId => CurrentPlatform.ToPlatformId();
+
+    /// <summary>
+    /// Gets the current platform value.
+    /// </summary>
+    private static HtmlPlatform CurrentPlatform => PlatformExtensions.GetCurrentPlatform();
 
     /// <summary>
     /// Gets the platform identifier for downloading the Playwright driver.
     /// </summary>
-    private static string DownloadPlatformId {
-        get {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return "win32_x64";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return RuntimeInformation.OSArchitecture == Architecture.Arm64
-                    ? "mac-arm64"
-                    : "mac";
-            if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
-                return "linux-arm64";
-            return "linux";
-        }
-    }
+    private static string DownloadPlatformId => CurrentPlatform.ToDownloadPlatformId();
 
     private static string NodeExecutable => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
 


### PR DESCRIPTION
## Summary
- add `HtmlPlatform` enum to centralize supported platforms
- provide `PlatformExtensions` for platform detection and ID conversions
- refactor `HtmlBrowser.Installer` to use enum-based logic
- add tests for platform conversions

## Testing
- `dotnet test Sources/HtmlTinkerX.sln`
- `pwsh -NoLogo -NoProfile -File PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_687ca0dd75e0832ebf484de18f337b70