### PR TITLE
Validate URLs in HtmlResourceParser

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlResourceParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlResourceParserTests.cs
@@ -14,4 +14,14 @@ public class HtmlResourceParserTests {
         Assert.Equal("app.js", links[0].Name);
         Assert.Equal("main.css", links[1].Name);
     }
+
+    [Fact]
+    public async Task ParseUrlAsync_InvalidUrl_ThrowsArgumentException() {
+        await Assert.ThrowsAsync<ArgumentException>(() => HtmlResourceParser.ParseUrlAsync("invalid"));
+    }
+
+    [Fact]
+    public async Task DownloadResourcesFromUrlAsync_InvalidUrl_ThrowsArgumentException() {
+        await Assert.ThrowsAsync<ArgumentException>(() => HtmlResourceParser.DownloadResourcesFromUrlAsync("invalid", "dir"));
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlResourceParser.cs
+++ b/Sources/HtmlTinkerX/HtmlResourceParser.cs
@@ -91,8 +91,12 @@ public static class HtmlResourceParser {
             throw new ArgumentNullException(nameof(url));
         }
 
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) {
+            throw new ArgumentException("The URL must be an absolute URI.", nameof(url));
+        }
+
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
-        string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url).ConfigureAwait(false);
+        string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, uri.ToString()).ConfigureAwait(false);
         return Parse(content, includeCss, includeInline);
     }
 
@@ -143,9 +147,12 @@ public static class HtmlResourceParser {
             throw new ArgumentNullException(nameof(url));
         }
 
-        Uri baseUri = new(url);
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var baseUri)) {
+            throw new ArgumentException("The URL must be an absolute URI.", nameof(url));
+        }
+
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
-        List<HtmlResourceLink> links = await ParseUrlAsync(url, includeCss, includeInline: false, client: http).ConfigureAwait(false);
+        List<HtmlResourceLink> links = await ParseUrlAsync(baseUri.ToString(), includeCss, includeInline: false, client: http).ConfigureAwait(false);
         return await DownloadResourcesAsync(links, baseUri, directory, http).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary
- validate URLs in HtmlResourceParser using Uri.TryCreate
- add negative unit tests for invalid URLs

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `VSTEST_CONNECTION_TIMEOUT=180 dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --no-build --filter FullyQualifiedName~HtmlResourceParserTests`


------
https://chatgpt.com/codex/tasks/task_e_689c98d808a4832e8c23d4d5ccd66c1d