### PR TITLE
Fix Netscape cookie expiry parsing

### DIFF
--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -36,7 +36,10 @@ public static class HtmlCookieParser {
             if (parts.Length < 7) {
                 continue;
             }
-            float? expires = float.TryParse(parts[4], out float f) ? f : null;
+            float? expires = null;
+            if (float.TryParse(parts[4], out float f) && f != 0) {
+                expires = f;
+            }
             list.Add(new HtmlCookie {
                 Domain = parts[0],
                 Path = parts[2],


### PR DESCRIPTION
## Summary
- handle 0 expiry in `ParseNetscapeFile` so session cookies work

## Testing
- `Invoke-Pester -Output Detailed -Path Tests/GetSet-HTMLCookie.Tests.ps1`
- `Invoke-Pester -Output Detailed -Path Tests/ConvertFrom-HTMLCookie.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_688140c60938832e948e7ae84430e92e