### PR TITLE
Handle malformed heading levels

### DIFF
--- a/Examples/Example-ExportHtmlOutlineMalformed.ps1
+++ b/Examples/Example-ExportHtmlOutlineMalformed.ps1
@@ -1,0 +1,11 @@
+Import-Module ./PSParseHTML.psd1 -Force
+
+$Content = @'
+<h1>Good</h1>
+<hX>Bad</hX>
+<h2>Also Good</h2>
+'@
+
+$OutFile = Join-Path $PSScriptRoot 'outline-malformed.json'
+Export-HTMLOutline -Content $Content -Path $OutFile
+Get-Content -LiteralPath $OutFile

--- a/Sources/HtmlTinkerX.Tests/HtmlOutlineBuilderTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOutlineBuilderTests.cs
@@ -23,4 +23,15 @@ public class HtmlOutlineBuilderTests {
         Assert.Equal("Detail 1.1.1", outline[0].Children[0].Children[0].Title);
         Assert.Equal("Section 2", outline[1].Title);
     }
+
+    [Theory]
+    [InlineData(HtmlParserEngine.AgilityPack)]
+    [InlineData(HtmlParserEngine.AngleSharp)]
+    public void Build_SkipsMalformedHeadings(HtmlParserEngine engine) {
+        string html = "<h1>Good</h1><hX>Bad</hX><h1>Also Good</h1>";
+        var outline = HtmlOutlineBuilder.Build(html, engine);
+        Assert.Equal(2, outline.Count);
+        Assert.Equal("Good", outline[0].Title);
+        Assert.Equal("Also Good", outline[1].Title);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlOutlineBuilder.cs
+++ b/Sources/HtmlTinkerX/HtmlOutlineBuilder.cs
@@ -57,7 +57,9 @@ public static class HtmlOutlineBuilder {
             if (node is not IElement element) {
                 continue;
             }
-            int level = int.Parse(element.TagName.Substring(1));
+            if (!int.TryParse(element.TagName.Substring(1), out int level)) {
+                continue;
+            }
             string title = element.TextContent.Trim();
             headings.Add((level, title, element.Id));
         }
@@ -78,7 +80,9 @@ public static class HtmlOutlineBuilder {
                 if (node == null) {
                     continue;
                 }
-                int level = int.Parse(node.Name!.Substring(1));
+                if (!int.TryParse(node.Name!.Substring(1), out int level)) {
+                    continue;
+                }
                 string title = HtmlEntity.DeEntitize(node.InnerText ?? string.Empty)!.Trim();
                 string? id = node.Id;
                 headings.Add((level, title, id));

--- a/Tests/Export-HTMLOutline.Tests.ps1
+++ b/Tests/Export-HTMLOutline.Tests.ps1
@@ -15,4 +15,22 @@ Describe 'Export-HTMLOutline' {
             Remove-Item -LiteralPath $outFile -ErrorAction SilentlyContinue
         }
     }
+
+    It 'Skips malformed heading tags' {
+        $content = @'
+<h1>Good</h1>
+<hX>Bad</hX>
+<h1>Also Good</h1>
+'@
+        $outFile = Join-Path $PSScriptRoot 'outline_test_malformed.json'
+        try {
+            Export-HTMLOutline -Content $content -Path $outFile
+            $outline = Get-Content -LiteralPath $outFile -Raw | ConvertFrom-Json
+            $outline.Count | Should -Be 2
+            $outline[0].title | Should -Be 'Good'
+            $outline[1].title | Should -Be 'Also Good'
+        } finally {
+            Remove-Item -LiteralPath $outFile -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- guard heading parsing in HtmlOutlineBuilder with `int.TryParse`
- add unit and Pester tests covering malformed heading tags
- provide example script for exporting outlines with invalid headings

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --framework net8.0 --filter HtmlOutlineBuilderTests`
- `pwsh -NoLogo -Command "Invoke-Pester Tests/Export-HTMLOutline.Tests.ps1 -Output Detailed"`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: Failed to negotiate protocol, waiting for response timed out after 90 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68979ef59260832eb21b86c945c956fe