### PR TITLE
Cache regex in HtmlUtilities and add performance test

### DIFF
--- a/Examples/Example-RemoveRedundantWhitespace.ps1
+++ b/Examples/Example-RemoveRedundantWhitespace.ps1
@@ -1,5 +1,0 @@
-Import-Module .\PSParseHTML.psd1 -Force
-
-$Html = '<div>   Hello  </div>  <span>  World</span>'
-$Normalized = [HtmlTinkerX.HtmlUtilities]::RemoveRedundantWhitespace($Html)
-$Normalized

--- a/Examples/Example-RemoveRedundantWhitespace.ps1
+++ b/Examples/Example-RemoveRedundantWhitespace.ps1
@@ -1,0 +1,5 @@
+Import-Module .\PSParseHTML.psd1 -Force
+
+$Html = '<div>   Hello  </div>  <span>  World</span>'
+$Normalized = [HtmlTinkerX.HtmlUtilities]::RemoveRedundantWhitespace($Html)
+$Normalized

--- a/Sources/HtmlTinkerX.Examples/RemoveRedundantWhitespaceExample.cs
+++ b/Sources/HtmlTinkerX.Examples/RemoveRedundantWhitespaceExample.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates removing redundant whitespace from HTML.
+/// </summary>
+public static class RemoveRedundantWhitespaceExample {
+    /// <summary>Executes the example logic.</summary>
+    public static void Run() {
+        const string html = "<div>   Hello  </div>  <span>  World</span>";
+        string normalized = HtmlUtilities.RemoveRedundantWhitespace(html);
+        Console.WriteLine(normalized);
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
@@ -2,11 +2,17 @@ using HtmlTinkerX;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using System.Diagnostics;
 using System.Net.Http;
+using System.Text.RegularExpressions;
+using Xunit.Abstractions;
 
 namespace HtmlTinkerX.Tests;
 
 public class HtmlUtilitiesTests {
+    private readonly ITestOutputHelper _output;
+
+    public HtmlUtilitiesTests(ITestOutputHelper output) => _output = output;
     private static TestServer CreateServer(string content, string charset) {
         var builder = new WebHostBuilder()
             .Configure(app => app.Run(async ctx => {
@@ -151,5 +157,36 @@ public class HtmlUtilitiesTests {
         const string html = "<div>   Hello  </div>  <span>  World</span>";
         string result = HtmlUtilities.RemoveRedundantWhitespace(html);
         Assert.Equal("<div> Hello </div><span> World</span>", result);
+    }
+
+    [Fact]
+    public void RemoveRedundantWhitespace_PerformanceBenchmark() {
+        const string html = "<div>   Hello  </div>  <span>  World</span>";
+        const int iterations = 10000;
+
+        static string OldRemove(string h) {
+            string collapsed = Regex.Replace(h, "\\s+", " ");
+            collapsed = Regex.Replace(collapsed, @">\s+<", "><");
+            return collapsed.Trim();
+        }
+
+        OldRemove(html);
+        HtmlUtilities.RemoveRedundantWhitespace(html);
+
+        var oldWatch = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++) {
+            OldRemove(html);
+        }
+        oldWatch.Stop();
+
+        var newWatch = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++) {
+            HtmlUtilities.RemoveRedundantWhitespace(html);
+        }
+        newWatch.Stop();
+
+        _output.WriteLine($"Old: {oldWatch.ElapsedMilliseconds} ms, New: {newWatch.ElapsedMilliseconds} ms");
+
+        Assert.True(newWatch.Elapsed <= oldWatch.Elapsed);
     }
 }

--- a/Sources/HtmlTinkerX/HtmlUtilities.cs
+++ b/Sources/HtmlTinkerX/HtmlUtilities.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace HtmlTinkerX;
 
@@ -9,6 +10,8 @@ namespace HtmlTinkerX;
 /// Helper methods for working with file paths.
 /// </summary>
 public static class HtmlUtilities {
+    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex TagWhitespaceRegex = new(@">\s+<", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     /// <summary>
     /// Resolves the provided path to an absolute file system path.
     /// Environment variables are expanded and relative paths are
@@ -151,8 +154,8 @@ public static class HtmlUtilities {
             throw new ArgumentNullException(nameof(html));
         }
 
-        string collapsed = System.Text.RegularExpressions.Regex.Replace(html, "\\s+", " ");
-        collapsed = System.Text.RegularExpressions.Regex.Replace(collapsed, @">\s+<", "><");
+        string collapsed = WhitespaceRegex.Replace(html, " ");
+        collapsed = TagWhitespaceRegex.Replace(collapsed, "><");
         return collapsed.Trim();
     }
 }


### PR DESCRIPTION
## Summary
- precompile HTML whitespace regexes for reuse
- add performance benchmark for RemoveRedundantWhitespace
- add example for removing redundant whitespace

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: Could not find 'mono' host)*
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689cbae0e47c832eb6a2900656200ddb