### PR TITLE
Propagate download errors to enumeration

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadFilterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadFilterTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -54,6 +55,35 @@ public class HtmlBrowserDownloadFilterTests {
         Assert.Contains(path1, files);
         Assert.True(File.Exists(path1));
         Assert.False(File.Exists(path2));
+
+        Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public async Task SavePageDownloadsAsync_DownloadFailure_FaultsEnumeration() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var page = new Mock<IPage>();
+        page.Setup(p => p.QuerySelectorAllAsync(It.IsAny<string>()))
+            .ReturnsAsync(Array.Empty<IElementHandle>());
+        page.Setup(p => p.WaitForSelectorAsync(It.IsAny<string>(), It.IsAny<PageWaitForSelectorOptions?>()))
+            .ReturnsAsync((IElementHandle?)null);
+        page.Setup(p => p.EvaluateAsync(It.IsAny<string>(), It.IsAny<object?>()))
+            .Callback(() => {
+                var dl = new Mock<IDownload>();
+                dl.SetupGet(d => d.Url).Returns("https://example.com/fail.txt");
+                dl.SetupGet(d => d.SuggestedFilename).Returns("fail.txt");
+                dl.Setup(d => d.SaveAsAsync(It.IsAny<string>()))
+                    .ThrowsAsync(new InvalidOperationException("boom"));
+
+                page.Raise(p => p.Download += null!, page.Object, dl.Object);
+            })
+            .ReturnsAsync((JsonElement?)default);
+        page.Setup(p => p.WaitForLoadStateAsync(It.IsAny<LoadState>(), It.IsAny<PageWaitForLoadStateOptions?>()))
+            .Returns(Task.CompletedTask);
+
+        await Assert.ThrowsAsync<ChannelClosedException>(async () => {
+            await foreach (string _ in HtmlBrowser.SavePageDownloadsAsync(page.Object, dir)) { }
+        });
 
         Directory.Delete(dir, true);
     }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -59,29 +59,37 @@ public static partial class HtmlBrowser {
         System.Threading.Channels.Channel<string> channel = System.Threading.Channels.Channel.CreateUnbounded<string>();
 
         void Handler(object? _, IDownload dl) {
-            bool match = string.IsNullOrEmpty(filter) ||
-                         dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                         dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
-            if (!match) {
-                return;
-            }
+            try {
+                bool match = string.IsNullOrEmpty(filter) ||
+                             dl.Url.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                             dl.SuggestedFilename.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+                if (!match) {
+                    return;
+                }
 
-            string filePath = Path.Combine(dir, dl.SuggestedFilename);
-            bool save;
-            lock (sync) {
-                save = downloads.Add(filePath);
-            }
-            if (!save) {
-                return;
-            }
+                string filePath = Path.Combine(dir, dl.SuggestedFilename);
+                bool save;
+                lock (sync) {
+                    save = downloads.Add(filePath);
+                }
+                if (!save) {
+                    return;
+                }
 
-            Task saveTask = Task.Run(async () => {
-                await dl.SaveAsAsync(filePath).ConfigureAwait(false);
-                await channel.Writer.WriteAsync(filePath, cancellationToken).ConfigureAwait(false);
-            }, cancellationToken);
+                Task saveTask = Task.Run(async () => {
+                    try {
+                        await dl.SaveAsAsync(filePath).ConfigureAwait(false);
+                        await channel.Writer.WriteAsync(filePath, cancellationToken).ConfigureAwait(false);
+                    } catch (Exception ex) {
+                        channel.Writer.TryComplete(ex);
+                    }
+                }, cancellationToken);
 
-            lock (sync) {
-                saveTasks.Add(saveTask);
+                lock (sync) {
+                    saveTasks.Add(saveTask);
+                }
+            } catch (Exception ex) {
+                channel.Writer.TryComplete(ex);
             }
         }
 


### PR DESCRIPTION
## Summary
- catch and forward download exceptions in `SavePageDownloadsAsync`
- assert enumeration faults when a download fails

## Testing
- `dotnet test Sources/HtmlTinkerX.sln -v minimal -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68836ed6321c832eb1fdbbc287a9db2c