### PR TITLE
Safely embed HAR JSON in viewer

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
@@ -34,17 +34,59 @@ public class HtmlHarViewerTests {
     public async Task BuildViewerHtml_EmbedsValidJson() {
         Har har = await HtmlHarViewer.ReadHarAsync(GetMinimalHarPath());
         string html = HtmlHarViewer.BuildViewerHtml(har);
-        int idx = html.IndexOf("const har =", StringComparison.Ordinal);
-        Assert.NotEqual(-1, idx);
-        int start = html.IndexOf('{', idx);
-        int end = html.IndexOf("};", start, StringComparison.Ordinal);
-        string json = html.Substring(start, end - start + 1);
+        string marker = "<script type='application/json' id='har-data'>";
+        int start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.NotEqual(-1, start);
+        start += marker.Length;
+        int end = html.IndexOf("</script>", start, StringComparison.Ordinal);
+        string json = html.Substring(start, end - start);
         var opts = new JsonSerializerOptions {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
         Har? parsed = JsonSerializer.Deserialize<Har>(json, opts);
         Assert.NotNull(parsed);
+    }
+
+    [Fact]
+    /// <summary>
+    /// Ensures malicious input is safely encoded in the viewer.
+    /// </summary>
+    public void BuildViewerHtml_EncodesMaliciousInput() {
+        var har = new Har {
+            Log = new HarLog {
+                Entries = new[] {
+                    new HarEntry {
+                        StartedDateTime = DateTime.UtcNow,
+                        Request = new HarRequest {
+                            Method = "GET",
+                            Url = "</script><script>alert('x')</script>"
+                        },
+                        Response = new HarResponse {
+                            Status = 200
+                        }
+                    }
+                }
+            }
+        };
+
+        string html = HtmlHarViewer.BuildViewerHtml(har);
+        Assert.DoesNotContain("</script><script>alert('x')</script>", html, StringComparison.Ordinal);
+
+        string marker = "<script type='application/json' id='har-data'>";
+        int start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0);
+        start += marker.Length;
+        int end = html.IndexOf("</script>", start, StringComparison.Ordinal);
+        string json = html.Substring(start, end - start);
+
+        var opts = new JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        Har? parsed = JsonSerializer.Deserialize<Har>(json, opts);
+        Assert.NotNull(parsed);
+        Assert.Equal("</script><script>alert('x')</script>", parsed.Log!.Entries![0].Request!.Url);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/HtmlHarViewer.cs
+++ b/Sources/HtmlTinkerX/HtmlHarViewer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -97,8 +98,18 @@ public static class HtmlHarViewer {
     /// </summary>
     /// <param name="har">HAR data.</param>
     /// <returns>HTML string.</returns>
+    /// <example>
+    /// <code>
+    /// Har har = await HtmlHarViewer.ReadHarAsync("session.har");
+    /// string html = HtmlHarViewer.BuildViewerHtml(har);
+    /// await File.WriteAllTextAsync("har.html", html);
+    /// </code>
+    /// </example>
     public static string BuildViewerHtml(Har har) {
-        var opts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var opts = new JsonSerializerOptions {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = JavaScriptEncoder.Default
+        };
         string json = JsonSerializer.Serialize(har, opts);
         return $$"""
 <!DOCTYPE html>
@@ -120,8 +131,9 @@ thead { background: #eee; }
 </thead>
 <tbody id='entries'></tbody>
 </table>
+<script type='application/json' id='har-data'>{{json}}</script>
 <script>
-const har = {{json}};
+const har = JSON.parse(document.getElementById('har-data').textContent);
 const entries = (har.log && har.log.entries) || [];
 const tbody = document.getElementById('entries');
 for (const e of entries) {


### PR DESCRIPTION
## Summary
- Encode HAR JSON for safe embedding and parse from an application/json script block
- Document viewer usage and add tests, including malicious input handling

## Testing
- `dotnet build Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: Failed to negotiate protocol, waiting for response timed out after 200 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68979f0da750832e802479d279373be4