### PR TITLE
Add Playwright fixture for tests

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace HtmlTinkerX.Tests;
 
+[Collection("Playwright collection")]
 public class HtmlBrowserInstallerTests
 {
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Playwright;
 
 namespace HtmlTinkerX.Tests.Playwright;
 
+[Collection("Playwright collection")]
 public class HtmlBrowserTesterTests {
     [Fact]
     public async Task TestUrlAsync_ValidUrl_ReturnsTestResult() {

--- a/Sources/HtmlTinkerX.Tests/PlaywrightFixture.cs
+++ b/Sources/HtmlTinkerX.Tests/PlaywrightFixture.cs
@@ -1,0 +1,28 @@
+using Microsoft.Playwright;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+/// <summary>
+/// xUnit fixture that installs Playwright once for the entire test suite.
+/// </summary>
+public sealed class PlaywrightFixture : IAsyncLifetime {
+    /// <summary>
+    /// Performs one-time initialization of Playwright.
+    /// </summary>
+    public async Task InitializeAsync() {
+        await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+    }
+
+    /// <summary>
+    /// No cleanup required.
+    /// </summary>
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+
+/// <summary>
+/// Collection definition for Playwright dependent tests.
+/// </summary>
+[CollectionDefinition("Playwright collection")]
+public sealed class PlaywrightCollection : ICollectionFixture<PlaywrightFixture> { }


### PR DESCRIPTION
## Summary
- add PlaywrightFixture to run Playwright installation once for tests
- apply new collection fixture to Playwright dependent tests

## Testing
- `dotnet build Sources/HtmlTinkerX.sln -c Release`
- `dotnet test Sources/HtmlTinkerX.sln -c Release` *(fails: PreMailerClientPathTests.NormalizeFileUriPath_UncPaths, PreMailerClientPathTests.NormalizeFileUriPath_UncPaths_TrailingSlash, HtmlHttpClientFactoryTests.Create_WithCookieContainer_StoresCookies, PreMailerClientRemoteCssAnalyticsTests.MoveCssInline_InlinesRemoteAndLocalCss_AddsAnalyticsTags)*

------
https://chatgpt.com/codex/tasks/task_e_6887c7df5d48832e99ed177034684e45