### PR TITLE
Use double for cookie expiration

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
@@ -27,7 +27,7 @@ public class HtmlBrowserCookiesTests {
                 Value = "value",
                 Domain = "domain",
                 Path = "/path",
-                Expires = 123f,
+                Expires = 123,
                 HttpOnly = true,
                 Secure = false,
                 SameSite = SameSiteAttribute.Lax
@@ -43,7 +43,7 @@ public class HtmlBrowserCookiesTests {
         Assert.Equal("value", c.Value);
         Assert.Equal("domain", c.Domain);
         Assert.Equal("/path", c.Path);
-        Assert.Equal(123f, c.Expires);
+        Assert.Equal(123d, c.Expires);
         Assert.True(c.HttpOnly);
         Assert.False(c.Secure);
         Assert.Equal(SameSiteAttribute.Lax, c.SameSite);
@@ -66,7 +66,7 @@ public class HtmlBrowserCookiesTests {
                 Url = "https://example.com",
                 Domain = "domain",
                 Path = "/path",
-                Expires = 456f,
+                Expires = 456,
                 HttpOnly = true,
                 Secure = true,
                 SameSite = SameSiteAttribute.Strict
@@ -80,7 +80,7 @@ public class HtmlBrowserCookiesTests {
             l.First().Url == "https://example.com" &&
             l.First().Domain == "domain" &&
             l.First().Path == "/path" &&
-            l.First().Expires == 456f &&
+            l.First().Expires == 456 &&
             l.First().HttpOnly == true &&
             l.First().Secure == true &&
             l.First().SameSite == SameSiteAttribute.Strict

--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -17,7 +17,7 @@ public class HtmlCookieParserTests {
         Assert.Equal("example.com", c.Domain);
         Assert.Equal("/", c.Path);
         Assert.True(c.Secure);
-        Assert.Equal(1704067199f, c.Expires);
+        Assert.Equal(1704067199d, c.Expires);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class HtmlCookieParserTests {
         Assert.Equal("example.com", c.Domain);
         Assert.Equal("/", c.Path);
         Assert.True(c.Secure);
-        Assert.True(c.Expires > 1e18f);
+        Assert.True(c.Expires > 1e18d);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -49,15 +49,15 @@ public static class HtmlCookieParser {
             if (parts.Length < 7) {
                 continue;
             }
-            long? expires = null;
-            if (long.TryParse(parts[4], out long l) && l != 0) {
-                expires = l;
+            double? expires = null;
+            if (double.TryParse(parts[4], out double d) && d != 0) {
+                expires = d;
             }
             list.Add(new HtmlCookie {
                 Domain = parts[0],
                 Path = parts[2],
                 Secure = parts[3].Equals("TRUE", StringComparison.OrdinalIgnoreCase),
-                Expires = expires.HasValue ? (float?)expires.Value : null,
+                Expires = expires,
                 Name = parts[5],
                 Value = parts[6]
             });
@@ -102,7 +102,7 @@ public static class HtmlCookieParser {
                     break;
                 case "expires":
                     if (DateTime.TryParse(val, out DateTime dt)) {
-                        cookie.Expires = (float)new DateTimeOffset(dt).ToUnixTimeSeconds();
+                        cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
                     }
                     break;
                 case "secure":
@@ -139,7 +139,7 @@ public static class HtmlCookieParser {
                 HttpOnly = CookieHelpers.TryGetPropertyIgnoreCase(root, "HttpOnly", out var h) ? h.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null
             };
             if (root.TryGetProperty("Expires", out var e) && DateTime.TryParse(e.GetString(), out DateTime dt)) {
-                cookie.Expires = (float)new DateTimeOffset(dt).ToUnixTimeSeconds();
+                cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
             }
             return cookie;
         }
@@ -166,7 +166,7 @@ public static class HtmlCookieParser {
         };
         if (root.TryGetProperty("expires", out var e)) {
             double exp = e.GetDouble();
-            cookie.Expires = (float)(exp >= 1e12 ? exp / 1000.0 : exp);
+            cookie.Expires = exp >= 1e12 ? exp / 1000.0 : exp;
         }
         return cookie;
     }
@@ -192,7 +192,7 @@ public static class HtmlCookieParser {
                     HttpOnly = el.TryGetProperty("httpOnly", out var h) ? h.GetBoolean() : (bool?)null
                 };
                 if (el.TryGetProperty("expires", out var e)) {
-                    c.Expires = (float)e.GetDouble();
+                    c.Expires = e.GetDouble();
                 }
                 list.Add(c);
             }

--- a/Sources/HtmlTinkerX/Models/HtmlCookie.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCookie.cs
@@ -22,7 +22,7 @@ public sealed class HtmlCookie {
     public string? Path { get; set; }
 
     /// <summary>Expiration time as UNIX timestamp.</summary>
-    public float? Expires { get; set; }
+    public double? Expires { get; set; }
 
     /// <summary>True when the cookie is HTTP only.</summary>
     public bool? HttpOnly { get; set; }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Cookies.cs
@@ -61,7 +61,7 @@ public static partial class HtmlBrowser {
                 Url = c.Url,
                 Domain = c.Domain,
                 Path = c.Path,
-                Expires = c.Expires,
+                Expires = c.Expires.HasValue ? (float?)c.Expires.Value : null,
                 HttpOnly = c.HttpOnly,
                 Secure = c.Secure,
                 SameSite = c.SameSite


### PR DESCRIPTION
## Summary
- represent cookie expiration using `double?`
- update cookie parsers and Playwright bridge for new type
- adjust cookie tests for double precision

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --framework net8.0`
- `pwsh -NoLogo -Command "Invoke-Pester -Path Tests/ConvertFrom-HTMLCookie.Tests.ps1,Tests/GetSet-HTMLCookie.Tests.ps1,Tests/New-HTMLCookie.Tests.ps1 -Passthru"` *(failed: ConvertFrom-HTMLCookie, New-HtmlBrowserCookie, and other cmdlets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68979eabee90832eb037ed1e8b57cfff