### PR TITLE
Add CookieContainer support

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHttpClientFactoryTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHttpClientFactoryTests.cs
@@ -21,6 +21,32 @@ public class HtmlHttpClientFactoryTests {
         return field?.GetValue(client) as HttpClientHandler;
     }
 
+    private static int GetFreePort() {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static HttpListener StartCookieServer(out string url) {
+        int port = GetFreePort();
+        string prefix = $"http://localhost:{port}/";
+        url = prefix;
+        HttpListener listener = new();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        _ = Task.Run(async () => {
+            var context = await listener.GetContextAsync();
+            context.Response.Headers.Add("Set-Cookie", "session=abc");
+            byte[] data = System.Text.Encoding.UTF8.GetBytes("ok");
+            context.Response.ContentLength64 = data.Length;
+            await context.Response.OutputStream.WriteAsync(data, 0, data.Length);
+            context.Response.OutputStream.Close();
+        });
+        return listener;
+    }
+
     [Fact]
     public void Create_AppliesDefaultHeaders() {
         HtmlHttpClientFactory.DefaultHeaders["X-Test"] = "1";
@@ -62,5 +88,31 @@ public class HtmlHttpClientFactoryTests {
         Assert.Contains("localhost", proxyUri.ToString());
         Assert.Contains("1234", proxyUri.ToString());
         Assert.Same(cred, handler.Proxy?.Credentials);
+    }
+
+    [Fact]
+    public void Create_WithCookieContainer_ReturnsSameInstance() {
+        using HttpClient client = HtmlHttpClientFactory.Create(out CookieContainer cookies);
+        HttpClientHandler? handler = GetHandler(client);
+        if (handler == null) {
+            return;
+        }
+        Assert.Same(cookies, handler.CookieContainer);
+    }
+
+    [Fact]
+    public async Task Create_WithCookieContainer_StoresCookies() {
+        HttpListener server = StartCookieServer(out string url);
+        try {
+            using HttpClient client = HtmlHttpClientFactory.Create(out CookieContainer container);
+            HttpResponseMessage response = await client.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+            Cookie cookie = container.GetCookies(new System.Uri(url))["session"];
+            Assert.NotNull(cookie);
+            Assert.Equal("abc", cookie.Value);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
     }
 }

--- a/Sources/HtmlTinkerX/HttpClientFactory.cs
+++ b/Sources/HtmlTinkerX/HttpClientFactory.cs
@@ -44,6 +44,32 @@ public static class HtmlHttpClientFactory {
     }
 
     /// <summary>
+    /// Creates a new <see cref="HttpClient"/> with cookie support and returns the used container.
+    /// </summary>
+    /// <param name="cookieContainer">Container that will store cookies for the created handler.</param>
+    /// <param name="proxy">Optional proxy address.</param>
+    /// <param name="credential">Optional proxy credentials.</param>
+    public static HttpClient Create(out CookieContainer cookieContainer, string? proxy = null, ICredentials? credential = null) {
+        cookieContainer = new CookieContainer();
+        HttpClientHandler handler = new() {
+            CookieContainer = cookieContainer,
+            UseCookies = true
+        };
+        string? proxyToUse = proxy ?? DefaultProxy;
+        if (!string.IsNullOrEmpty(proxyToUse)) {
+            handler.Proxy = new WebProxy(proxyToUse);
+            handler.UseProxy = true;
+            ICredentials? credToUse = credential ?? DefaultProxyCredential;
+            if (credToUse != null) {
+                handler.Proxy!.Credentials = credToUse;
+            }
+        }
+        HttpClient client = new HttpClient(handler, disposeHandler: true);
+        ApplyDefaults(client);
+        return client;
+    }
+
+    /// <summary>
     /// Gets a shared instance using the configured defaults.
     /// </summary>
     public static HttpClient Shared {


### PR DESCRIPTION
## Summary
- allow retrieval of cookie container when creating HttpClient
- test that cookies are stored using returned container

## Testing
- `dotnet restore Sources/HtmlTinkerX.sln`
- `dotnet build Sources/HtmlTinkerX.sln --no-restore`
- `dotnet test Sources/HtmlTinkerX.sln --no-build` *(fails: Failed: 4, Passed: 412)*

------
https://chatgpt.com/codex/tasks/task_e_68832cb8591c832e9f8b4356603f6cee