### PR TITLE
Fix CS8602 warnings

### DIFF
--- a/Sources/HtmlTinkerX/HtmlOutlineBuilder.cs
+++ b/Sources/HtmlTinkerX/HtmlOutlineBuilder.cs
@@ -75,7 +75,10 @@ public static class HtmlOutlineBuilder {
         var nodes = document.DocumentNode.SelectNodes("//h1|//h2|//h3|//h4|//h5|//h6");
         if (nodes != null) {
             foreach (var node in nodes) {
-                int level = int.Parse(node.Name.Substring(1));
+                if (node == null) {
+                    continue;
+                }
+                int level = int.Parse(node.Name!.Substring(1));
                 string title = HtmlEntity.DeEntitize(node.InnerText ?? string.Empty).Trim();
                 string? id = node.Id;
                 headings.Add((level, title, id));

--- a/Sources/HtmlTinkerX/HtmlParserFromList.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromList.cs
@@ -59,7 +59,11 @@ public static class HtmlParserFromList {
         }
         return results;
 
-        static void CollectSegments(INode node, List<string> list) {
+        static void CollectSegments(INode? node, List<string> list) {
+            if (node == null) {
+                return;
+            }
+
             if (node.NodeType == NodeType.Text) {
                 string text = node.TextContent.Trim();
                 if (!string.IsNullOrWhiteSpace(text)) {
@@ -67,6 +71,9 @@ public static class HtmlParserFromList {
                 }
             } else {
                 foreach (var child in node.ChildNodes) {
+                    if (child == null) {
+                        continue;
+                    }
                     CollectSegments(child, list);
                 }
             }
@@ -175,7 +182,10 @@ public static class HtmlParserFromList {
         }
         return results;
 
-        static void CollectSegments(HtmlNode node, List<string> list) {
+        static void CollectSegments(HtmlNode? node, List<string> list) {
+            if (node == null) {
+                return;
+            }
             if (node.NodeType == HtmlNodeType.Text) {
                 string text = HtmlEntity.DeEntitize(node.InnerText ?? string.Empty).Trim();
                 if (!string.IsNullOrWhiteSpace(text)) {
@@ -183,6 +193,9 @@ public static class HtmlParserFromList {
                 }
             } else {
                 foreach (var child in node.ChildNodes) {
+                    if (child == null) {
+                        continue;
+                    }
                     CollectSegments(child, list);
                 }
             }

--- a/Sources/HtmlTinkerX/HtmlParserFromOpenGraph.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromOpenGraph.cs
@@ -34,7 +34,7 @@ public static class HtmlParserFromOpenGraph {
             if (string.IsNullOrEmpty(property)) {
                 continue;
             }
-            string key = property.Substring(3); // remove "og:" prefix
+            string key = property!.Substring(3); // remove "og:" prefix
             string content = node.GetAttribute("content") ?? string.Empty;
 
             OpenGraphProperty? existing = result.Properties.Find(p => p.Name == key);

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -89,6 +89,9 @@ public static class HtmlParserFromTable {
             List<string> headers = new();
             if (hasHeader) {
                 foreach (var cell in headerCells) {
+                    if (cell == null) {
+                        continue;
+                    }
                     string header = cell.TextContent.Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
@@ -124,6 +127,9 @@ public static class HtmlParserFromTable {
             List<Dictionary<string, string?>> tableRows = new();
             Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
             foreach (var row in rows.Skip(startIndex)) {
+                if (row == null) {
+                    continue;
+                }
                 var cells = row.QuerySelectorAll("th,td");
                 string?[] rowValues = new string?[headers.Count];
                 int col = 0;
@@ -233,6 +239,9 @@ public static class HtmlParserFromTable {
             List<string> headers = new();
             if (hasHeader) {
                 foreach (var cell in headerCells) {
+                    if (cell == null) {
+                        continue;
+                    }
                     string header = cell.TextContent.Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
@@ -257,6 +266,9 @@ public static class HtmlParserFromTable {
             List<Dictionary<string, string?>> tableRows = new();
             Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
             foreach (var row in rows.Skip(startIndex)) {
+                if (row == null) {
+                    continue;
+                }
                 var cells = row.QuerySelectorAll("th,td");
                 string?[] rowValues = new string?[headers.Count];
                 int col = 0;
@@ -430,6 +442,9 @@ public static class HtmlParserFromTable {
                 Dictionary<string, string?> obj = new();
                 int index = 0;
                 foreach (var row in rows) {
+                    if (row == null) {
+                        continue;
+                    }
                     var cells = row.SelectNodes("th|td");
                     if (cells == null || cells.Count == 0) {
                         continue;
@@ -440,7 +455,7 @@ public static class HtmlParserFromTable {
                             header = header.Replace(kv.Key, kv.Value);
                         }
                     }
-                    string value = cells.Count > 1 ? HtmlEntity.DeEntitize(cells[1].InnerText ?? string.Empty).Trim() : string.Empty;
+                    string value = cells.Count > 1 ? HtmlEntity.DeEntitize(cells![1].InnerText ?? string.Empty).Trim() : string.Empty;
                     if (replaceContent != null) {
                         foreach (var kv in replaceContent) {
                             value = value.Replace(kv.Key, kv.Value);
@@ -479,6 +494,9 @@ public static class HtmlParserFromTable {
             List<string> headers = new();
             if (hasHeader) {
                 foreach (var cell in headerCells) {
+                    if (cell == null) {
+                        continue;
+                    }
                     string header = HtmlEntity.DeEntitize(cell.InnerText ?? string.Empty).Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
@@ -510,6 +528,9 @@ public static class HtmlParserFromTable {
             List<Dictionary<string, string?>> tableRows = new();
             Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
             foreach (var row in rows.Skip(startIndex)) {
+                if (row == null) {
+                    continue;
+                }
                 var cells = row.SelectNodes("th|td");
                 if (cells == null) {
                     continue;
@@ -617,6 +638,9 @@ public static class HtmlParserFromTable {
                 Dictionary<string, string?> obj = new();
                 int index = 0;
                 foreach (var row in rows) {
+                    if (row == null) {
+                        continue;
+                    }
                     var cells = row.SelectNodes("th|td");
                     if (cells == null || cells.Count == 0) {
                         continue;
@@ -662,6 +686,9 @@ public static class HtmlParserFromTable {
             List<string> headers = new();
             if (hasHeader) {
                 foreach (var cell in headerCells) {
+                    if (cell == null) {
+                        continue;
+                    }
                     string header = HtmlEntity.DeEntitize(cell.InnerText ?? string.Empty).Trim();
                     if (replaceHeaders != null) {
                         foreach (var kv in replaceHeaders) {
@@ -686,6 +713,9 @@ public static class HtmlParserFromTable {
             List<Dictionary<string, string?>> tableRows = new();
             Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
             foreach (var row in rows.Skip(startIndex)) {
+                if (row == null) {
+                    continue;
+                }
                 var cells = row.SelectNodes("th|td");
                 if (cells == null) {
                     continue;


### PR DESCRIPTION
## Summary
- remove nullable warnings across parsing helpers
- add null checks on list and table parsers
- assert non-null values when appropriate

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `dotnet test Sources/HtmlTinkerX.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687cff286ac8832ea263ffc2485e8bfc