### PR TITLE
Implement unescape for JS beautifier

### DIFF
--- a/Sources/HtmlTinkerX.Tests/JavaScriptBeautifierTests.cs
+++ b/Sources/HtmlTinkerX.Tests/JavaScriptBeautifierTests.cs
@@ -54,6 +54,16 @@ public class JavaScriptBeautifierTests {
         Assert.Equal(expected, result);
     }
 
+    [Fact]
+    public void TestUnescapeHexSequences() {
+        var beautifier = new Beautifier();
+        beautifier.Opts.UnescapeStrings = true;
+
+        string result = beautifier.Beautify("'\\x41\\u0042'");
+
+        Assert.Equal("'AB'", result);
+    }
+
     [Theory]
     [InlineData("function test(){var x=1;if(x>0){return x;}}",
                 "function test() {\n    var x = 1;\n    if (x > 0) {\n        return x;\n    }\n}")]

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
@@ -578,11 +578,13 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                         while (esc || Input[ParserPos] != sep) {
                             resultingString += Input[ParserPos];
                             if (esc1 != 0 && esc1 >= esc2) {
-                                if (!int.TryParse(new string(resultingString.Skip(Math.Max(0, resultingString.Count() - esc2)).Take(esc2).ToArray()), NumberStyles.HexNumber, CultureInfo.CurrentCulture, out esc1))
+                                var hex = resultingString.Substring(resultingString.Length - esc2, esc2);
+                                if (!int.TryParse(hex, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out esc1)) {
                                     esc1 = 0;
+                                }
+
                                 if (esc1 != 0 && esc1 >= 0x20 && esc1 <= 0x7e) {
-                                    // FIXME
-                                    resultingString = new string(resultingString.Take(2 + esc2).ToArray());
+                                    resultingString = resultingString.Substring(0, resultingString.Length - (esc2 + 2));
 
                                     if ((char)esc1 == sep || (char)esc1 == '\\') {
                                         resultingString += '\\';
@@ -590,6 +592,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
                                     resultingString += (char)esc1;
                                 }
+
                                 esc1 = 0;
                             }
 
@@ -599,20 +602,15 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                                 esc = Input[ParserPos] == '\\';
                             } else {
                                 esc = false;
-                                // TODO
-                                //if (/*this.Opts.UnescapeStrings*/false)
-                                /*{
-                                    if (this.Input[this.ParserPos] == 'x')
-                                    {
-                                        ++esc1;
+                                if (Opts.UnescapeStrings) {
+                                    if (Input[ParserPos] == 'x') {
+                                        esc1 = 1;
                                         esc2 = 2;
-                                    }
-                                    else if (this.Input[this.ParserPos] == 'u')
-                                    {
-                                        ++esc1;
+                                    } else if (Input[ParserPos] == 'u') {
+                                        esc1 = 1;
                                         esc2 = 4;
                                     }
-                                }*/
+                                }
                             }
 
                             ParserPos += 1;

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierOptions.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierOptions.cs
@@ -44,6 +44,7 @@ public class BeautifierOptions {
         EvalCode = false;
         WrapLineLength = 0;
         BreakChainedMethods = false;
+        UnescapeStrings = false;
     }
 
     /// <summary>
@@ -105,4 +106,9 @@ public class BeautifierOptions {
     /// Gets or sets a value indicating whether to break chained methods.
     /// </summary>
     public bool BreakChainedMethods { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether hexadecimal escape sequences in strings should be converted to characters.
+    /// </summary>
+    public bool UnescapeStrings { get; set; }
 }


### PR DESCRIPTION
## Summary
- decode `\xNN` and `\uNNNN` escapes when `UnescapeStrings` option is set
- expose `UnescapeStrings` in `BeautifierOptions`
- add unit test for unescaping

## Testing
- `dotnet build Sources/HtmlTinkerX.sln --no-restore` *(fails: unable to resolve packages)*
- `dotnet test Sources/HtmlTinkerX.sln` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_6882851ecb50832ebb81879e269afe83