### PR TITLE
Encode HtmlDiffViewer output

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlDiffViewerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDiffViewerTests.cs
@@ -11,4 +11,11 @@ public class HtmlDiffViewerTests {
         string html = HtmlDiffViewer.BuildViewerHtml(diffs);
         Assert.Contains("<table>", html);
     }
+
+    [Fact]
+    public void BuildViewerHtml_EncodesScriptTags() {
+        var diffs = HtmlDiffer.Compare("<p></p>", "<script>alert('x')</script>");
+        string html = HtmlDiffViewer.BuildViewerHtml(diffs);
+        Assert.DoesNotContain("<script>", html);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlDiffViewer.cs
+++ b/Sources/HtmlTinkerX/HtmlDiffViewer.cs
@@ -2,6 +2,7 @@ using AngleSharp.Diffing.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace HtmlTinkerX;
 
@@ -20,7 +21,8 @@ public static class HtmlDiffViewer {
         }
 
         string rows = string.Join(Environment.NewLine,
-            diffs.Select(d => $"<tr><td>{d.GetType().Name}</td><td>{d.Target}</td><td>{d.Result}</td></tr>"));
+            diffs.Select(d =>
+                $"<tr><td>{d.GetType().Name}</td><td>{WebUtility.HtmlEncode(d.Target.ToString())}</td><td>{WebUtility.HtmlEncode(d.Result.ToString())}</td></tr>"));
 
         return $$"""
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- HTML-encode diff viewer target and result values to prevent HTML injection
- Add unit test verifying diff viewer does not emit raw `<script>` tags

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --framework net8.0 --filter HtmlDiffViewerTests`


------
https://chatgpt.com/codex/tasks/task_e_689c981f12bc832e9db1560f78d4046f