### PR TITLE
Encode HAR JSON before embedding

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlHarViewerTests.cs
@@ -1,4 +1,5 @@
 using HtmlTinkerX;
+using System.Net;
 using System.Text.Json;
 
 namespace HtmlTinkerX.Tests;
@@ -40,6 +41,7 @@ public class HtmlHarViewerTests {
         start += marker.Length;
         int end = html.IndexOf("</script>", start, StringComparison.Ordinal);
         string json = html.Substring(start, end - start);
+        json = WebUtility.HtmlDecode(json);
         var opts = new JsonSerializerOptions {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -79,6 +81,7 @@ public class HtmlHarViewerTests {
         start += marker.Length;
         int end = html.IndexOf("</script>", start, StringComparison.Ordinal);
         string json = html.Substring(start, end - start);
+        json = WebUtility.HtmlDecode(json);
 
         var opts = new JsonSerializerOptions {
             PropertyNameCaseInsensitive = true,
@@ -87,6 +90,39 @@ public class HtmlHarViewerTests {
         Har? parsed = JsonSerializer.Deserialize<Har>(json, opts);
         Assert.NotNull(parsed);
         Assert.Equal("</script><script>alert('x')</script>", parsed.Log!.Entries![0].Request!.Url);
+    }
+
+    [Fact]
+    /// <summary>
+    /// Verifies the embedded JSON payload is HTML-encoded.
+    /// </summary>
+    public void BuildViewerHtml_EncodesJsonScriptTag() {
+        var har = new Har {
+            Log = new HarLog {
+                Entries = new[] {
+                    new HarEntry {
+                        StartedDateTime = DateTime.UtcNow,
+                        Request = new HarRequest {
+                            Method = "GET",
+                            Url = "</script><script>alert('x')</script>"
+                        },
+                        Response = new HarResponse {
+                            Status = 200
+                        }
+                    }
+                }
+            }
+        };
+
+        string html = HtmlHarViewer.BuildViewerHtml(har);
+        string marker = "<script type='application/json' id='har-data'>";
+        int start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0);
+        start += marker.Length;
+        int end = html.IndexOf("</script>", start, StringComparison.Ordinal);
+        string json = html.Substring(start, end - start);
+
+        Assert.DoesNotContain("</script>", json, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/HtmlHarViewer.cs
+++ b/Sources/HtmlTinkerX/HtmlHarViewer.cs
@@ -111,6 +111,7 @@ public static class HtmlHarViewer {
             Encoder = JavaScriptEncoder.Default
         };
         string json = JsonSerializer.Serialize(har, opts);
+        string encodedJson = HtmlEncoder.Default.Encode(json);
         return $$"""
 <!DOCTYPE html>
 <html>
@@ -131,7 +132,7 @@ thead { background: #eee; }
 </thead>
 <tbody id='entries'></tbody>
 </table>
-<script type='application/json' id='har-data'>{{json}}</script>
+<script type='application/json' id='har-data'>{{encodedJson}}</script>
 <script>
 const har = JSON.parse(document.getElementById('har-data').textContent);
 const entries = (har.log && har.log.entries) || [];


### PR DESCRIPTION
## Summary
- HTML-encode serialized HAR JSON before embedding into viewer markup
- Decode embedded JSON in tests and add regression coverage for script injection

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net472` *(fails: Failed to negotiate protocol, waiting for response timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689c98dfc2a8832ebd37a6061ed4712f