### PR TITLE
Add Netscape cookie export utility

### DIFF
--- a/Sources/HtmlTinkerX.Examples/ParseCookiesExample.cs
+++ b/Sources/HtmlTinkerX.Examples/ParseCookiesExample.cs
@@ -19,6 +19,8 @@ public static class ParseCookiesExample {
         await HtmlBrowser.SetCookiesAsync(session, cookies).ConfigureAwait(false);
         List<HtmlCookie> result = await HtmlBrowser.GetCookiesAsync(session).ConfigureAwait(false);
         Console.WriteLine($"Retrieved {result.Count} cookie(s) from session.");
+        string netscape = HtmlCookieParser.ToNetscapeFile(result);
+        Console.WriteLine(netscape);
         await HtmlBrowser.CloseSessionAsync(session).ConfigureAwait(false);
 
         string header = "Set-Cookie: id=abc; Path=/; Secure";

--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -35,6 +35,43 @@ public class HtmlCookieParserTests {
     }
 
     [Fact]
+    public void ToNetscapeFile_FormatsCookie() {
+        List<HtmlCookie> cookies = new() {
+            new HtmlCookie { Domain = "example.com", Path = "/", Secure = true, Expires = 1704067199d, Name = "sessionId", Value = "abc123xyz" }
+        };
+        string file = HtmlCookieParser.ToNetscapeFile(cookies);
+        string[] lines = file.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal("# Netscape HTTP Cookie File", lines[0]);
+        string[] parts = lines[1].Split('\t');
+        Assert.Equal(7, parts.Length);
+        Assert.Equal("example.com", parts[0]);
+        Assert.Equal("FALSE", parts[1]);
+        Assert.Equal("/", parts[2]);
+        Assert.Equal("TRUE", parts[3]);
+        Assert.Equal("1704067199", parts[4]);
+        Assert.Equal("sessionId", parts[5]);
+        Assert.Equal("abc123xyz", parts[6]);
+    }
+
+    [Fact]
+    public void ToNetscapeFile_RoundTrips() {
+        List<HtmlCookie> cookies = new() {
+            new HtmlCookie { Domain = ".example.com", Path = "/", Secure = false, Expires = 1704067200d, Name = "id", Value = "1" }
+        };
+        string file = HtmlCookieParser.ToNetscapeFile(cookies);
+        Assert.Contains("\tTRUE\t", file);
+        List<HtmlCookie> parsed = HtmlCookieParser.ParseNetscapeFile(file);
+        Assert.Single(parsed);
+        HtmlCookie c = parsed[0];
+        Assert.Equal(".example.com", c.Domain);
+        Assert.Equal("/", c.Path);
+        Assert.False(c.Secure);
+        Assert.Equal(1704067200d, c.Expires);
+        Assert.Equal("id", c.Name);
+        Assert.Equal("1", c.Value);
+    }
+
+    [Fact]
     public void ParseSetCookieHeader_ParsesCookie() {
         string header = "Set-Cookie: sessionId=abc123xyz; Path=/; Secure; Expires=Wed, 31 Jan 2024 23:59:59 GMT";
         HtmlCookie c = HtmlCookieParser.ParseSetCookieHeader(header);

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Playwright;
 
@@ -198,5 +200,35 @@ public static class HtmlCookieParser {
             }
         }
         return list;
+    }
+
+    /// <summary>
+    /// Converts cookies to the Netscape HTTP cookie file format.
+    /// </summary>
+    /// <param name="cookies">Collection of cookies to convert.</param>
+    public static string ToNetscapeFile(IEnumerable<HtmlCookie> cookies) {
+        if (cookies == null) {
+            throw new ArgumentNullException(nameof(cookies));
+        }
+        StringBuilder sb = new();
+        sb.AppendLine("# Netscape HTTP Cookie File");
+        foreach (HtmlCookie cookie in cookies) {
+            string domain = cookie.Domain ?? string.Empty;
+            bool tail = domain.StartsWith(".", StringComparison.Ordinal);
+            string flag = tail ? "TRUE" : "FALSE";
+            string path = cookie.Path ?? "/";
+            string secure = cookie.Secure == true ? "TRUE" : "FALSE";
+            string expires = cookie.Expires.HasValue ? cookie.Expires.Value.ToString(CultureInfo.InvariantCulture) : "0";
+            string name = cookie.Name ?? string.Empty;
+            string value = cookie.Value ?? string.Empty;
+            sb.Append(domain).Append('\t')
+              .Append(flag).Append('\t')
+              .Append(path).Append('\t')
+              .Append(secure).Append('\t')
+              .Append(expires).Append('\t')
+              .Append(name).Append('\t')
+              .Append(value).Append('\n');
+        }
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- implement `ToNetscapeFile` to emit tab-separated Netscape cookie file
- show exporting cookies in example
- test round-trip and formatting for Netscape cookie files

## Testing
- `dotnet test Sources/HtmlTinkerX.sln --framework net8.0 --no-build`
- `dotnet test Sources/HtmlTinkerX.sln --framework net472 --no-build` *(fails: Failed to negotiate protocol, waiting for response timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689cbac6ad20832e8c930a6043773db0