### PR TITLE
Add network log limit support

### DIFF
--- a/Examples/Example-NetworkLogLimit.ps1
+++ b/Examples/Example-NetworkLogLimit.ps1
@@ -1,0 +1,9 @@
+Import-Module .\PSParseHTML.psd1 -Force
+
+$path = Join-Path $PSScriptRoot 'Input/route_page.html'
+$uri = [System.Uri]::new($path).AbsoluteUri
+$session = Invoke-HTMLRendering -Url $uri -Session
+$session.NetworkLogLimit = 2
+Start-Sleep -Milliseconds 500
+Get-HTMLNetworkLog -Session $session | Format-Table Method, Url
+Close-HTMLSession -Session $session

--- a/Sources/HtmlTinkerX.Examples/NetworkLogLimitExample.cs
+++ b/Sources/HtmlTinkerX.Examples/NetworkLogLimitExample.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates limiting captured network log entries.
+/// </summary>
+public static class NetworkLogLimitExample {
+    /// <summary>Executes the example logic.</summary>
+    public static async Task RunAsync() {
+        string path = Path.Combine("..", "..", "..", "Examples", "Input", "route_page.html");
+        string url = new Uri(Path.GetFullPath(path)).AbsoluteUri;
+        await using HtmlBrowserSession session = await HtmlBrowser.OpenSessionAsync(url).ConfigureAwait(false);
+        session.NetworkLogLimit = 2;
+        foreach (HtmlNetworkEntry entry in HtmlBrowser.GetNetworkLog(session)) {
+            Console.WriteLine($"{entry.Method} {entry.Url}");
+        }
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserNetworkLogLimitTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserNetworkLogLimitTests.cs
@@ -1,0 +1,71 @@
+using HtmlTinkerX;
+using Microsoft.Playwright;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlBrowserNetworkLogLimitTests {
+    [Fact]
+    public async Task NetworkLogLimit_TrimsOldEntries() {
+        var playwright = new Mock<IPlaywright>();
+        var browser = new Mock<IBrowser>();
+        var context = new Mock<IBrowserContext>();
+        var page = new Mock<IPage>();
+
+        var req1 = new Mock<IRequest>();
+        req1.SetupGet(r => r.Url).Returns("https://1.com");
+        req1.SetupGet(r => r.Method).Returns("GET");
+        req1.SetupGet(r => r.Headers).Returns(new Dictionary<string, string>());
+
+        var req2 = new Mock<IRequest>();
+        req2.SetupGet(r => r.Url).Returns("https://2.com");
+        req2.SetupGet(r => r.Method).Returns("GET");
+        req2.SetupGet(r => r.Headers).Returns(new Dictionary<string, string>());
+
+        var req3 = new Mock<IRequest>();
+        req3.SetupGet(r => r.Url).Returns("https://3.com");
+        req3.SetupGet(r => r.Method).Returns("GET");
+        req3.SetupGet(r => r.Headers).Returns(new Dictionary<string, string>());
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+        session.NetworkLogLimit = 2;
+
+        page.Raise(p => p.Request += null!, page.Object, req1.Object);
+        page.Raise(p => p.Request += null!, page.Object, req2.Object);
+        page.Raise(p => p.Request += null!, page.Object, req3.Object);
+
+        Assert.Equal(2, session.NetworkLog.Count());
+        Assert.DoesNotContain(session.NetworkLog, e => e.Url == "https://1.com");
+        await session.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task NetworkLogLimit_Null_KeepsAllEntries() {
+        var playwright = new Mock<IPlaywright>();
+        var browser = new Mock<IBrowser>();
+        var context = new Mock<IBrowserContext>();
+        var page = new Mock<IPage>();
+
+        var req1 = new Mock<IRequest>();
+        req1.SetupGet(r => r.Url).Returns("https://1.com");
+        req1.SetupGet(r => r.Method).Returns("GET");
+        req1.SetupGet(r => r.Headers).Returns(new Dictionary<string, string>());
+
+        var req2 = new Mock<IRequest>();
+        req2.SetupGet(r => r.Url).Returns("https://2.com");
+        req2.SetupGet(r => r.Method).Returns("GET");
+        req2.SetupGet(r => r.Headers).Returns(new Dictionary<string, string>());
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        page.Raise(p => p.Request += null!, page.Object, req1.Object);
+        page.Raise(p => p.Request += null!, page.Object, req2.Object);
+
+        Assert.Equal(2, session.NetworkLog.Count());
+        await session.DisposeAsync();
+    }
+}

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -40,7 +40,21 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// </summary>
     public string? VideoPath { get; internal set; }
     private readonly ConcurrentDictionary<IRequest, HtmlNetworkEntry> _network;
+    private readonly ConcurrentQueue<IRequest> _order = new();
     private readonly ConcurrentQueue<HtmlConsoleEntry> _console = new();
+    private int? _networkLogLimit;
+    /// <summary>
+    /// Gets or sets the maximum number of network log entries to keep.
+    /// </summary>
+    public int? NetworkLogLimit {
+        get => _networkLogLimit;
+        set {
+            _networkLogLimit = value;
+            if (value.HasValue) {
+                TrimNetworkLog(value.Value);
+            }
+        }
+    }
     /// <summary>Captured network log entries.</summary>
     public IEnumerable<HtmlNetworkEntry> NetworkLog => _network.Values;
     /// <summary>Captured console log entries.</summary>
@@ -75,6 +89,10 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
                 Started = System.DateTimeOffset.UtcNow
             };
             _network[req] = entry;
+            _order.Enqueue(req);
+            if (NetworkLogLimit.HasValue) {
+                TrimNetworkLog(NetworkLogLimit.Value);
+            }
         };
 
         Page.Response += (_, res) => {
@@ -100,6 +118,12 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
                 entry.Finished = System.DateTimeOffset.UtcNow;
             }
         };
+    }
+
+    private void TrimNetworkLog(int limit) {
+        while (_order.Count > limit && _order.TryDequeue(out IRequest? oldReq)) {
+            _network.TryRemove(oldReq, out _);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add NetworkLogLimit to HtmlBrowserSession
- discard old network events past limit
- add sample using new limit
- document feature in example app
- test trimming logic

## Testing
- `dotnet test Sources/HtmlTinkerX.sln --no-build --verbosity minimal` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68832cc4b3c0832e9edf748adfe21811