### PR TITLE
Use enum for Beautifier modes

### DIFF
--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
@@ -99,7 +99,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
         private void BlankState() {
             // internal flags
-            Flags = new BeautifierFlags("BLOCK");
+            Flags = new BeautifierFlags(BeautifierMode.Block);
             FlagStore = new List<BeautifierFlags>();
             WantedNewline = false;
             JustAddedNewline = false;
@@ -125,12 +125,12 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
             // Words which always should start on a new line
             LineStarters = "continue,try,throw,return,var,if,switch,case,default,for,while,break,function".Split(',');
-            SetMode("BLOCK");
+            SetMode(BeautifierMode.Block);
             ParserPos = 0;
         }
 
-        private void SetMode(string mode) {
-            var prev = new BeautifierFlags("BLOCK");
+        private void SetMode(BeautifierMode mode) {
+            var prev = new BeautifierFlags(BeautifierMode.Block);
 
             if (Flags != null) {
                 FlagStore.Add(Flags);
@@ -229,16 +229,16 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             return s == "case" || s == "return" || s == "do" || s == "if" || s == "throw" || s == "else";
         }
 
-        private bool IsArray(string mode) {
-            return mode == "[EXPRESSION]" || mode == "[INDENTED-EXPRESSION]";
+        private bool IsArray(BeautifierMode mode) {
+            return mode == BeautifierMode.ArrayExpression || mode == BeautifierMode.IndentedArrayExpression;
         }
 
-        private bool IsExpression(string mode) {
-            return mode == "[EXPRESSION]" ||
-                mode == "[INDENTED-EXPRESSION]" ||
-                mode == "(EXPRESSION)" ||
-                mode == "(FOR-EXPRESSION)" ||
-                mode == "(COND-EXPRESSION)";
+        private bool IsExpression(BeautifierMode mode) {
+            return mode == BeautifierMode.ArrayExpression ||
+                mode == BeautifierMode.IndentedArrayExpression ||
+                mode == BeautifierMode.ParentheticalExpression ||
+                mode == BeautifierMode.ForExpression ||
+                mode == BeautifierMode.ConditionalExpression;
         }
 
         private void AllowWrapOrPreservedNewline(string tokenText, bool forceLinwrap = false) {
@@ -347,7 +347,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
         }
 
         private void RestoreMode() {
-            DoBlockJustClosed = Flags.Mode == "DO_BLOCK";
+            DoBlockJustClosed = Flags.Mode == BeautifierMode.DoBlock;
 
             if (FlagStore.Count > 0) {
                 var mode = Flags.Mode;
@@ -541,7 +541,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             if (c == '\'' || c == '"' ||
                 (c == '/' &&
                 ((LastType == "TK_WORD" && IsSpecialWord(LastText)) ||
-                (LastType == "TK_END_EXPR" && (Flags.PreviousMode == "(FOR-EXPRESSION)" || Flags.PreviousMode == "(COND-EXPRESSION)")) ||
+                (LastType == "TK_END_EXPR" && (Flags.PreviousMode == BeautifierMode.ForExpression || Flags.PreviousMode == BeautifierMode.ConditionalExpression)) ||
                 ((new[] { "TK_COMMENT", "TK_START_EXPR", "TK_START_BLOCK", "TK_END_BLOCK", "TK_OPERATOR", "TK_EQUALS", "TK_EOF", "TK_SEMICOLON", "TK_COMMA" }).Contains(LastType))))) {
                 var sep = c;
                 var esc = false;
@@ -742,52 +742,52 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                         Append(" ");
                     }
 
-                    SetMode("(EXPRESSION)");
+                    SetMode(BeautifierMode.ParentheticalExpression);
                     Append(tokenText);
                     return;
                 }
 
-                if (Flags.Mode == "[EXPRESSION]" || Flags.Mode == "[INDENTED-EXPRESSION]") {
+                if (Flags.Mode == BeautifierMode.ArrayExpression || Flags.Mode == BeautifierMode.IndentedArrayExpression) {
                     if (LastLastText == "]" && LastText == ",") {
                         // # ], [ goes to a new line
-                        if (Flags.Mode == "[EXPRESSION]") {
-                            Flags.Mode = "[INDENTED-EXPRESSION]";
+                        if (Flags.Mode == BeautifierMode.ArrayExpression) {
+                            Flags.Mode = BeautifierMode.IndentedArrayExpression;
                             if (!Opts.KeepArrayIndentation) {
                                 Indent();
                             }
                         }
 
-                        SetMode("[EXPRESSION]");
+                        SetMode(BeautifierMode.ArrayExpression);
 
                         if (!Opts.KeepArrayIndentation) {
                             AppendNewline();
                         }
                     } else if (LastText == "[") {
-                        if (Flags.Mode == "[EXPRESSION]") {
-                            Flags.Mode = "[INDENTED-EXPRESSION]";
+                        if (Flags.Mode == BeautifierMode.ArrayExpression) {
+                            Flags.Mode = BeautifierMode.IndentedArrayExpression;
 
                             if (!Opts.KeepArrayIndentation) {
                                 Indent();
                             }
                         }
-                        SetMode("[EXPRESSION]");
+                        SetMode(BeautifierMode.ArrayExpression);
 
                         if (!Opts.KeepArrayIndentation) {
                             AppendNewline();
                         }
                     } else {
-                        SetMode("[EXPRESSION]");
+                        SetMode(BeautifierMode.ArrayExpression);
                     }
                 } else {
-                    SetMode("[EXPRESSION]");
+                    SetMode(BeautifierMode.ArrayExpression);
                 }
             } else {
                 if (LastText == "for") {
-                    SetMode("(FOR-EXPRESSION)");
+                    SetMode(BeautifierMode.ForExpression);
                 } else if (LastText == "if" || LastText == "while") {
-                    SetMode("(COND-EXPRESSION)");
+                    SetMode(BeautifierMode.ConditionalExpression);
                 } else {
-                    SetMode("(EXPRESSION)");
+                    SetMode(BeautifierMode.ParentheticalExpression);
                 }
             }
 
@@ -811,7 +811,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
             if (LastType == "TK_EQUALS" ||
                 LastType == "TK_OPERATOR") {
-                if (Flags.Mode != "OJBECT") {
+                if (Flags.Mode != BeautifierMode.Object) {
                     AllowWrapOrPreservedNewline(tokenText);
                 }
             }
@@ -828,7 +828,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                         RestoreMode();
                         return;
                     }
-                } else if (Flags.Mode == "[INDENTED-EXPRESSION]") {
+                } else if (Flags.Mode == BeautifierMode.IndentedArrayExpression) {
                     if (LastText == "]") {
                         RestoreMode();
                         AppendNewline();
@@ -843,9 +843,9 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
         private void HandleStartBlock(string tokenText) {
             if (LastWord == "do") {
-                SetMode("DO_BLOCK");
+                SetMode(BeautifierMode.DoBlock);
             } else {
-                SetMode("BLOCK");
+                SetMode(BeautifierMode.Block);
             }
 
             if (Opts.BraceStyle == BraceStyle.Expand) {
@@ -987,7 +987,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                         Append(" ");
                     }
                 }
-            } else if (LastType == "TK_SEMICOLON" && (Flags.Mode == "BLOCK" || Flags.Mode == "DO_BLOCK")) {
+            } else if (LastType == "TK_SEMICOLON" && (Flags.Mode == BeautifierMode.Block || Flags.Mode == BeautifierMode.DoBlock)) {
                 prefix = "NEWLINE";
             } else if (LastType == "TK_SEMICOLON" && IsExpression(Flags.Mode)) {
                 prefix = "SPACE";
@@ -1015,7 +1015,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                 LastType == "TK_START_EXPR" ||
                 LastType == "TK_EQUALS" ||
                 LastType == "TK_OPERATOR") {
-                if (Flags.Mode != "OBJECT") {
+                if (Flags.Mode != BeautifierMode.Object) {
                     AllowWrapOrPreservedNewline(tokenText);
                 }
             }
@@ -1085,15 +1085,15 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             Append(tokenText);
             Flags.VarLine = false;
             Flags.VarLineReindented = false;
-            if (Flags.Mode == "OBJECT") {
+            if (Flags.Mode == BeautifierMode.Object) {
                 // OBJECT mode is weird and doesn't get reset too well.
-                Flags.Mode = "BLOCK";
+                Flags.Mode = BeautifierMode.Block;
             }
         }
 
         private void HandleString(string tokenText) {
             if (LastType == "TK_END_EXPR" &&
-                (Flags.PreviousMode == "(COND-EXPRESSION)" || Flags.PreviousMode == "(FOR-EXPRESSION)")) {
+                (Flags.PreviousMode == BeautifierMode.ConditionalExpression || Flags.PreviousMode == BeautifierMode.ForExpression)) {
                 Append(" ");
             } else if (LastType == "TK_WORD") {
                 Append(" ");
@@ -1101,7 +1101,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                        LastType == "TK_START_EXPR" ||
                        LastType == "TK_EQUALS" ||
                        LastType == "TK_OPERATOR") {
-                if (Flags.Mode != "OBJECT") {
+                if (Flags.Mode != BeautifierMode.Object) {
                     AllowWrapOrPreservedNewline(tokenText);
                 }
             } else {
@@ -1145,15 +1145,15 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                 return;
             }
 
-            if (LastType == "TK_END_BLOCK" && Flags.Mode != "(EXPRESSION)") {
+            if (LastType == "TK_END_BLOCK" && Flags.Mode != BeautifierMode.ParentheticalExpression) {
                 Append(tokenText);
-                if (Flags.Mode == "OBJECT" && LastText == "}") {
+                if (Flags.Mode == BeautifierMode.Object && LastText == "}") {
                     AppendNewline();
                 } else {
                     Append(" ");
                 }
             } else {
-                if (Flags.Mode == "OBJECT") {
+                if (Flags.Mode == BeautifierMode.Object) {
                     Append(tokenText);
                     AppendNewline();
                 } else {
@@ -1212,15 +1212,15 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                     spaceBefore = true;
                 }
 
-                if (Flags.Mode == "BLOCK" && (LastText == ";" || LastText == "{")) {
+                if (Flags.Mode == BeautifierMode.Block && (LastText == ";" || LastText == "{")) {
                     // { foo: --i }
                     // foo(): --bar
                     AppendNewline();
                 }
             } else if (tokenText == ":") {
                 if (Flags.TernaryDepth == 0) {
-                    if (Flags.Mode == "BLOCK") {
-                        Flags.Mode = "OBJECT";
+                    if (Flags.Mode == BeautifierMode.Block) {
+                        Flags.Mode = BeautifierMode.Object;
                     }
                     spaceBefore = false;
                 } else {

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierFlags.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierFlags.cs
@@ -32,8 +32,8 @@ public class BeautifierFlags {
     /// Initializes a new instance of the <see cref="BeautifierFlags"/> class.
     /// </summary>
     /// <param name="mode">The initial mode.</param>
-    public BeautifierFlags(string mode) {
-        PreviousMode = "BLOCK";
+    public BeautifierFlags(BeautifierMode mode) {
+        PreviousMode = BeautifierMode.Block;
         Mode = mode;
         VarLine = false;
         VarLineTainted = false;
@@ -51,12 +51,12 @@ public class BeautifierFlags {
     /// <summary>
     /// Gets or sets the previous mode.
     /// </summary>
-    public string PreviousMode { get; set; }
+    public BeautifierMode PreviousMode { get; set; }
 
     /// <summary>
     /// Gets or sets the current mode.
     /// </summary>
-    public string Mode { get; set; }
+    public BeautifierMode Mode { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether we're on a variable line.

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierMode.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierMode.cs
@@ -1,0 +1,70 @@
+#region License
+// MIT License
+//
+// Copyright (c) 2018 Denis Ivanov
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#endregion
+
+namespace HtmlTinkerX.JavaScriptBeautifier;
+
+/// <summary>
+/// Represents the internal parser mode used by the <see cref="Beautifier"/>.
+/// </summary>
+public enum BeautifierMode {
+    /// <summary>
+    /// Normal block of statements.
+    /// </summary>
+    Block,
+
+    /// <summary>
+    /// Block opened by a "do" statement.
+    /// </summary>
+    DoBlock,
+
+    /// <summary>
+    /// Array expression enclosed in square brackets.
+    /// </summary>
+    ArrayExpression,
+
+    /// <summary>
+    /// Array expression where indentation has already been increased.
+    /// </summary>
+    IndentedArrayExpression,
+
+    /// <summary>
+    /// Parenthetical expression enclosed in parentheses.
+    /// </summary>
+    ParentheticalExpression,
+
+    /// <summary>
+    /// Parenthetical expression used for a "for" loop.
+    /// </summary>
+    ForExpression,
+
+    /// <summary>
+    /// Parenthetical expression used for a condition.
+    /// </summary>
+    ConditionalExpression,
+
+    /// <summary>
+    /// Object literal expression.
+    /// </summary>
+    Object
+}


### PR DESCRIPTION
## Summary
- add `BeautifierMode` enum for beautifier state management
- store `BeautifierMode` values in `BeautifierFlags`
- update `Beautifier` logic to rely on the enum instead of string literals

## Testing
- `dotnet test Sources/HtmlTinkerX.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687cec3cc464832eb5e1311033f38fc6