### PR TITLE
Capture console error stack trace

### DIFF
--- a/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
@@ -111,6 +111,21 @@ public class HtmlBrowserTesterTests {
         Assert.NotNull(errors);
         Assert.All(errors, error => Assert.True(error.IsError));
     }
+
+    [Fact]
+    public async Task ConsoleError_CapturesStackTrace() {
+        // Arrange
+        var url = "data:text/html,<script>console.error(new Error('fail'));</script>";
+
+        // Act
+        var errors = await HtmlBrowserTester.TestConsoleErrorsAsync(url);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.True(error.IsError);
+        Assert.False(string.IsNullOrEmpty(error.StackTrace));
+        Assert.Contains("Error: fail", error.StackTrace);
+    }
     
     [Fact]
     public async Task TestPerformanceAsync_ReturnsMetrics() {

--- a/Sources/HtmlTinkerX/Models/HtmlConsoleEntry.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlConsoleEntry.cs
@@ -14,4 +14,9 @@ public sealed class HtmlConsoleEntry {
 
     /// <summary>Location of the message if available.</summary>
     public string? Location { get; set; }
+
+    /// <summary>
+    /// Stack trace information if present.
+    /// </summary>
+    public string? StackTrace { get; set; }
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -2,7 +2,9 @@ using Microsoft.Playwright;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using System.Text.Json.Nodes;
 
 namespace HtmlTinkerX;
 
@@ -58,12 +60,32 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
         VideoPath = videoPath;
         _network = network ?? new ConcurrentDictionary<IRequest, HtmlNetworkEntry>();
 
-        Page.Console += (_, msg) => {
+        Page.Console += async (_, msg) => {
             HtmlConsoleEntry entry = new() {
                 Text = msg.Text,
                 Type = HtmlEnumParser.ParseConsoleMessageType(msg.Type),
                 Location = msg.Location?.ToString()
             };
+
+            if (entry.Type == HtmlConsoleMessageType.Error || entry.Type == HtmlConsoleMessageType.Assert) {
+                try {
+                    var firstArg = msg.Args.FirstOrDefault();
+                    if (firstArg != null) {
+                        var obj = await firstArg.JsonValueAsync<object>().ConfigureAwait(false);
+                        if (obj is System.Text.Json.Nodes.JsonObject jsonObj) {
+                            if (jsonObj.TryGetPropertyValue("message", out var messageNode) && messageNode is not null) {
+                                entry.Text = messageNode.ToString();
+                            }
+                            if (jsonObj.TryGetPropertyValue("stack", out var stackNode) && stackNode is not null) {
+                                entry.StackTrace = stackNode.ToString();
+                            }
+                        }
+                    }
+                } catch {
+                    // Ignore stack trace parsing errors
+                }
+            }
+
             _console.Enqueue(entry);
         };
 

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -61,28 +61,43 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
         _network = network ?? new ConcurrentDictionary<IRequest, HtmlNetworkEntry>();
 
         Page.Console += async (_, msg) => {
-            HtmlConsoleEntry entry = new() {
+            HtmlConsoleEntry entry = new()
+            {
                 Text = msg.Text,
                 Type = HtmlEnumParser.ParseConsoleMessageType(msg.Type),
                 Location = msg.Location?.ToString()
             };
 
-            if (entry.Type == HtmlConsoleMessageType.Error || entry.Type == HtmlConsoleMessageType.Assert) {
-                try {
-                    var firstArg = msg.Args.FirstOrDefault();
-                    if (firstArg != null) {
-                        var obj = await firstArg.JsonValueAsync<object>().ConfigureAwait(false);
-                        if (obj is System.Text.Json.Nodes.JsonObject jsonObj) {
-                            if (jsonObj.TryGetPropertyValue("message", out var messageNode) && messageNode is not null) {
-                                entry.Text = messageNode.ToString();
-                            }
-                            if (jsonObj.TryGetPropertyValue("stack", out var stackNode) && stackNode is not null) {
-                                entry.StackTrace = stackNode.ToString();
-                            }
+            if (entry.Type == HtmlConsoleMessageType.Error || entry.Type == HtmlConsoleMessageType.Assert)
+            {
+                var firstArg = msg.Args.FirstOrDefault();
+                if (firstArg != null)
+                {
+                    try
+                    {
+                        string? message = await firstArg.EvaluateAsync<string?>("arg => arg?.message").ConfigureAwait(false);
+                        if (!string.IsNullOrEmpty(message))
+                        {
+                            entry.Text = message;
                         }
                     }
-                } catch {
-                    // Ignore stack trace parsing errors
+                    catch
+                    {
+                        // Ignore message extraction failures
+                    }
+
+                    try
+                    {
+                        string? stack = await firstArg.EvaluateAsync<string?>("arg => arg?.stack").ConfigureAwait(false);
+                        if (!string.IsNullOrEmpty(stack))
+                        {
+                            entry.StackTrace = stack;
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore stack trace extraction failures
+                    }
                 }
             }
 

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text.Json.Nodes;
 
 namespace HtmlTinkerX;
 
@@ -246,6 +247,25 @@ public static class HtmlBrowserTester {
                 Timestamp = DateTimeOffset.UtcNow,
                 Location = msg.Location
             };
+
+            if (entry.IsError) {
+                try {
+                    var firstArg = msg.Args.FirstOrDefault();
+                    if (firstArg != null) {
+                        var obj = await firstArg.JsonValueAsync<object>().ConfigureAwait(false);
+                        if (obj is JsonObject jsonObj) {
+                            if (jsonObj.TryGetPropertyValue("message", out var messageNode) && messageNode is not null) {
+                                entry.Text = messageNode.ToString();
+                            }
+                            if (jsonObj.TryGetPropertyValue("stack", out var stackNode) && stackNode is not null) {
+                                entry.StackTrace = stackNode.ToString();
+                            }
+                        }
+                    }
+                } catch {
+                    // Ignore stack trace parsing errors
+                }
+            }
 
             if (!string.IsNullOrEmpty(msg.Location)) {
                 var parts = msg.Location.Split(':');

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -240,30 +240,46 @@ public static class HtmlBrowserTester {
             }
         };
 
-        page.Console += async (_, msg) => {
-            var entry = new HtmlConsoleEntryDetailed {
+        page.Console += async (_, msg) =>
+        {
+            var entry = new HtmlConsoleEntryDetailed
+            {
                 Text = msg.Text,
                 Type = HtmlEnumParser.ParseConsoleMessageType(msg.Type),
                 Timestamp = DateTimeOffset.UtcNow,
                 Location = msg.Location
             };
 
-            if (entry.IsError) {
-                try {
-                    var firstArg = msg.Args.FirstOrDefault();
-                    if (firstArg != null) {
-                        var obj = await firstArg.JsonValueAsync<object>().ConfigureAwait(false);
-                        if (obj is JsonObject jsonObj) {
-                            if (jsonObj.TryGetPropertyValue("message", out var messageNode) && messageNode is not null) {
-                                entry.Text = messageNode.ToString();
-                            }
-                            if (jsonObj.TryGetPropertyValue("stack", out var stackNode) && stackNode is not null) {
-                                entry.StackTrace = stackNode.ToString();
-                            }
+            if (entry.IsError)
+            {
+                var firstArg = msg.Args.FirstOrDefault();
+                if (firstArg != null)
+                {
+                    try
+                    {
+                        string? message = await firstArg.EvaluateAsync<string?>("arg => arg?.message").ConfigureAwait(false);
+                        if (!string.IsNullOrEmpty(message))
+                        {
+                            entry.Text = message;
                         }
                     }
-                } catch {
-                    // Ignore stack trace parsing errors
+                    catch
+                    {
+                        // Ignore message extraction failures
+                    }
+
+                    try
+                    {
+                        string? stack = await firstArg.EvaluateAsync<string?>("arg => arg?.stack").ConfigureAwait(false);
+                        if (!string.IsNullOrEmpty(stack))
+                        {
+                            entry.StackTrace = stack;
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore stack trace extraction failures
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- capture stack trace info for console errors
- include stack trace when logging console errors in browser session
- record stack trace in tester
- test that stack trace is captured

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --verbosity minimal` *(fails: Failed to negotiate protocol)*

------
https://chatgpt.com/codex/tasks/task_e_687f347c7824832e8c2fe41e21c144ca