### PR TITLE
Use UriBuilder for GET form submission

### DIFF
--- a/Sources/HtmlTinkerX.Examples/HtmlFormSubmitterExample.cs
+++ b/Sources/HtmlTinkerX.Examples/HtmlFormSubmitterExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates submitting a form using an HTTP GET request while preserving existing query parameters.
+/// </summary>
+public static class HtmlFormSubmitterExample {
+    /// <summary>
+    /// Executes the example logic.
+    /// </summary>
+    public static async Task RunAsync() {
+        var fields = new Dictionary<string, string> {
+            ["user"] = "admin",
+            ["pass"] = "secret"
+        };
+
+        string url = "https://httpbin.org/get?existing=value";
+        string result = await HtmlFormSubmitter.SubmitAsync(url, FormMethod.Get, fields).ConfigureAwait(false);
+        Console.WriteLine(result);
+    }
+}
+

--- a/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
@@ -29,4 +29,24 @@ public class HtmlFormSubmitterTests {
         string result = await HtmlFormSubmitter.SubmitAsync(server.BaseAddress + "login", FormMethod.Post, fields, client);
         Assert.Equal("admin:secret", result);
     }
+
+    [Fact]
+    public async Task SubmitAsync_GetsFormWithExistingQuery() {
+        using var server = TestServerCompat.CreateTestServer(async context => {
+            string user = context.Request.Query["user"].ToString();
+            string pass = context.Request.Query["pass"].ToString();
+            string existing = context.Request.Query["existing"].ToString();
+            await context.Response.WriteAsync($"{user}:{pass}:{existing}");
+        }, "/login", "GET");
+        using HttpClient client = server.CreateClient();
+
+        var fields = new Dictionary<string, string> {
+            ["user"] = "admin",
+            ["pass"] = "secret"
+        };
+
+        string action = server.BaseAddress + "login?existing=value";
+        string result = await HtmlFormSubmitter.SubmitAsync(action, FormMethod.Get, fields, client);
+        Assert.Equal("admin:secret:value", result);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
@@ -1,7 +1,6 @@
 using Microsoft.Playwright;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,9 +58,23 @@ public static class HtmlFormSubmitter {
 
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
         if (method == FormMethod.Get) {
-            string query = string.Join("&", fields.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
-            string url = actionUrl.Contains("?") ? $"{actionUrl}&{query}" : $"{actionUrl}?{query}";
-            using HttpResponseMessage response = await http.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            var builder = new UriBuilder(actionUrl);
+            var parameters = new List<KeyValuePair<string, string>>();
+            if (!string.IsNullOrEmpty(builder.Query)) {
+                string[] existing = builder.Query.TrimStart('?').Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string pair in existing) {
+                    string[] kv = pair.Split(new[] { '=' }, 2);
+                    string key = Uri.UnescapeDataString(kv[0]);
+                    string value = kv.Length > 1 ? Uri.UnescapeDataString(kv[1]) : string.Empty;
+                    parameters.Add(new KeyValuePair<string, string>(key, value));
+                }
+            }
+            foreach (var kv in fields) {
+                parameters.Add(kv);
+            }
+            using var queryContent = new FormUrlEncodedContent(parameters);
+            builder.Query = await queryContent.ReadAsStringAsync().ConfigureAwait(false);
+            using HttpResponseMessage response = await http.GetAsync(builder.Uri, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         } else {


### PR DESCRIPTION
## Summary
- preserve existing query parameters when submitting forms via GET using `UriBuilder` and `FormUrlEncodedContent`
- add regression test for GET submissions with existing query string
- add example demonstrating form submission with query preservation

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlFormSubmitterTests`


------
https://chatgpt.com/codex/tasks/task_e_6897bd923944832e865b0deaf6e9524a