### PR TITLE
Fix AddCookiesAsync always awaited

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
@@ -92,6 +92,24 @@ public class HtmlBrowserCookiesTests {
     }
 
     [Fact]
+    public async Task SetCookiesAsync_EmptyList_StillCallsAddCookiesAsync() {
+        var context = new Mock<IBrowserContext>();
+        var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));
+        typeof(HtmlBrowserSession)
+            .GetField("<Context>k__BackingField", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(session, context.Object);
+
+        IEnumerable<HtmlCookie> cookies = Array.Empty<HtmlCookie>();
+
+        context.Setup(c => c.AddCookiesAsync(It.Is<IEnumerable<Cookie>>(l => !l.Any())))
+            .Returns(Task.CompletedTask).Verifiable();
+
+        await HtmlBrowser.SetCookiesAsync(session, cookies);
+
+        context.Verify();
+    }
+
+    [Fact]
     public async Task GetCookiesAsync_FiltersByDomain() {
         var context = new Mock<IBrowserContext>();
         var session = (HtmlBrowserSession)RuntimeHelpers.GetUninitializedObject(typeof(HtmlBrowserSession));

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Cookies.cs
@@ -69,7 +69,6 @@ public static partial class HtmlBrowser {
             list.Add(nc);
         }
         cancellationToken.ThrowIfCancellationRequested();
-        if (list.Count > 0)
-            await session.Context.AddCookiesAsync(list).ConfigureAwait(false);
+        await session.Context.AddCookiesAsync(list).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- ensure SetCookiesAsync always awaits AddCookiesAsync
- add unit test verifying empty cookie list path

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -c Debug -f net8.0 --no-build --verbosity minimal`
- ❌ `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -c Debug -f net472 --no-build --verbosity minimal` *(failed: Attempting to cancel the build)*

------
https://chatgpt.com/codex/tasks/task_e_687ff9986f78832e96739889ffa4b2df