### PR TITLE
Add null guard for console log retrieval

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserConsoleLogTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserConsoleLogTests.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using Microsoft.Playwright;
 using Moq;
 using Xunit;
+using System;
 
 namespace HtmlTinkerX.Tests;
 
@@ -27,5 +28,10 @@ public class HtmlBrowserConsoleLogTests {
         Assert.Equal(HtmlConsoleMessageType.Log, entry.Type);
         Assert.Equal("file.js:1:2", entry.Location);
         await session.DisposeAsync();
+    }
+
+    [Fact]
+    public void GetConsoleLog_NullSession_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlBrowser.GetConsoleLog(null!));
     }
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Console.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Console.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace HtmlTinkerX;
@@ -10,6 +11,11 @@ public static partial class HtmlBrowser {
     /// Returns console log captured in the specified session.
     /// </summary>
     /// <param name="session">Browser session containing console log entries.</param>
-    public static IEnumerable<HtmlConsoleEntry> GetConsoleLog(HtmlBrowserSession session)
-        => session.ConsoleLog;
+    public static IEnumerable<HtmlConsoleEntry> GetConsoleLog(HtmlBrowserSession session) {
+        if (session == null) {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        return session.ConsoleLog;
+    }
 }


### PR DESCRIPTION
## Summary
- validate `HtmlBrowserSession` is not null before accessing ConsoleLog
- test that `GetConsoleLog` throws `ArgumentNullException` when session is null

## Testing
- `dotnet build Sources/HtmlTinkerX.sln --no-restore --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_687dff3cbf58832e929112847935b3a3