### PR TITLE
Fix browser tests

### DIFF
--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -168,13 +168,21 @@ public static class HtmlBrowserTester {
                     
                     // Navigate and measure
                     var startTime = DateTimeOffset.UtcNow;
-                    var response = await page.GotoAsync(url, new PageGotoOptions {
-            WaitUntil = WaitUntilState.NetworkIdle,
-            Timeout = timeout
-                    });
-                    
-                    result.PageLoadTime = DateTimeOffset.UtcNow - startTime;
-                    
+                    try {
+                        await page.GotoAsync(url, new PageGotoOptions {
+                            WaitUntil = WaitUntilState.NetworkIdle,
+                            Timeout = timeout
+                        });
+                    } catch (Exception ex) {
+                        result.ConsoleEntries.Add(new HtmlConsoleEntryDetailed {
+                            Text = ex.Message,
+                            Type = HtmlConsoleMessageType.Error,
+                            Timestamp = DateTimeOffset.UtcNow
+                        });
+                    } finally {
+                        result.PageLoadTime = DateTimeOffset.UtcNow - startTime;
+                    }
+
                     // Wait a bit for any delayed console messages or network requests
                     await page.WaitForTimeoutAsync(1000);
                 } finally {

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -31,18 +31,19 @@ public static class HtmlBrowserTester {
         string? proxyPassword = null) {
         
         var result = new HtmlBrowserTestResult { Url = url };
-        
-        // Ensure Playwright and browser are installed
-        await HtmlBrowser.EnsureInstalledAsync(engine);
-        
-        // Create a browser session without navigating first
-        var playwright = await Playwright.CreateAsync();
+
         try {
-            var browserType = engine switch {
-                HtmlBrowserEngine.Firefox => playwright.Firefox,
-                HtmlBrowserEngine.WebKit => playwright.Webkit,
-                _ => playwright.Chromium
-            };
+            // Ensure Playwright and browser are installed
+            await HtmlBrowser.EnsureInstalledAsync(engine);
+
+            // Create a browser session without navigating first
+            var playwright = await Playwright.CreateAsync();
+            try {
+                var browserType = engine switch {
+                    HtmlBrowserEngine.Firefox => playwright.Firefox,
+                    HtmlBrowserEngine.WebKit => playwright.Webkit,
+                    _ => playwright.Chromium
+                };
             
             var launchOptions = new BrowserTypeLaunchOptions { Headless = headless };
             if (!string.IsNullOrEmpty(proxy)) {
@@ -53,9 +54,10 @@ public static class HtmlBrowserTester {
                 };
             }
             
-            var browser = await browserType.LaunchAsync(launchOptions);
+                var browser = await browserType.LaunchAsync(launchOptions);
             try {
-                var context = await browser.NewContextAsync();
+                var contextOptions = new BrowserNewContextOptions { IgnoreHTTPSErrors = true };
+                var context = await browser.NewContextAsync(contextOptions);
                 try {
                     var page = await context.NewPageAsync();
                     
@@ -175,8 +177,6 @@ public static class HtmlBrowserTester {
                     
                     // Wait a bit for any delayed console messages or network requests
                     await page.WaitForTimeoutAsync(1000);
-                    
-                    return result;
                 } finally {
                     await context.CloseAsync();
                 }
@@ -186,7 +186,16 @@ public static class HtmlBrowserTester {
         } finally {
             playwright.Dispose();
         }
+    } catch (Exception ex) {
+        result.ConsoleEntries.Add(new HtmlConsoleEntryDetailed {
+            Text = ex.Message,
+            Type = HtmlConsoleMessageType.Error,
+            Timestamp = DateTimeOffset.UtcNow
+        });
     }
+
+    return result;
+}
     
     /// <summary>
     /// Tests if a specific CSS resource is loaded.

--- a/Sources/PSParseHTML.PowerShell/Communication/TestHtmlBrowser.cs
+++ b/Sources/PSParseHTML.PowerShell/Communication/TestHtmlBrowser.cs
@@ -171,7 +171,7 @@ public sealed class TestHtmlBrowserCommand : AsyncPSCmdlet {
 /// <summary>
 /// Cleans up Playwright browser downloads and cache.
 /// </summary>
-[Cmdlet(VerbsCommon.Clear, "HtmlBrowserCache")]
+[Cmdlet(VerbsCommon.Clear, "HtmlBrowserCache", SupportsShouldProcess = true)]
 public sealed class ClearHtmlBrowserCacheCommand : PSCmdlet {
     /// <summary>
     /// Force cleanup without confirmation.

--- a/Tests/BrowserTesting.Tests.ps1
+++ b/Tests/BrowserTesting.Tests.ps1
@@ -21,6 +21,12 @@ Describe "Test-HtmlBrowser" {
             $result.PageLoadTime | Should -Not -BeNullOrEmpty
             $result.PageLoadTime.TotalMilliseconds | Should -BeGreaterThan 0
         }
+
+        It "Should capture timing information on timeout" {
+            $result = Test-HtmlBrowser -Url "http://10.255.255.1" -Timeout 1000
+
+            $result.PageLoadTime | Should -Not -BeNullOrEmpty
+        }
     }
 
     Context "Error Detection" {


### PR DESCRIPTION
## Summary
- add SupportsShouldProcess to Clear-HtmlBrowserCache
- handle Playwright errors gracefully
- ignore HTTPS errors when testing URLs

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./PSParseHTML.Tests.ps1` *(fails: Page did not produce any video frames)*

------
https://chatgpt.com/codex/tasks/task_e_687d3ddd47dc832ea4b30286cd409874