### PR TITLE
Add asynchronous CSS inlining formatter

### DIFF
--- a/Sources/HtmlTinkerX.Examples/FormatHtmlInlineCssExample.cs
+++ b/Sources/HtmlTinkerX.Examples/FormatHtmlInlineCssExample.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates inlining CSS in HTML asynchronously.
+/// </summary>
+public static class FormatHtmlInlineCssExample {
+    /// <summary>Executes the example logic.</summary>
+    public static async Task RunAsync() {
+        const string html = "<html><head><style>h1{color:red}</style></head><body><h1>Hello</h1></body></html>";
+        string result = await HtmlFormatter.FormatHtmlInlineCssAsync(
+            html,
+            new PreMailerOptions { RemoveStyleElements = true });
+        Console.WriteLine(result);
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/FormatHtmlInlineCssAsyncTests.cs
+++ b/Sources/HtmlTinkerX.Tests/FormatHtmlInlineCssAsyncTests.cs
@@ -1,0 +1,26 @@
+using HtmlTinkerX;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class FormatHtmlInlineCssAsyncTests {
+    private const string Html = "<html><head><style>p{color:red}</style></head><body><p>Hello</p></body></html>";
+
+    [Fact]
+    public async Task FormatHtmlInlineCssAsync_RemovesStyleElements() {
+        var options = new PreMailerOptions { RemoveStyleElements = true };
+        string result = await HtmlFormatter.FormatHtmlInlineCssAsync(Html, options, CancellationToken.None);
+        Assert.DoesNotContain("<style", result, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("style=", result, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FormatHtmlInlineCssAsync_CanceledToken_Throws() {
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            HtmlFormatter.FormatHtmlInlineCssAsync(Html, null, cts.Token));
+    }
+}

--- a/Sources/HtmlTinkerX/HtmlFormatter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormatter.cs
@@ -6,6 +6,7 @@ using NUglify.Html;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace HtmlTinkerX;
@@ -306,5 +307,22 @@ public static class HtmlFormatter {
             alphabeticallyOrderAttributes,
             removeEmptyBlocks,
             isFragment).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously inlines CSS in the provided HTML string using PreMailer.Net.
+    /// </summary>
+    /// <param name="html">HTML markup to process.</param>
+    /// <param name="options">Optional processing options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>HTML with CSS inlined.</returns>
+    public static async Task<string> FormatHtmlInlineCssAsync(
+        string html,
+        PreMailerOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        PreMailerResult result = await PreMailerClient
+            .MoveCssInlineAsync(html, options, cancellationToken)
+            .ConfigureAwait(false);
+        return result.Html;
     }
 }


### PR DESCRIPTION
## Summary
- add `FormatHtmlInlineCssAsync` to `HtmlFormatter`
- add example usage in examples project
- test async CSS inlining functionality

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln -c Release --no-build --framework net8.0`
- `dotnet test Sources/HtmlTinkerX.sln -c Release --no-build --framework net472` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_687f34314a30832eb099da550a300b3e