### PR TITLE
Add cancellation support to Playwright form submission

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -48,5 +49,22 @@ public class HtmlFormSubmitterTests {
         string action = server.BaseAddress + "login?existing=value";
         string result = await HtmlFormSubmitter.SubmitAsync(action, FormMethod.Get, fields, client);
         Assert.Equal("admin:secret:value", result);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_CanceledToken_Throws() {
+        using var server = CreateServer();
+        using HttpClient client = server.CreateClient();
+
+        var fields = new Dictionary<string, string> {
+            ["user"] = "admin",
+            ["pass"] = "secret"
+        };
+
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            HtmlFormSubmitter.SubmitAsync(server.BaseAddress + "login", FormMethod.Post, fields, client, cts.Token));
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormSubmitterTests.cs
@@ -64,7 +64,7 @@ public class HtmlFormSubmitterTests {
         using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
             HtmlFormSubmitter.SubmitAsync(server.BaseAddress + "login", FormMethod.Post, fields, client, cts.Token));
     }
 }

--- a/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
@@ -30,6 +30,8 @@ public static class HtmlFormSubmitter {
             throw new ArgumentNullException(nameof(fields));
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         var form = page.Locator(formSelector);
         await WithCancellation(form.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout }), cancellationToken).ConfigureAwait(false);
         foreach (var kv in fields) {
@@ -88,6 +90,8 @@ public static class HtmlFormSubmitter {
         if (fields == null) {
             throw new ArgumentNullException(nameof(fields));
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
         if (method == FormMethod.Get) {

--- a/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
+++ b/Sources/HtmlTinkerX/HtmlFormSubmitter.cs
@@ -18,7 +18,8 @@ public static class HtmlFormSubmitter {
     /// <param name="formSelector">CSS selector identifying the form.</param>
     /// <param name="fields">Field values keyed by name attribute.</param>
     /// <param name="timeout">Timeout in milliseconds.</param>
-    public static async Task SubmitAsync(IPage page, string formSelector, IDictionary<string, string> fields, int timeout = 10000) {
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task SubmitAsync(IPage page, string formSelector, IDictionary<string, string> fields, int timeout = 10000, CancellationToken cancellationToken = default) {
         if (page == null) {
             throw new ArgumentNullException(nameof(page));
         }
@@ -30,14 +31,46 @@ public static class HtmlFormSubmitter {
         }
 
         var form = page.Locator(formSelector);
-        await form.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout }).ConfigureAwait(false);
+        await WithCancellation(form.WaitForAsync(new LocatorWaitForOptions { Timeout = timeout }), cancellationToken).ConfigureAwait(false);
         foreach (var kv in fields) {
             var input = form.Locator($":scope [name=\"{kv.Key}\"]");
-            await input.FillAsync(kv.Value, new LocatorFillOptions { Timeout = timeout }).ConfigureAwait(false);
+            await WithCancellation(input.FillAsync(kv.Value, new LocatorFillOptions { Timeout = timeout }), cancellationToken).ConfigureAwait(false);
         }
-        await form.EvaluateAsync("form => form.submit()").ConfigureAwait(false);
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
+        await WithCancellation(form.EvaluateAsync("form => form.submit()"), cancellationToken).ConfigureAwait(false);
+        await WithCancellation(page.WaitForLoadStateAsync(LoadState.NetworkIdle), cancellationToken).ConfigureAwait(false);
     }
+
+#if NET6_0_OR_GREATER
+    private static Task WithCancellation(Task task, CancellationToken cancellationToken) => task.WaitAsync(cancellationToken);
+    private static Task<T> WithCancellation<T>(Task<T> task, CancellationToken cancellationToken) => task.WaitAsync(cancellationToken);
+#else
+    private static async Task WithCancellation(Task task, CancellationToken cancellationToken) {
+        if (!cancellationToken.CanBeCanceled) {
+            await task.ConfigureAwait(false);
+            return;
+        }
+        var tcs = new TaskCompletionSource<bool>();
+        using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), tcs)) {
+            if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false)) {
+                throw new TaskCanceledException();
+            }
+        }
+        await task.ConfigureAwait(false);
+    }
+
+    private static async Task<T> WithCancellation<T>(Task<T> task, CancellationToken cancellationToken) {
+        if (!cancellationToken.CanBeCanceled) {
+            return await task.ConfigureAwait(false);
+        }
+        var tcs = new TaskCompletionSource<bool>();
+        using (cancellationToken.Register(static s => ((TaskCompletionSource<bool>)s!).TrySetResult(true), tcs)) {
+            if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false)) {
+                throw new TaskCanceledException();
+            }
+        }
+        return await task.ConfigureAwait(false);
+    }
+#endif
 
     /// <summary>
     /// Submits a form via HTTP request using the provided action and method.


### PR DESCRIPTION
## Summary
- add optional CancellationToken to Playwright form submission helper
- implement cross-framework cancellation handling for Playwright calls
- test HtmlFormSubmitter cancellation behavior

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: Could not find 'mono' host)*
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689c9823e338832eabcd2111adfa836d