### PR TITLE
Implement PNG compression quality

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
@@ -4,6 +4,9 @@ using Moq;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats;
+using System.Reflection;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -111,5 +114,16 @@ public class HtmlBrowserScreenshotTests {
 
         File.Delete(file);
         Directory.Delete(dir);
+    }
+
+    [Theory]
+    [InlineData(100, 0)]
+    [InlineData(50, 5)]
+    [InlineData(0, 9)]
+    public void GetEncoder_MapsQualityToCompression(int quality, int expected) {
+        MethodInfo method = typeof(HtmlBrowser).GetMethod("GetEncoder", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var encoder = (IImageEncoder)method.Invoke(null, new object[] { ImageFormat.Png, quality })!;
+        var png = Assert.IsType<PngEncoder>(encoder);
+        Assert.Equal(expected, (int)png.CompressionLevel);
     }
 }

--- a/Sources/HtmlTinkerX/Models/ScreenshotOptions.cs
+++ b/Sources/HtmlTinkerX/Models/ScreenshotOptions.cs
@@ -15,7 +15,7 @@ public sealed class ScreenshotOptions {
     /// <summary>Image file format.</summary>
     public ImageFormat Format { get; set; } = ImageFormat.Png;
 
-    /// <summary>Encoder quality for JPEG output.</summary>
+    /// <summary>Encoder quality for JPEG output and compression for PNG.</summary>
     public int Quality { get; set; } = 100;
 
     /// <summary>Optional CSS selector to wait for before capturing.</summary>

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
@@ -175,6 +175,21 @@ public static partial class HtmlBrowser {
         ImageFormat.Jpeg => new JpegEncoder { Quality = quality },
         ImageFormat.Bmp => new BmpEncoder(),
         ImageFormat.Gif => new GifEncoder(),
-        _ => new PngEncoder()
+        _ => new PngEncoder { CompressionLevel = (PngCompressionLevel)QualityToCompression(quality) }
     };
+
+    private static int QualityToCompression(int quality) {
+        if (quality < 0) {
+            quality = 0;
+        } else if (quality > 100) {
+            quality = 100;
+        }
+        int level = (int)Math.Round((100 - quality) / 10.0);
+        if (level < 0) {
+            level = 0;
+        } else if (level > 9) {
+            level = 9;
+        }
+        return level;
+    }
 }


### PR DESCRIPTION
## Summary
- link ScreenshotOptions.Quality to `PngEncoder.CompressionLevel`
- document PNG compression in ScreenshotOptions
- test compression level mapping via reflection

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln -c Release` *(fails: PreMailerClientPathTests.NormalizeFileUriPath_UncPaths, PreMailerClientPathTests.NormalizeFileUriPath_UncPaths_TrailingSlash, PreMailerClientRemoteCssAnalyticsTests.MoveCssInline_InlinesRemoteAndLocalCss_AddsAnalyticsTags)*

------
https://chatgpt.com/codex/tasks/task_e_687ff9b07a68832e9432e9f290575ab2