### PR TITLE
Add EnsureDirectoryExists helper and update usages

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
@@ -112,4 +112,28 @@ public class HtmlUtilitiesTests {
         string result = await HtmlUtilities.GetStringWithProperEncodingAsync(client, server.BaseAddress.ToString());
         Assert.Equal("<meta charset=\"UTF-16\">Hello", result);
     }
+
+    [Fact]
+    public void EnsureDirectoryExists_CreatesMissingDirectory() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try {
+            string full = HtmlUtilities.EnsureDirectoryExists(dir);
+            Assert.True(Directory.Exists(full));
+        } finally {
+            if (Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void EnsureDirectoryExists_CreatesParentForFile() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string file = Path.Combine(dir, "test.txt");
+        try {
+            string full = HtmlUtilities.EnsureDirectoryExists(file);
+            Assert.True(Directory.Exists(Path.GetDirectoryName(full)!));
+            Assert.Equal(Path.GetFullPath(file), full);
+        } finally {
+            if (Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlResourceParser.cs
+++ b/Sources/HtmlTinkerX/HtmlResourceParser.cs
@@ -105,8 +105,7 @@ public static class HtmlResourceParser {
             throw new ArgumentNullException(nameof(directory));
         }
 
-        string dir = HtmlUtilities.ResolvePath(directory);
-        Directory.CreateDirectory(dir);
+        string dir = HtmlUtilities.EnsureDirectoryExists(directory);
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
         List<string> paths = new();
 

--- a/Sources/HtmlTinkerX/HtmlUtilities.cs
+++ b/Sources/HtmlTinkerX/HtmlUtilities.cs
@@ -26,6 +26,23 @@ public static class HtmlUtilities {
     }
 
     /// <summary>
+    /// Ensures the directory for the specified path exists and returns the
+    /// resolved absolute path.
+    /// </summary>
+    /// <param name="path">Directory or file path.</param>
+    /// <returns>The resolved absolute path.</returns>
+    public static string EnsureDirectoryExists(string path) {
+        string fullPath = ResolvePath(path);
+        string? dir = Directory.Exists(fullPath) || !Path.HasExtension(fullPath)
+            ? fullPath
+            : Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
+        return fullPath;
+    }
+
+    /// <summary>
     /// Reads the contents of a file after verifying that it exists.
     /// </summary>
     /// <param name="path">Path to the file.</param>

--- a/Sources/HtmlTinkerX/Models/HtmlResourceLink.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlResourceLink.cs
@@ -58,15 +58,12 @@ public sealed class HtmlResourceLink {
             throw new ArgumentNullException(nameof(path));
         }
 
-        string resolved = HtmlUtilities.ResolvePath(path);
+        string resolved = HtmlUtilities.EnsureDirectoryExists(path);
         if (Directory.Exists(resolved) || !Path.HasExtension(resolved)) {
-            Directory.CreateDirectory(resolved);
             string fileName = string.IsNullOrEmpty(Name)
                 ? (!string.IsNullOrEmpty(Source) ? Path.GetFileName(Source) : $"resource_{Index}")
                 : Name;
             resolved = Path.Combine(resolved, fileName);
-        } else {
-            Directory.CreateDirectory(Path.GetDirectoryName(resolved)!);
         }
 
         if (!string.IsNullOrEmpty(Content)) {

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -52,8 +52,7 @@ public static partial class HtmlBrowser {
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async IAsyncEnumerable<string> SavePageDownloadsAsync(IPage page, string directory, string? filter = null, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
-        string dir = HtmlUtilities.ResolvePath(directory);
-        Directory.CreateDirectory(dir);
+        string dir = HtmlUtilities.EnsureDirectoryExists(directory);
         HashSet<string> downloads = new();
         List<Task> saveTasks = new();
         object sync = new();

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SavePdf.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SavePdf.cs
@@ -130,11 +130,7 @@ public static partial class HtmlBrowser {
             await page.WaitForTimeoutAsync(delayMs);
         }
 
-        string fullPath = HtmlUtilities.ResolvePath(path);
-        string? dir = Path.GetDirectoryName(fullPath);
-        if (!string.IsNullOrEmpty(dir)) {
-            Directory.CreateDirectory(dir);
-        }
+        string fullPath = HtmlUtilities.EnsureDirectoryExists(path);
         var options = new PagePdfOptions {
             Path = fullPath,
             Landscape = landscape,

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
@@ -118,11 +118,7 @@ public static partial class HtmlBrowser {
             }
         }
 
-        string fullPath = HtmlUtilities.ResolvePath(path);
-        string? dir = Path.GetDirectoryName(fullPath);
-        if (!string.IsNullOrEmpty(dir)) {
-            Directory.CreateDirectory(dir);
-        }
+        string fullPath = HtmlUtilities.EnsureDirectoryExists(path);
         var pwOptions = new PageScreenshotOptions { FullPage = options.FullPage };
         pwOptions.Type = options.Format == ImageFormat.Jpeg ? ScreenshotType.Jpeg : ScreenshotType.Png;
         if (pwOptions.Type == ScreenshotType.Jpeg) {

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Tracing.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Tracing.cs
@@ -34,11 +34,7 @@ public static partial class HtmlBrowser {
     /// <returns>A task representing the asynchronous operation.</returns>
     public static Task StopTracingAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
-        string full = HtmlUtilities.ResolvePath(path);
-        string? dir = Path.GetDirectoryName(full);
-        if (!string.IsNullOrEmpty(dir)) {
-            Directory.CreateDirectory(dir);
-        }
+        string full = HtmlUtilities.EnsureDirectoryExists(path);
         return session.Context.Tracing.StopAsync(new Microsoft.Playwright.TracingStopOptions { Path = full });
     }
 
@@ -51,11 +47,7 @@ public static partial class HtmlBrowser {
     /// <returns>A task that completes when the file has been written.</returns>
     public static Task ExportHarAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
         cancellationToken.ThrowIfCancellationRequested();
-        string full = HtmlUtilities.ResolvePath(path);
-        string? dir = Path.GetDirectoryName(full);
-        if (!string.IsNullOrEmpty(dir)) {
-            Directory.CreateDirectory(dir);
-        }
+        string full = HtmlUtilities.EnsureDirectoryExists(path);
         var log = new {
             log = new {
                 version = "1.2",

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
@@ -94,9 +94,8 @@ public static partial class HtmlBrowser {
         }
 
         if (!string.IsNullOrEmpty(videoPath)) {
-            string resolved = HtmlUtilities.ResolvePath(videoPath!);
+            string resolved = HtmlUtilities.EnsureDirectoryExists(videoPath!);
             string dir = Path.GetDirectoryName(resolved) ?? resolved;
-            Directory.CreateDirectory(dir);
             contextOptions.RecordVideoDir = dir;
             contextOptions.RecordVideoSize = new RecordVideoSize { Width = videoWidth, Height = videoHeight };
         }


### PR DESCRIPTION
## Summary
- add `EnsureDirectoryExists` to `HtmlUtilities`
- use helper across the library when creating directories
- extend `HtmlUtilitiesTests` for the new helper

## Testing
- `dotnet test Sources/HtmlTinkerX.sln -f net8.0 -v minimal`
- `dotnet build Sources/HtmlTinkerX.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687e5ce55acc832e9a4ac2bc56d26902