### PR TITLE
Add null check test for ParseTablesWithAngleSharpDetailed

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -47,5 +48,10 @@ public class HtmlParserTests {
 
         var doc = await HtmlParser.ParseUrlWithHtmlAgilityPackAsync(server.BaseAddress.ToString(), client);
         Assert.NotNull(doc.DocumentNode);
+    }
+
+    [Fact]
+    public void ParseTablesWithAngleSharpDetailed_NullHtml_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlParser.ParseTablesWithAngleSharpDetailed(null!));
     }
 }


### PR DESCRIPTION
## Summary
- validate `ParseTablesWithAngleSharpDetailed` throws when html is null

## Testing
- `dotnet build Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -c Release --no-restore`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -c Release --framework net8.0 --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68836ee50ce8832ea71eacac75ab6a66