### PR TITLE
Guard shared HttpClient initialization

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHttpClientFactoryTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHttpClientFactoryTests.cs
@@ -72,6 +72,31 @@ public class HtmlHttpClientFactoryTests {
     }
 
     [Fact]
+    public async Task Shared_IsThreadSafe() {
+        HtmlHttpClientFactory.ResetShared();
+        const int count = 20;
+        HttpClient?[] clients = new HttpClient?[count];
+        Task[] tasks = new Task[count];
+        TaskCompletionSource<bool> start = new();
+        for (int i = 0; i < count; i++) {
+            int index = i;
+            tasks[i] = Task.Run(async () => {
+                await start.Task;
+                clients[index] = HtmlHttpClientFactory.Shared;
+            });
+        }
+        start.SetResult(true);
+        await Task.WhenAll(tasks);
+        HttpClient? first = clients[0];
+        Assert.NotNull(first);
+        HttpClient firstClient = first!;
+        foreach (HttpClient? client in clients) {
+            Assert.NotNull(client);
+            Assert.Same(firstClient, client!);
+        }
+    }
+
+    [Fact]
     public void Create_WithProxy_ConfiguresProxy() {
         var cred = new NetworkCredential("u", "p");
         using HttpClient client = HtmlHttpClientFactory.Create("http://localhost:1234", cred);

--- a/Sources/HtmlTinkerX/HttpClientFactory.cs
+++ b/Sources/HtmlTinkerX/HttpClientFactory.cs
@@ -10,7 +10,8 @@ namespace HtmlTinkerX;
 /// Default timeout, headers and proxy settings can be configured globally.
 /// </summary>
 public static class HtmlHttpClientFactory {
-    private static HttpClient? _sharedClient;
+    private static readonly object _sharedClientLock = new();
+    private static volatile HttpClient? _sharedClient;
 
     /// <summary>Default timeout used for new clients.</summary>
     public static TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromSeconds(100);
@@ -75,16 +76,22 @@ public static class HtmlHttpClientFactory {
     public static HttpClient Shared {
         get {
             if (_sharedClient == null) {
-                _sharedClient = Create();
+                lock (_sharedClientLock) {
+                    if (_sharedClient == null) {
+                        _sharedClient = Create();
+                    }
+                }
             }
-            return _sharedClient;
+            return _sharedClient!;
         }
     }
 
     /// <summary>Recreates the shared client with current defaults.</summary>
     public static void ResetShared() {
-        _sharedClient?.Dispose();
-        _sharedClient = null;
+        lock (_sharedClientLock) {
+            _sharedClient?.Dispose();
+            _sharedClient = null;
+        }
     }
 
     private static void ApplyDefaults(HttpClient client) {


### PR DESCRIPTION
## Summary
- ensure HtmlHttpClientFactory.Shared is created under double-checked locking
- reset shared client within lock
- test concurrent access to Shared property

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlHttpClientFactoryTests`

------
https://chatgpt.com/codex/tasks/task_e_689c982945f4832e921fa2867f275b3d