### PR TITLE
Fix HAR viewer JSON serialization

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
@@ -1,4 +1,5 @@
 using HtmlTinkerX;
+using System.Text.Json;
 
 namespace HtmlTinkerX.Tests;
 
@@ -24,6 +25,26 @@ public class HtmlHarViewerTests {
         Har har = await HtmlHarViewer.ReadHarAsync(GetHarPath());
         string html = HtmlHarViewer.BuildViewerHtml(har);
         Assert.Contains("<table>", html);
+    }
+
+    [Fact]
+    /// <summary>
+    /// Ensures the generated viewer embeds valid JSON data.
+    /// </summary>
+    public async Task BuildViewerHtml_EmbedsValidJson() {
+        Har har = await HtmlHarViewer.ReadHarAsync(GetMinimalHarPath());
+        string html = HtmlHarViewer.BuildViewerHtml(har);
+        int idx = html.IndexOf("const har =", StringComparison.Ordinal);
+        Assert.NotEqual(-1, idx);
+        int start = html.IndexOf('{', idx);
+        int end = html.IndexOf("};", start, StringComparison.Ordinal);
+        string json = html.Substring(start, end - start + 1);
+        var opts = new JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        Har? parsed = JsonSerializer.Deserialize<Har>(json, opts);
+        Assert.NotNull(parsed);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/HtmlHarViewer.cs
+++ b/Sources/HtmlTinkerX/HtmlHarViewer.cs
@@ -77,7 +77,10 @@ public static class HtmlHarViewer {
     /// </example>
     public static async Task<Har> ReadHarAsync(string path) {
         string json = await HtmlUtilities.ReadFileCheckedAsync(path).ConfigureAwait(false);
-        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var opts = new JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
         try {
             Har? har = JsonSerializer.Deserialize<Har>(json, opts);
             return har ?? throw new InvalidDataException("Invalid HAR content");


### PR DESCRIPTION
## Summary
- use camelCase naming for HAR JSON deserialization
- test that the generated HAR viewer script contains valid JSON

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln -c Release --no-build -f net8.0` *(fails: HtmlBrowserTesterTests.TestUrlAsync_CapturesNetworkRequests)*
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./PSParseHTML.Tests.ps1` *(interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687dff364a68832e8451e27c79e9962d