### PR TITLE
Add mobile device emulation helper

### DIFF
--- a/Sources/HtmlTinkerX.Examples/MobileDeviceExample.cs
+++ b/Sources/HtmlTinkerX.Examples/MobileDeviceExample.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates how to open a page emulating a mobile device.
+/// </summary>
+public static class MobileDeviceExample {
+    /// <summary>Executes the example logic.</summary>
+    public static async Task RunAsync() {
+        HtmlMobileDeviceInfo info = HtmlBrowser.GetMobileDeviceInfo(HtmlMobileDevice.IPhone12);
+        await using HtmlBrowserSession session = await HtmlBrowser.OpenSessionAsync(
+            "https://example.com",
+            userAgent: info.UserAgent,
+            viewportWidth: info.ViewportWidth,
+            viewportHeight: info.ViewportHeight).ConfigureAwait(false);
+        Console.WriteLine(await session.Page.TitleAsync().ConfigureAwait(false));
+        await HtmlBrowser.CloseSessionAsync(session).ConfigureAwait(false);
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserMobileDeviceTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserMobileDeviceTests.cs
@@ -1,0 +1,14 @@
+using HtmlTinkerX;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlBrowserMobileDeviceTests {
+    [Fact]
+    public void GetMobileDeviceInfo_ReturnsExpectedInfo() {
+        HtmlMobileDeviceInfo info = HtmlBrowser.GetMobileDeviceInfo(HtmlMobileDevice.Pixel5);
+        Assert.Contains("Pixel 5", info.UserAgent);
+        Assert.Equal(393, info.ViewportWidth);
+        Assert.Equal(851, info.ViewportHeight);
+    }
+}

--- a/Sources/HtmlTinkerX/Enums/HtmlMobileDevice.cs
+++ b/Sources/HtmlTinkerX/Enums/HtmlMobileDevice.cs
@@ -1,0 +1,13 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Common mobile devices for emulation.
+/// </summary>
+public enum HtmlMobileDevice {
+    /// <summary>Apple iPhone 12.</summary>
+    IPhone12,
+    /// <summary>Google Pixel 5.</summary>
+    Pixel5,
+    /// <summary>Samsung Galaxy S8.</summary>
+    GalaxyS8
+}

--- a/Sources/HtmlTinkerX/Models/HtmlMobileDeviceInfo.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlMobileDeviceInfo.cs
@@ -1,0 +1,13 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Viewport and user agent settings for a mobile device.
+/// </summary>
+public sealed class HtmlMobileDeviceInfo {
+    /// <summary>User agent string.</summary>
+    public string UserAgent { get; set; } = string.Empty;
+    /// <summary>Viewport width in pixels.</summary>
+    public int ViewportWidth { get; set; }
+    /// <summary>Viewport height in pixels.</summary>
+    public int ViewportHeight { get; set; }
+}

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
@@ -505,4 +505,39 @@ public static partial class HtmlBrowser {
         string[] parts = text.Replace("  ", " ").Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
         return $"Strict mode violation for '{query}':" + Environment.NewLine + string.Join(Environment.NewLine, parts);
     }
+    /// <summary>
+    /// Provides viewport and user agent settings for well known mobile devices.
+    /// </summary>
+    public static HtmlMobileDeviceInfo GetMobileDeviceInfo(HtmlMobileDevice device) => device switch {
+        HtmlMobileDevice.IPhone12 => new HtmlMobileDeviceInfo {
+            UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1",
+            ViewportWidth = 390,
+            ViewportHeight = 844
+        },
+        HtmlMobileDevice.Pixel5 => new HtmlMobileDeviceInfo {
+            UserAgent = "Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0 Mobile Safari/537.36",
+            ViewportWidth = 393,
+            ViewportHeight = 851
+        },
+        HtmlMobileDevice.GalaxyS8 => new HtmlMobileDeviceInfo {
+            UserAgent = "Mozilla/5.0 (Linux; Android 7.0; SM-G950U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0 Mobile Safari/537.36",
+            ViewportWidth = 360,
+            ViewportHeight = 740
+        },
+        _ => throw new System.ArgumentOutOfRangeException(nameof(device))
+    };
+
+    /// <summary>
+    /// Applies mobile device emulation settings to an existing session.
+    /// </summary>
+    public static async Task SetMobileDeviceAsync(HtmlBrowserSession session, HtmlMobileDevice device, CancellationToken cancellationToken = default) {
+        if (session == null) {
+            throw new System.ArgumentNullException(nameof(session));
+        }
+        HtmlMobileDeviceInfo info = GetMobileDeviceInfo(device);
+        cancellationToken.ThrowIfCancellationRequested();
+        await session.Context.AddInitScriptAsync($"Object.defineProperty(navigator, 'userAgent', {{ get: () => '{info.UserAgent}' }});").ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        await session.Page.SetViewportSizeAsync(info.ViewportWidth, info.ViewportHeight).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
## Summary
- add `HtmlMobileDevice` enum and `HtmlMobileDeviceInfo` model
- implement device helper methods in `HtmlBrowser`
- include example for using mobile device settings
- cover new helper in unit tests

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet build Sources/HtmlTinkerX.sln -c Debug`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --no-build`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net472 --no-build` *(fails: mono not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f342210ec832e874269ae677c3d3d