### PR TITLE
Fix table parsing when thead missing

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlParserFromTableHelpersTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserFromTableHelpersTests.cs
@@ -29,4 +29,15 @@ public class HtmlParserFromTableHelpersTests {
         Assert.Equal("1", row["A"]);
         Assert.Equal("2", row["B"]);
     }
+
+    [Fact]
+    public void ReadTableMetadata_NoThead_DoesNotThrow() {
+        const string html = "<table><tbody><tr><td>1</td><td>2</td></tr></tbody></table>";
+        var doc = HtmlParser.ParseWithAngleSharp(html);
+        var table = doc.QuerySelector("table")!;
+        var (meta, rows, _) = HtmlParserFromTable.ReadTableMetadata(table, 0, null, false, false);
+        Assert.Equal(2, meta.ColumnCount);
+        Assert.Equal(new[] { "Column1", "Column2" }, meta.Headers);
+        Assert.Equal(1, meta.RowCount);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -97,11 +97,22 @@ public static class HtmlParserFromTable {
 
         int headerRowIndex = 0;
         bool hasHeader = false;
-        for (int i = 0; i < rows.Length; i++) {
-            if (rows[i].QuerySelectorAll("th").Length > 0) {
-                headerRowIndex = i;
-                hasHeader = true;
-                break;
+        IElement? theadRow = table.QuerySelector("thead tr");
+        if (theadRow != null) {
+            int idx = Array.IndexOf(rows, theadRow);
+            if (idx >= 0) {
+                headerRowIndex = idx;
+                hasHeader = theadRow.QuerySelectorAll("th").Length > 0;
+            }
+        }
+
+        if (!hasHeader) {
+            for (int i = 0; i < rows.Length; i++) {
+                if (rows[i].QuerySelectorAll("th").Length > 0) {
+                    headerRowIndex = i;
+                    hasHeader = true;
+                    break;
+                }
             }
         }
         var headerRow = rows[headerRowIndex];


### PR DESCRIPTION
## Summary
- guard against null thead rows when parsing table metadata
- test ReadTableMetadata on tables without a thead

## Testing
- `dotnet test Sources/HtmlTinkerX.sln --verbosity minimal` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_687ff99fad98832e9b1a2439b43f3106