### PR TITLE
Fix WriteHarAsync null log handling

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
@@ -104,4 +104,21 @@ public class HtmlHarViewerTests {
         Assert.NotNull(parsed);
         Assert.Equal(har.Log?.Entries?.Length, parsed.Log?.Entries?.Length);
     }
+
+    [Fact]
+    public async Task WriteHarAsync_AllowsNullLog() {
+        var har = new Har { Log = null };
+        using var ms = new MemoryStream();
+        await HtmlHarViewer.WriteHarAsync(har, ms);
+        ms.Position = 0;
+        using var reader = new StreamReader(ms);
+        string json = await reader.ReadToEndAsync();
+        var opts = new JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        Har? parsed = JsonSerializer.Deserialize<Har>(json, opts);
+        Assert.NotNull(parsed);
+        Assert.NotNull(parsed.Log);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlHarViewer.cs
+++ b/Sources/HtmlTinkerX/HtmlHarViewer.cs
@@ -158,6 +158,10 @@ for (const e of entries) {
             throw new ArgumentNullException(nameof(outputStream));
         }
 
+        if (har.Log == null) {
+            har.Log = new HarLog();
+        }
+
         var opts = new JsonSerializerOptions {
             WriteIndented = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase


### PR DESCRIPTION
## Summary
- ensure WriteHarAsync creates an empty HarLog if Har.Log is null
- test WriteHarAsync when Har.Log is null

## Testing
- `dotnet test Sources/HtmlTinkerX.sln --framework net8.0`
- `dotnet test Sources/HtmlTinkerX.sln --framework net472` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_68836ecfe658832e923c60276ca0d017