### PR TITLE
Add file existence check in ReadHarAsync

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
@@ -78,6 +78,15 @@ public class HtmlHarViewerTests {
 
     [Fact]
     /// <summary>
+    /// Ensures missing files throw <see cref="FileNotFoundException"/>.
+    /// </summary>
+    public async Task ReadHarAsync_FileNotFoundThrows() {
+        string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".har");
+        await Assert.ThrowsAsync<FileNotFoundException>(() => HtmlHarViewer.ReadHarAsync(missingPath));
+    }
+
+    [Fact]
+    /// <summary>
     /// Serializes a HAR to a stream.
     /// </summary>
     public async Task WriteHarAsync_WritesJson() {

--- a/Sources/HtmlTinkerX/HtmlHarViewer.cs
+++ b/Sources/HtmlTinkerX/HtmlHarViewer.cs
@@ -76,6 +76,9 @@ public static class HtmlHarViewer {
     /// </code>
     /// </example>
     public static async Task<Har> ReadHarAsync(string path) {
+        if (!File.Exists(path)) {
+            throw new FileNotFoundException($"File not found: {path}", path);
+        }
         string json = await HtmlUtilities.ReadFileCheckedAsync(path).ConfigureAwait(false);
         var opts = new JsonSerializerOptions {
             PropertyNameCaseInsensitive = true,


### PR DESCRIPTION
## Summary
- validate file existence in `HtmlHarViewer.ReadHarAsync`
- test missing file scenario

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -v n`
- `dotnet test Sources/HtmlTinkerX.sln -v n` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_688285275108832e89dc271e6ce0a1e3