### PR TITLE
Fix large expires in Netscape parser

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -21,6 +21,20 @@ public class HtmlCookieParserTests {
     }
 
     [Fact]
+    public void ParseNetscapeFile_ParsesLargeExpiration() {
+        string data = "example.com\tFALSE\t/\tTRUE\t9223372036854775807\tsessionId\tabc123xyz";
+        List<HtmlCookie> result = HtmlCookieParser.ParseNetscapeFile(data);
+        Assert.Single(result);
+        HtmlCookie c = result[0];
+        Assert.Equal("sessionId", c.Name);
+        Assert.Equal("abc123xyz", c.Value);
+        Assert.Equal("example.com", c.Domain);
+        Assert.Equal("/", c.Path);
+        Assert.True(c.Secure);
+        Assert.True(c.Expires > 1e18f);
+    }
+
+    [Fact]
     public void ParseSetCookieHeader_ParsesCookie() {
         string header = "Set-Cookie: sessionId=abc123xyz; Path=/; Secure; Expires=Wed, 31 Jan 2024 23:59:59 GMT";
         HtmlCookie c = HtmlCookieParser.ParseSetCookieHeader(header);

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -36,15 +36,15 @@ public static class HtmlCookieParser {
             if (parts.Length < 7) {
                 continue;
             }
-            float? expires = null;
-            if (float.TryParse(parts[4], out float f) && f != 0) {
-                expires = f;
+            long? expires = null;
+            if (long.TryParse(parts[4], out long l) && l != 0) {
+                expires = l;
             }
             list.Add(new HtmlCookie {
                 Domain = parts[0],
                 Path = parts[2],
                 Secure = parts[3].Equals("TRUE", StringComparison.OrdinalIgnoreCase),
-                Expires = expires,
+                Expires = expires.HasValue ? (float?)expires.Value : null,
                 Name = parts[5],
                 Value = parts[6]
             });


### PR DESCRIPTION
## Summary
- parse Netscape cookie expiration using `long` values
- add regression test for big expiration numbers

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --no-build --verbosity minimal`
- `pwsh -NoLogo -NoProfile -File ./PSParseHTML.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_688325b185cc832eb071ad78aa9a2927