### PR TITLE
Catch remote CSS errors

### DIFF
--- a/Sources/HtmlTinkerX.Tests/FormatHtmlInlineCssAsyncTests.cs
+++ b/Sources/HtmlTinkerX.Tests/FormatHtmlInlineCssAsyncTests.cs
@@ -23,4 +23,16 @@ public class FormatHtmlInlineCssAsyncTests {
         await Assert.ThrowsAsync<TaskCanceledException>(() =>
             HtmlFormatter.FormatHtmlInlineCssAsync(Html, null, cts.Token));
     }
+
+    [Fact]
+    public async Task FormatHtmlInlineCssAsync_InvalidCssUrl_ReturnsHtml() {
+        const string invalidUrlHtml =
+            "<html><head><link rel='stylesheet' href='http://localhost:1/style.css'></head><body><p>Hello</p></body></html>";
+        var options = new PreMailerOptions { DownloadRemoteCss = true };
+        string result = await HtmlFormatter.FormatHtmlInlineCssAsync(
+            invalidUrlHtml,
+            options,
+            CancellationToken.None);
+        Assert.Contains("<p>Hello</p>", result, System.StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlFormatter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormatter.cs
@@ -320,9 +320,17 @@ public static class HtmlFormatter {
         string html,
         PreMailerOptions? options = null,
         CancellationToken cancellationToken = default) {
-        PreMailerResult result = await PreMailerClient
-            .MoveCssInlineAsync(html, options, cancellationToken)
-            .ConfigureAwait(false);
-        return result.Html;
+        try {
+            PreMailerResult result = await PreMailerClient
+                .MoveCssInlineAsync(html, options, cancellationToken)
+                .ConfigureAwait(false);
+            return result.Html;
+        } catch (TaskCanceledException) {
+            throw;
+        } catch (Exception ex) when (options?.DownloadRemoteCss == true) {
+            LoggingMessages.Logger.WriteWarning(
+                "Failed to inline remote CSS: {0}", ex.Message);
+            return html;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- log remote CSS failures in `FormatHtmlInlineCssAsync`
- test handling of invalid CSS URLs

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688325c259a4832e9dcd93155354a511