### PR TITLE
Add severity filter for HTML console logs

### DIFF
--- a/Examples/Example-ConsoleLog.ps1
+++ b/Examples/Example-ConsoleLog.ps1
@@ -4,6 +4,7 @@ $path = Join-Path $PSScriptRoot 'Input/console_page.html'
 $uri = [System.Uri]::new($path).AbsoluteUri
 $session = Invoke-HTMLRendering -Url $uri -Session
 Start-Sleep -Milliseconds 500
-Get-HTMLConsoleLog -Session $session | Format-Table
+Get-HTMLConsoleLog -Session $session -Severity Error | Format-Table
 Close-HTMLSession -Session $session
+
 

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserConsoleLogTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserConsoleLogTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Playwright;
 using Moq;
 using Xunit;
 using System;
+using System.Linq;
 
 namespace HtmlTinkerX.Tests;
 
@@ -33,5 +34,31 @@ public class HtmlBrowserConsoleLogTests {
     [Fact]
     public void GetConsoleLog_NullSession_Throws() {
         Assert.Throws<ArgumentNullException>(() => HtmlBrowser.GetConsoleLog(null!));
+    }
+
+    [Fact]
+    public async Task GetConsoleLog_FiltersBySeverity() {
+        var playwright = new Mock<IPlaywright>();
+        var browser = new Mock<IBrowser>();
+        var context = new Mock<IBrowserContext>();
+        var page = new Mock<IPage>();
+
+        var err = new Mock<IConsoleMessage>();
+        err.SetupGet(m => m.Text).Returns("boom");
+        err.SetupGet(m => m.Type).Returns("error");
+
+        var info = new Mock<IConsoleMessage>();
+        info.SetupGet(m => m.Text).Returns("hi");
+        info.SetupGet(m => m.Type).Returns("log");
+
+        var session = new HtmlBrowserSession(playwright.Object, browser.Object, context.Object, page.Object);
+
+        page.Raise(p => p.Console += null!, page.Object, err.Object);
+        page.Raise(p => p.Console += null!, page.Object, info.Object);
+
+        var entries = HtmlBrowser.GetConsoleLog(session, HtmlConsoleSeverity.Error).ToList();
+        Assert.Single(entries);
+        Assert.Equal(HtmlConsoleMessageType.Error, entries[0].Type);
+        await session.DisposeAsync();
     }
 }

--- a/Sources/HtmlTinkerX/Enums/HtmlConsoleSeverity.cs
+++ b/Sources/HtmlTinkerX/Enums/HtmlConsoleSeverity.cs
@@ -1,0 +1,13 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Severity levels for filtering console log entries.
+/// </summary>
+public enum HtmlConsoleSeverity {
+    /// <summary>Informational messages.</summary>
+    Info,
+    /// <summary>Warning messages.</summary>
+    Warning,
+    /// <summary>Error messages.</summary>
+    Error
+}

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Console.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Console.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HtmlTinkerX;
 
@@ -11,11 +12,22 @@ public static partial class HtmlBrowser {
     /// Returns console log captured in the specified session.
     /// </summary>
     /// <param name="session">Browser session containing console log entries.</param>
-    public static IEnumerable<HtmlConsoleEntry> GetConsoleLog(HtmlBrowserSession session) {
+    /// <param name="severity">Optional severity filter.</param>
+    public static IEnumerable<HtmlConsoleEntry> GetConsoleLog(HtmlBrowserSession session, HtmlConsoleSeverity? severity = null) {
         if (session == null) {
             throw new ArgumentNullException(nameof(session));
         }
 
-        return session.ConsoleLog;
+        if (severity == null) {
+            return session.ConsoleLog;
+        }
+
+        HtmlConsoleSeverity sev = severity.Value;
+        return session.ConsoleLog.Where(e => sev switch {
+            HtmlConsoleSeverity.Error => e.Type == HtmlConsoleMessageType.Error || e.Type == HtmlConsoleMessageType.Assert,
+            HtmlConsoleSeverity.Warning => e.Type == HtmlConsoleMessageType.Warning,
+            HtmlConsoleSeverity.Info => e.Type != HtmlConsoleMessageType.Error && e.Type != HtmlConsoleMessageType.Assert && e.Type != HtmlConsoleMessageType.Warning,
+            _ => true
+        });
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlConsoleLog.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlConsoleLog.cs
@@ -18,11 +18,15 @@ public sealed class CmdletGetHtmlConsoleLog : AsyncPSCmdlet {
     [Parameter(Position = 0, ValueFromPipeline = true)]
     public HtmlBrowserSession? Session { get; set; }
 
+    /// <summary>Optional severity filter.</summary>
+    [Parameter(Position = 1)]
+    public HtmlConsoleSeverity? Severity { get; set; }
+
     /// <inheritdoc />
     protected override Task ProcessRecordAsync() {
         HtmlBrowserSession session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession")
             ?? throw new PSInvalidOperationException("No session provided and no default session found.");
-        WriteObject(HtmlBrowser.GetConsoleLog(session), true);
+        WriteObject(HtmlBrowser.GetConsoleLog(session, Severity), true);
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- add `HtmlConsoleSeverity` enum for filtering
- extend `HtmlBrowser.GetConsoleLog` with severity parameter
- add `Severity` parameter to `Get-HTMLConsoleLog`
- demonstrate usage in console log example
- test severity filtering

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File PSParseHTML.Tests.ps1`
- `dotnet test Sources/HtmlTinkerX.sln --no-build` *(fails: Failed to negotiate protocol)*

------
https://chatgpt.com/codex/tasks/task_e_687e69ebe9c0832e85b823d1d4869882