### PR TITLE
Enable Assembly Load Context to avoid module conflicts

### DIFF
--- a/Examples/Example-AssemblyLoadContext.ps1
+++ b/Examples/Example-AssemblyLoadContext.ps1
@@ -1,0 +1,14 @@
+Import-Module ..\PSParseHTML.psd1 -Force
+
+Get-HTMLResource -Url 'https://example.com' | Out-Null
+
+# Display assembly load contexts used by module assemblies
+[AppDomain]::CurrentDomain.GetAssemblies() |
+    Where-Object { $_.GetName().Name -like 'HtmlTinkerX*' -or $_.GetName().Name -like 'PSParseHTML.*' } |
+    ForEach-Object {
+        [pscustomobject]@{
+            Name = $_.GetName().Name
+            ALC  = [Runtime.Loader.AssemblyLoadContext]::GetLoadContext($_).Name
+        }
+    } | Format-Table -AutoSize
+

--- a/Sources/HtmlTinkerX.Tests/AssemblyLoadContextTests.cs
+++ b/Sources/HtmlTinkerX.Tests/AssemblyLoadContextTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class AssemblyLoadContextTests {
+    [Fact]
+    public void OnImportAddsResolver() {
+        // invoke the private resolver to ensure it loads assemblies into a custom ALC
+#if NET5_0_OR_GREATER
+        string assemblyDir = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location)!;
+        string depPath = Path.Combine(assemblyDir, "HtmlAgilityPack.dll");
+        Assert.True(File.Exists(depPath));
+        AssemblyName name = AssemblyName.GetAssemblyName(depPath);
+        MethodInfo method = typeof(OnModuleImportAndRemove).GetMethod("ResolveAlc", BindingFlags.NonPublic | BindingFlags.Static)!;
+        Assembly? asm = (Assembly?)method.Invoke(null, new object[] { AssemblyLoadContext.Default, name });
+        Assert.NotNull(asm);
+        AssemblyLoadContext alc = AssemblyLoadContext.GetLoadContext(asm!)!;
+        Assert.NotEqual("Default", alc.Name);
+#endif
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj
+++ b/Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj
@@ -24,6 +24,11 @@
 
     <ItemGroup>
         <ProjectReference Include="..\HtmlTinkerX\HtmlTinkerX.csproj" />
+        <ProjectReference Include="..\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Management.Automation" Version="7.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
+++ b/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
+#if NET5_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
 
 /// <summary>
 /// OnModuleImportAndRemove is a class that implements the IModuleAssemblyInitializer and IModuleAssemblyCleanup interfaces.
@@ -17,6 +20,11 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
         }
+#if NET5_0_OR_GREATER
+        else {
+            AssemblyLoadContext.Default.Resolving += ResolveAlc;
+        }
+#endif
     }
 
     /// <summary>
@@ -27,6 +35,11 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
         }
+#if NET5_0_OR_GREATER
+        else {
+            AssemblyLoadContext.Default.Resolving -= ResolveAlc;
+        }
+#endif
     }
 
     /// <summary>
@@ -62,6 +75,51 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
 
         return null;
     }
+
+#if NET5_0_OR_GREATER
+    private sealed class LoadContext : AssemblyLoadContext {
+        private readonly string _assemblyDir;
+
+        public LoadContext(string assemblyDir)
+            : base(name: "PSParseHTML", isCollectible: false) {
+            _assemblyDir = assemblyDir;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName) {
+            string asmPath = Path.Join(_assemblyDir, $"{assemblyName.Name}.dll");
+            if (File.Exists(asmPath)) {
+                return LoadFromAssemblyPath(asmPath);
+            }
+
+            return null;
+        }
+    }
+
+    private static readonly string _assemblyDir =
+        Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location)!;
+
+    private static readonly LoadContext _alc = new LoadContext(_assemblyDir);
+
+    private static Assembly? ResolveAlc(AssemblyLoadContext defaultAlc, AssemblyName assemblyToResolve) {
+        string asmPath = Path.Join(_assemblyDir, $"{assemblyToResolve.Name}.dll");
+        if (IsSatisfyingAssembly(assemblyToResolve, asmPath)) {
+            return _alc.LoadFromAssemblyName(assemblyToResolve);
+        }
+
+        return null;
+    }
+
+    private static bool IsSatisfyingAssembly(AssemblyName requiredAssemblyName, string assemblyPath) {
+        if (requiredAssemblyName.Name == "PSParseHTML.PowerShell" || !File.Exists(assemblyPath)) {
+            return false;
+        }
+
+        AssemblyName asmToLoadName = AssemblyName.GetAssemblyName(assemblyPath);
+
+        return string.Equals(asmToLoadName.Name, requiredAssemblyName.Name, StringComparison.OrdinalIgnoreCase)
+            && asmToLoadName.Version >= requiredAssemblyName.Version;
+    }
+#endif
 
     /// <summary>
     /// Determine if the current runtime is .NET Framework


### PR DESCRIPTION
## Summary
- support custom AssemblyLoadContext in PowerShell module
- provide example showing loaded contexts
- add unit test for new resolver

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687d2c75c19c832e8e4d26ac61e0e0cd