### PR TITLE
Fix Playwright linux deps

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
@@ -1,0 +1,54 @@
+using HtmlTinkerX;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlBrowserInstallerTests
+{
+    [Fact]
+    public async Task EnsureInstalledAsync_InstallsDepsOnLinux()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return;
+        }
+
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+
+        try
+        {
+            // prepare fake driver so IsDriverPresent returns true
+            string baseDir = Path.Combine(tempDriver, ".playwright");
+            string platformId = PlatformExtensions.GetCurrentPlatform().ToPlatformId();
+            string nodeDir = Path.Combine(baseDir, "node", platformId);
+            Directory.CreateDirectory(nodeDir);
+            Directory.CreateDirectory(Path.Combine(baseDir, "package"));
+            File.WriteAllText(Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"), "");
+            File.WriteAllText(Path.Combine(baseDir, ".version"), typeof(Microsoft.Playwright.Playwright).Assembly.GetName().Version?.ToString(3) ?? "1.52.0");
+
+            string[]? captured = null;
+            HtmlBrowser.PlaywrightInstaller = args => captured = args;
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+
+            Assert.NotNull(captured);
+            Assert.Contains("--with-deps", captured);
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = args => Microsoft.Playwright.Program.Main(args);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", null);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", null);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+}
+

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
@@ -18,6 +18,11 @@ public static partial class HtmlBrowser {
     /// Only one installation process can run at a time across all threads.
     /// </summary>
     private static readonly SemaphoreSlim InstallationSemaphore = new SemaphoreSlim(1, 1);
+
+    /// <summary>
+    /// Delegate used to execute Playwright CLI commands. Exposed for unit testing.
+    /// </summary>
+    internal static Action<string[]> PlaywrightInstaller { get; set; } = static args => Microsoft.Playwright.Program.Main(args);
     /// <summary>
     /// Gets the version of the Playwright driver.
     /// </summary>
@@ -244,7 +249,11 @@ public static partial class HtmlBrowser {
             runtimeInstalled = IsBrowserRuntimeInstalled(engine);
             if (!runtimeInstalled) {
                 string runtime = engine.ToString().ToLowerInvariant();
-                Microsoft.Playwright.Program.Main(new[] { "install", runtime });
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                    PlaywrightInstaller(new[] { "install", "--with-deps", runtime });
+                } else {
+                    PlaywrightInstaller(new[] { "install", runtime });
+                }
             }
         } finally {
             InstallationSemaphore.Release();


### PR DESCRIPTION
## Summary
- install Playwright dependencies on Linux when ensuring Playwright runtime
- expose a delegate so tests can capture Playwright CLI invocations
- add unit test verifying `--with-deps` is used on Linux

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln --no-build -c Release --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6880af05d328832eb2dbd8c12feba562