### PR TITLE
Add ToFullPath extension and refactor path handling

### DIFF
--- a/Sources/HtmlTinkerX.Examples/ToFullPathExample.cs
+++ b/Sources/HtmlTinkerX.Examples/ToFullPathExample.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates converting a relative path to a full path using <see cref="HtmlUtilities.ToFullPath(string)"/>.
+/// </summary>
+public static class ToFullPathExample {
+    /// <summary>Executes the example logic.</summary>
+    public static Task RunAsync() {
+        string relative = ".";
+        string full = relative.ToFullPath();
+        Console.WriteLine(full);
+        return Task.CompletedTask;
+    }
+}
+

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -55,7 +55,7 @@ public class HtmlBrowserSessionDisposeTests {
 
         await session.DisposeAsync();
 
-        video.Verify(v => v.SaveAsAsync(HtmlUtilities.ResolvePath(outFile)), Moq.Times.Once);
+        video.Verify(v => v.SaveAsAsync(outFile.ToFullPath()), Moq.Times.Once);
         Assert.False(System.IO.File.Exists(tempVideo));
         browser.Verify();
         context.Verify();

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserVideoRecordingTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserVideoRecordingTests.cs
@@ -67,7 +67,7 @@ public class HtmlBrowserVideoRecordingTests {
 
         await HtmlBrowser.StopVideoRecordingAsync(session);
 
-        video.Verify(v => v.SaveAsAsync(HtmlUtilities.ResolvePath(outFile)), Times.Once);
+        video.Verify(v => v.SaveAsAsync(outFile.ToFullPath()), Times.Once);
         Assert.False(File.Exists(tempVideo));
         if (useSession) {
             Assert.False(File.Exists(statePath!));

--- a/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
@@ -33,6 +33,15 @@ public class HtmlUtilitiesTests {
     }
 
     [Fact]
+    public void ToFullPath_ReturnsSameAsResolvePath() {
+        string temp = Path.GetTempPath();
+        Environment.SetEnvironmentVariable("TMP_TEST", temp);
+        string expected = HtmlUtilities.ResolvePath("%TMP_TEST%");
+        string actual = "%TMP_TEST%".ToFullPath();
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public void ReadFileChecked_ReturnsContent() {
         string path = Path.GetTempFileName();
         try {

--- a/Sources/HtmlTinkerX/HtmlUtilities.cs
+++ b/Sources/HtmlTinkerX/HtmlUtilities.cs
@@ -26,6 +26,14 @@ public static class HtmlUtilities {
     }
 
     /// <summary>
+    /// Converts a path to an absolute file system path.
+    /// </summary>
+    /// <param name="path">File system path to resolve.</param>
+    /// <returns>Absolute file path.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> is null or empty.</exception>
+    public static string ToFullPath(this string path) => ResolvePath(path);
+
+    /// <summary>
     /// Ensures the directory for the specified path exists and returns the
     /// resolved absolute path.
     /// </summary>

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -37,7 +37,7 @@ public static partial class HtmlBrowser {
             null,
             cancellationToken: cancellationToken).ConfigureAwait(false);
         var page = session.Page;
-        string dir = HtmlUtilities.ResolvePath(directory);
+        string dir = directory.ToFullPath();
         await foreach (string file in SavePageDownloadsAsync(page, dir, filter, cancellationToken).ConfigureAwait(false)) {
             yield return file;
         }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
@@ -74,7 +74,7 @@ public static partial class HtmlBrowser {
             proxyPassword: proxyPassword,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        string fullPath = HtmlUtilities.ResolvePath(path);
+        string fullPath = path.ToFullPath();
         await CaptureScreenshotAsync(
             session.Page,
             fullPath,

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SessionState.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SessionState.cs
@@ -16,7 +16,7 @@ public static partial class HtmlBrowser {
     /// <param name="path">File path where the session state should be stored.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static Task ExportSessionAsync(HtmlBrowserSession session, string path, CancellationToken cancellationToken = default) {
-        string fullPath = HtmlUtilities.ResolvePath(path);
+        string fullPath = path.ToFullPath();
         string? dir = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(dir)) {
             Directory.CreateDirectory(dir);
@@ -84,7 +84,7 @@ public static partial class HtmlBrowser {
             videoPath: null,
             videoWidth: 800,
             videoHeight: 600,
-            storageStatePath: HtmlUtilities.ResolvePath(statePath),
+            storageStatePath: statePath.ToFullPath(),
             userAgent: userAgent,
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
@@ -346,7 +346,7 @@ public static partial class HtmlBrowser {
     /// <param name="timeout">Navigation timeout in milliseconds.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task SavePageContentAsync(string url, string path, HtmlBrowserEngine browser = HtmlBrowserEngine.Chromium, bool clean = false, string? username = null, string? password = null, HtmlFormLogin? formLogin = null, bool headless = true, int slowMo = 0, string? userAgent = null, int? viewportWidth = null, int? viewportHeight = null, float? deviceScaleFactor = null, string? proxy = null, string? proxyUsername = null, string? proxyPassword = null, double? geoLatitude = null, double? geoLongitude = null, string? timezone = null, int timeout = 10000, CancellationToken cancellationToken = default) {
-        string fullPath = HtmlUtilities.ResolvePath(path);
+        string fullPath = path.ToFullPath();
         string content = await GetPageContentAsync(url, browser, clean, username, password, formLogin, headless, slowMo, userAgent, viewportWidth, viewportHeight, deviceScaleFactor, proxy, proxyUsername, proxyPassword, geoLatitude, geoLongitude, timezone, timeout, cancellationToken).ConfigureAwait(false);
 #if NETSTANDARD2_0 || NETFRAMEWORK
         File.WriteAllText(fullPath, content);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -135,7 +135,7 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
         }
 
         if (Video != null && !string.IsNullOrEmpty(VideoPath)) {
-            string fullPath = HtmlUtilities.ResolvePath(VideoPath!);
+            string fullPath = VideoPath!.ToFullPath();
             await Video.SaveAsAsync(fullPath).ConfigureAwait(false);
             try {
                 string tempPath = await Video.PathAsync().ConfigureAwait(false);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -161,7 +161,7 @@ public static class HtmlBrowserTester {
         int timeout = 30000) {
         
         // Resolve the file path
-        var resolvedPath = HtmlUtilities.ResolvePath(filePath);
+        var resolvedPath = filePath.ToFullPath();
         if (!System.IO.File.Exists(resolvedPath)) {
             throw new System.IO.FileNotFoundException($"HTML file not found: {resolvedPath}");
         }

--- a/Sources/HtmlTinkerX/PreMailer/PreMailerClient.cs
+++ b/Sources/HtmlTinkerX/PreMailer/PreMailerClient.cs
@@ -31,7 +31,7 @@ public class PreMailerClient {
     /// <param name="options">Optional processing options.</param>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     public static PreMailerClient FromFile(string htmlFilePath, PreMailerOptions? options = null) {
-        string path = HtmlUtilities.ResolvePath(htmlFilePath);
+        string path = htmlFilePath.ToFullPath();
         if (!File.Exists(path)) {
             throw new FileNotFoundException($"HTML file not found: {path}", path);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletCompareHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletCompareHtml.cs
@@ -52,7 +52,7 @@ public sealed class CmdletCompareHtml : AsyncPSCmdlet {
     private static bool TryReadFile(string path, out string content) {
         content = string.Empty;
         try {
-            string fullPath = HtmlUtilities.ResolvePath(path);
+            string fullPath = path.ToFullPath();
             if (File.Exists(fullPath)) {
                 content = File.ReadAllText(fullPath);
                 return true;

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAttributes.cs
@@ -85,7 +85,7 @@ public sealed class CmdletConvertFromHtmlAttributes : AsyncPSCmdlet {
                 Id,
                 Name),
             ParameterSetFile => HtmlParserExtensions.GetElementsFromFile(
-                HtmlUtilities.ResolvePath(Path),
+                Path.ToFullPath(),
                 Tag,
                 Class,
                 Id,

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlCookie.cs
@@ -32,7 +32,7 @@ public sealed class CmdletConvertFromHtmlCookie : PSCmdlet {
     /// <inheritdoc />
     protected override void ProcessRecord() {
         string data = ParameterSetName == ParameterSetFile
-            ? File.ReadAllText(HtmlUtilities.ResolvePath(Path))
+            ? File.ReadAllText(Path.ToFullPath())
             : Content;
 
         switch (Format) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertHtmlToText.cs
@@ -71,7 +71,7 @@ public sealed class CmdletConvertHtmlToText : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         ValidateProxy(Proxy, ProxyCredential);
         string text = ParameterSetName switch {
-            ParameterSetFile => HtmlParserToText.ConvertFileToText(HtmlUtilities.ResolvePath(Path)),
+            ParameterSetFile => HtmlParserToText.ConvertFileToText(Path.ToFullPath()),
             ParameterSetUrl => HtmlParserToText.ConvertToText(
                 await HtmlUtilities.GetStringWithProperEncodingAsync(
                     HttpClientHelper.Create(Proxy, ProxyCredential),
@@ -80,7 +80,7 @@ public sealed class CmdletConvertHtmlToText : AsyncPSCmdlet {
         };
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, text);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletExportHtmlOutline.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletExportHtmlOutline.cs
@@ -56,7 +56,7 @@ public sealed class CmdletExportHtmlOutline : AsyncPSCmdlet {
 
         var opts = new JsonSerializerOptions { WriteIndented = true };
         string json = JsonSerializer.Serialize(outline, opts);
-        string outPath = HtmlUtilities.ResolvePath(Path);
+        string outPath = Path.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
         System.IO.File.WriteAllText(outPath, json);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatCss.cs
@@ -34,11 +34,11 @@ public sealed class CmdletFormatCss : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string formatted = ParameterSetName == ParameterSetFile
-            ? await HtmlFormatter.FormatCssFileAsync(HtmlUtilities.ResolvePath(Path)).ConfigureAwait(false)
+            ? await HtmlFormatter.FormatCssFileAsync(Path.ToFullPath()).ConfigureAwait(false)
             : await HtmlFormatter.FormatCssAsync(Content).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, formatted);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatHtml.cs
@@ -65,7 +65,7 @@ public sealed class CmdletFormatHtml : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         string result = ParameterSetName == ParameterSetFile
             ? await HtmlFormatter.FormatHtmlFileAsync(
-                HtmlUtilities.ResolvePath(Path),
+                Path.ToFullPath(),
                 Indent,
                 BlockStartLine,
                 RemoveHTMLComments.IsPresent,
@@ -86,7 +86,7 @@ public sealed class CmdletFormatHtml : AsyncPSCmdlet {
                 RemoveEmptyBlocks.IsPresent).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, result);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -100,11 +100,11 @@ public sealed class CmdletFormatJavaScript : AsyncPSCmdlet {
         };
 
         string formatted = ParameterSetName == ParameterSetFile
-            ? await HtmlFormatter.FormatJavaScriptFileAsync(HtmlUtilities.ResolvePath(Path), opts).ConfigureAwait(false)
+            ? await HtmlFormatter.FormatJavaScriptFileAsync(Path.ToFullPath(), opts).ConfigureAwait(false)
             : await HtmlFormatter.FormatJavaScriptAsync(Content, opts).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, formatted);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlBrowserInteractable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlBrowserInteractable.cs
@@ -156,7 +156,7 @@ public sealed class CmdletGetHtmlBrowserInteractable : AsyncPSCmdlet {
                 }
                 break;
             case ParameterSetFile:
-                string fileUrl = new Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri;
+                string fileUrl = new Uri(Path!.ToFullPath()).AbsoluteUri;
                 await using (HtmlBrowserSession sess = await HtmlBrowser.OpenSessionAsync(
                     fileUrl,
                     Browser,

--- a/Sources/PSParseHTML.PowerShell/CmdletGetHtmlBrowserLoginForm.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletGetHtmlBrowserLoginForm.cs
@@ -97,7 +97,7 @@ public sealed class CmdletGetHtmlBrowserLoginForm : AsyncPSCmdlet {
                 }
                 break;
             case ParameterSetFile:
-                string fileUrl = new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri;
+                string fileUrl = new System.Uri(Path!.ToFullPath()).AbsoluteUri;
                 await using (HtmlBrowserSession sess = await HtmlBrowser.OpenSessionAsync(
                     fileUrl,
                     Browser,

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlRendering.cs
@@ -154,7 +154,7 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
         }
 
         string target = ParameterSetName == ParameterSetFile
-            ? new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri
+            ? new System.Uri(Path!.ToFullPath()).AbsoluteUri
             : Url;
 
         if (Session.IsPresent) {
@@ -185,7 +185,7 @@ public sealed class CmdletInvokeHtmlRendering : AsyncPSCmdlet {
             }
             WriteObject(sess);
         } else if (!string.IsNullOrEmpty(OutFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutFile!);
+            string outPath = OutFile!.ToFullPath();
             await HtmlBrowser.SavePageContentAsync(target, outPath, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout, token).ConfigureAwait(false);
         } else {
             string html = await HtmlBrowser.GetPageContentAsync(target, Browser, Clean.IsPresent, user, pass, form, !Visible.IsPresent, SlowMo, UserAgent, ViewportWidth, ViewportHeight, (float?)DeviceScaleFactor, Proxy, pUser, pPass, GeoLatitude, GeoLongitude, Timezone, Timeout, token).ConfigureAwait(false);

--- a/Sources/PSParseHTML.PowerShell/CmdletMeasureHtmlDocumentStructure.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletMeasureHtmlDocumentStructure.cs
@@ -38,9 +38,9 @@ public sealed class CmdletMeasureHtmlDocumentStructure : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         string html = ParameterSetName == ParameterSetFile
 #if NETSTANDARD2_0 || NETFRAMEWORK
-            ? await Task.Run(() => File.ReadAllText(HtmlUtilities.ResolvePath(Path)), CancelToken).ConfigureAwait(false)
+            ? await Task.Run(() => File.ReadAllText(Path.ToFullPath()), CancelToken).ConfigureAwait(false)
 #else
-            ? await File.ReadAllTextAsync(HtmlUtilities.ResolvePath(Path), CancelToken).ConfigureAwait(false)
+            ? await File.ReadAllTextAsync(Path.ToFullPath(), CancelToken).ConfigureAwait(false)
 #endif
             : Content;
 

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeCss.cs
@@ -33,11 +33,11 @@ public sealed class CmdletOptimizeCss : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string result = ParameterSetName == ParameterSetPath
-            ? await HtmlOptimizer.OptimizeCssFileAsync(HtmlUtilities.ResolvePath(Path)).ConfigureAwait(false)
+            ? await HtmlOptimizer.OptimizeCssFileAsync(Path.ToFullPath()).ConfigureAwait(false)
             : await HtmlOptimizer.OptimizeCssAsync(Css).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             File.WriteAllText(outPath, result);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -37,10 +37,10 @@ public sealed class CmdletOptimizeHtml : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string result = ParameterSetName == ParameterSetFile
-            ? await HtmlOptimizer.OptimizeHtmlFileAsync(HtmlUtilities.ResolvePath(Path), CSSDecodeEscapes.IsPresent).ConfigureAwait(false)
+            ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), CSSDecodeEscapes.IsPresent).ConfigureAwait(false)
             : await HtmlOptimizer.OptimizeHtmlAsync(Content, CSSDecodeEscapes.IsPresent).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, result);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeJavaScript.cs
@@ -33,11 +33,11 @@ public sealed class CmdletOptimizeJavaScript : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string optimized = ParameterSetName == ParameterSetFile
-            ? await HtmlOptimizer.OptimizeJavaScriptFileAsync(HtmlUtilities.ResolvePath(Path)).ConfigureAwait(false)
+            ? await HtmlOptimizer.OptimizeJavaScriptFileAsync(Path.ToFullPath()).ConfigureAwait(false)
             : await HtmlOptimizer.OptimizeJavaScriptAsync(Content).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(OutputFile)) {
-            string outPath = HtmlUtilities.ResolvePath(OutputFile!);
+            string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             File.WriteAllText(outPath, optimized);
 #else

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlBrowserAttachment.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlBrowserAttachment.cs
@@ -67,12 +67,12 @@ public sealed class CmdletSaveHtmlBrowserAttachment : AsyncPSCmdlet {
         IAsyncEnumerable<string> files = ParameterSetName switch {
             ParameterSetSession => HtmlBrowser.SavePageDownloadsAsync(
                 (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                HtmlUtilities.ResolvePath(Path),
+                Path.ToFullPath(),
                 Filter,
                 token),
             _ => HtmlBrowser.SavePageDownloadsAsync(
                 Url,
-                HtmlUtilities.ResolvePath(Path),
+                Path.ToFullPath(),
                 Browser,
                 Clean.IsPresent,
                 Filter,

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlBrowserPdf.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlBrowserPdf.cs
@@ -137,7 +137,7 @@ public sealed class CmdletSaveHtmlBrowserPdf : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         HtmlBrowserSession? session = Session ?? (HtmlBrowserSession?)GetVariableValue("PSParseHTML_DefaultSession");
-        string outPath = HtmlUtilities.ResolvePath(OutFile);
+        string outPath = OutFile.ToFullPath();
         string? dir = System.IO.Path.GetDirectoryName(outPath);
         if (!string.IsNullOrEmpty(dir)) {
             Directory.CreateDirectory(dir);

--- a/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlBrowserScreenshot.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletSaveHtmlBrowserScreenshot.cs
@@ -208,7 +208,7 @@ public sealed class CmdletSaveHtmlBrowserScreenshot : AsyncPSCmdlet {
             case ParameterSetClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     Url,
-                    HtmlUtilities.ResolvePath(OutFile!),
+                    OutFile!.ToFullPath(),
                     Browser,
                     Clean.IsPresent,
                     options,
@@ -220,8 +220,8 @@ public sealed class CmdletSaveHtmlBrowserScreenshot : AsyncPSCmdlet {
                 break;
             case ParameterSetFileClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
-                    new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri,
-                    HtmlUtilities.ResolvePath(OutFile!),
+                    new System.Uri(Path!.ToFullPath()).AbsoluteUri,
+                    OutFile!.ToFullPath(),
                     Browser,
                     Clean.IsPresent,
                     options,
@@ -234,22 +234,22 @@ public sealed class CmdletSaveHtmlBrowserScreenshot : AsyncPSCmdlet {
             case ParameterSetSessionClip:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    HtmlUtilities.ResolvePath(OutFile!),
+                    OutFile!.ToFullPath(),
                     options).ConfigureAwait(false);
                 break;
             case ParameterSetSessionDefault:
                 await HtmlBrowser.CaptureScreenshotAsync(
                     (session ?? throw new PSInvalidOperationException("No session provided and no default session found.")).Page,
-                    HtmlUtilities.ResolvePath(OutFile!),
+                    OutFile!.ToFullPath(),
                     options).ConfigureAwait(false);
                 break;
             default:
                 string target = ParameterSetName == ParameterSetFileDefault
-                    ? new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri
+                    ? new System.Uri(Path!.ToFullPath()).AbsoluteUri
                     : Url;
                 await HtmlBrowser.CaptureScreenshotAsync(
                     target,
-                    HtmlUtilities.ResolvePath(OutFile!),
+                    OutFile!.ToFullPath(),
                     Browser,
                     Clean.IsPresent,
                     options,
@@ -264,7 +264,7 @@ public sealed class CmdletSaveHtmlBrowserScreenshot : AsyncPSCmdlet {
         if (Open.IsPresent) {
             try {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo {
-                    FileName = HtmlUtilities.ResolvePath(OutFile!),
+                    FileName = OutFile!.ToFullPath(),
                     UseShellExecute = true,
                 });
             } catch (System.Exception ex) {

--- a/Sources/PSParseHTML.PowerShell/CmdletShowHtmlBrowserHar.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletShowHtmlBrowserHar.cs
@@ -27,10 +27,10 @@ public sealed class CmdletShowHtmlBrowserHar : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         Har har = await HtmlHarViewer.ReadHarAsync(Path).ConfigureAwait(false);
-        string resolved = HtmlUtilities.ResolvePath(Path);
+        string resolved = Path.ToFullPath();
         string outPath = OutFile is null
             ? System.IO.Path.ChangeExtension(resolved, ".html")
-            : HtmlUtilities.ResolvePath(OutFile);
+            : OutFile.ToFullPath();
 
         string html = HtmlHarViewer.BuildViewerHtml(har);
 #if NETSTANDARD2_0 || NETFRAMEWORK

--- a/Sources/PSParseHTML.PowerShell/CmdletStartHtmlBrowserVideoCapture.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletStartHtmlBrowserVideoCapture.cs
@@ -157,7 +157,7 @@ public sealed class CmdletStartHtmlBrowserVideoCapture : AsyncPSCmdlet {
                 };
                 break;
             case ParameterSetFile:
-                target = new System.Uri(HtmlUtilities.ResolvePath(Path!)).AbsoluteUri;
+                target = new System.Uri(Path!.ToFullPath()).AbsoluteUri;
                 break;
             default:
                 target = Url;


### PR DESCRIPTION
## Summary
- add `ToFullPath` extension in `HtmlUtilities`
- refactor ResolvePath usages to new extension
- test new helper and update existing tests
- demonstrate extension in a new example

## Testing
- `dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj`
- `dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj`
- `dotnet build Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_6887c813f83c832e8434700072583f7b