### PR TITLE
Fix case-insensitive cookie flags

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -61,4 +61,20 @@ public class HtmlCookieParserTests {
         Assert.Equal("abc123xyz", c.Value);
         Assert.Equal("example.com", c.Domain);
     }
+
+    [Fact]
+    public void ParseOrgJsonCookie_AllowsLowercaseProperties() {
+        string json = "{\"path\":\"/\",\"secure\":\"true\",\"name\":\"sessionId\",\"httponly\":\"true\",\"domain\":\"example.com\",\"value\":\"abc123xyz\"}";
+        HtmlCookie c = HtmlCookieParser.ParseOrgJsonCookie(json);
+        Assert.True(c.Secure);
+        Assert.True(c.HttpOnly);
+    }
+
+    [Fact]
+    public void ParseOrgJsonCookie_AllowsMixedCaseProperties() {
+        string json = "{\"Path\":\"/\",\"SeCuRe\":\"true\",\"name\":\"sessionId\",\"HtTpOnLy\":\"true\",\"Domain\":\"example.com\",\"value\":\"abc123xyz\"}";
+        HtmlCookie c = HtmlCookieParser.ParseOrgJsonCookie(json);
+        Assert.True(c.Secure);
+        Assert.True(c.HttpOnly);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -18,6 +18,17 @@ public static class HtmlCookieParser {
         };
     }
 
+    private static bool TryGetPropertyIgnoreCase(JsonElement element, string name, out JsonElement value) {
+        foreach (JsonProperty property in element.EnumerateObject()) {
+            if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) {
+                value = property.Value;
+                return true;
+            }
+        }
+        value = default;
+        return false;
+    }
+
     /// <summary>
     /// Parses cookies from a Netscape HTTP cookie file.
     /// </summary>
@@ -122,8 +133,8 @@ public static class HtmlCookieParser {
                 Domain = root.TryGetProperty("Domain", out var d) ? d.GetString() : null,
                 Name = root.TryGetProperty("name", out var n) ? n.GetString() ?? string.Empty : string.Empty,
                 Value = root.TryGetProperty("value", out var v) ? v.GetString() ?? string.Empty : string.Empty,
-                Secure = root.TryGetProperty("Secure", out var s) ? s.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null,
-                HttpOnly = root.TryGetProperty("HttpOnly", out var h) ? h.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null
+                Secure = TryGetPropertyIgnoreCase(root, "Secure", out var s) ? s.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null,
+                HttpOnly = TryGetPropertyIgnoreCase(root, "HttpOnly", out var h) ? h.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null
             };
             if (root.TryGetProperty("Expires", out var e) && DateTime.TryParse(e.GetString(), out DateTime dt)) {
                 cookie.Expires = (float)new DateTimeOffset(dt).ToUnixTimeSeconds();


### PR DESCRIPTION
## Summary
- add case-insensitive JSON property lookup helper
- parse `Secure` and `HttpOnly` with case-insensitive comparison
- test lowercase and mixed-case property names

## Testing
- `~/.dotnet/dotnet build Sources/HtmlTinkerX.sln -c Release -v minimal`
- `~/.dotnet/dotnet test Sources/HtmlTinkerX.sln -c Release -v minimal` *(failed: Could not find 'mono' host)*
- `pwsh ./PSParseHTML.Tests.ps1` *(failed: cannot download Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6883259db1d8832e9c3ee978078450b6