### PR TITLE
Add JSON-LD parsing capability

### DIFF
--- a/Sources/HtmlTinkerX.Examples/JsonLdExtractionExample.cs
+++ b/Sources/HtmlTinkerX.Examples/JsonLdExtractionExample.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace HtmlTinkerX.Examples;
+
+/// <summary>
+/// Demonstrates extracting JSON-LD data into a typed model.
+/// </summary>
+public static class JsonLdExtractionExample {
+    /// <summary>Executes the example logic.</summary>
+    public static void Run() {
+        const string html = @"<html>
+<head>
+<script type=""application/ld+json"">
+{
+  ""@context"": ""https://schema.org"",
+  ""@type"": ""Product"",
+  ""name"": ""Widget""
+}
+</script>
+</head>
+<body></body>
+</html>";
+
+        List<Product> products = HtmlParser.ParseJsonLd<Product>(html);
+        foreach (Product product in products) {
+            Console.WriteLine(product.Name);
+        }
+    }
+
+    private class Product {
+        public string? Name { get; set; }
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlMicrodataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlMicrodataTests.cs
@@ -33,4 +33,17 @@ public class HtmlMicrodataTests {
         Assert.Equal("https://schema.org/Product", items[0].Type);
         Assert.Equal("Widget", items[0].Properties["name"][0]);
     }
+
+    private class JsonLdPerson {
+        public string? Name { get; set; }
+    }
+
+    [Fact]
+    public void MicrodataParser_ExtractJsonLd_ReturnsModels() {
+        const string html = "<script type=\"application/ld+json\">{\"name\":\"Jane\"}</script>";
+        IDocument doc = HtmlParser.ParseWithAngleSharp(html);
+        var people = MicrodataParser.ExtractJsonLd<JsonLdPerson>(doc);
+        Assert.Single(people);
+        Assert.Equal("Jane", people[0].Name);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -352,9 +352,9 @@ public static class HtmlParser {
     /// </summary>
     /// <param name="html">HTML content containing microdata.</param>
     /// <returns>List of microdata items.</returns>
-    public static List<HtmlMicrodataItem> ParseMicrodataItems(string html) {
-        return HtmlParserFromMicrodata.ParseMicrodataItems(html);
-    }
+      public static List<HtmlMicrodataItem> ParseMicrodataItems(string html) {
+          return HtmlParserFromMicrodata.ParseMicrodataItems(html);
+      }
 
     /// <summary>
     /// Extracts microdata items from a web page.
@@ -362,18 +362,32 @@ public static class HtmlParser {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="client">Optional HTTP client.</param>
     /// <returns>List of microdata items.</returns>
-    public static async Task<List<HtmlMicrodataItem>> ParseUrlMicrodataItemsAsync(string url, HttpClient? client = null) {
-        return await HtmlParserFromMicrodata.ParseUrlMicrodataItemsAsync(url, client).ConfigureAwait(false);
-    }
+      public static async Task<List<HtmlMicrodataItem>> ParseUrlMicrodataItemsAsync(string url, HttpClient? client = null) {
+          return await HtmlParserFromMicrodata.ParseUrlMicrodataItemsAsync(url, client).ConfigureAwait(false);
+      }
+
+      /// <summary>
+      /// Extracts JSON-LD objects from HTML markup and deserializes them to the specified model.
+      /// </summary>
+      /// <typeparam name="T">Type to deserialize JSON-LD blocks into.</typeparam>
+      /// <param name="html">HTML content containing JSON-LD script blocks.</param>
+      /// <returns>List of deserialized models.</returns>
+      public static List<T> ParseJsonLd<T>(string html) {
+          if (html == null) {
+              throw new ArgumentNullException(nameof(html));
+          }
+          IDocument document = ParseWithAngleSharp(html);
+          return MicrodataParser.ExtractJsonLd<T>(document);
+      }
 
     /// <summary>
     /// Compares microdata items with built-in schema definitions and returns mismatches.
     /// </summary>
     /// <param name="items">Microdata items to validate.</param>
     /// <returns>List of mismatches found.</returns>
-    public static List<MicrodataSchemaMismatch> ValidateMicrodataItems(List<HtmlMicrodataItem> items) {
-        return MicrodataSchemaValidator.Validate(items);
-    }
+      public static List<MicrodataSchemaMismatch> ValidateMicrodataItems(List<HtmlMicrodataItem> items) {
+          return MicrodataSchemaValidator.Validate(items);
+      }
 
 
     /// <summary>

--- a/Sources/HtmlTinkerX/MicrodataParser.cs
+++ b/Sources/HtmlTinkerX/MicrodataParser.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace HtmlTinkerX;
 
@@ -13,6 +14,26 @@ internal static class MicrodataParser {
             items.Add(ParseItem(root));
         }
         return items;
+    }
+
+    internal static List<T> ExtractJsonLd<T>(IDocument document) {
+        List<T> results = new();
+        JsonSerializerOptions options = new() { PropertyNameCaseInsensitive = true };
+        foreach (var script in document.QuerySelectorAll("script[type='application/ld+json']")) {
+            string json = script.TextContent;
+            if (string.IsNullOrWhiteSpace(json)) {
+                continue;
+            }
+            try {
+                T? model = JsonSerializer.Deserialize<T>(json, options);
+                if (model != null) {
+                    results.Add(model);
+                }
+            } catch (JsonException) {
+                // Ignore invalid JSON-LD blocks
+            }
+        }
+        return results;
     }
 
     private static HtmlMicrodataItem ParseItem(IElement element) {


### PR DESCRIPTION
## Summary
- support extracting JSON-LD scripts into typed models
- expose public helper to parse JSON-LD
- add C# example and unit test for JSON-LD parsing

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlMicrodataTests`


------
https://chatgpt.com/codex/tasks/task_e_689cbabf64d8832e9b8c2c5f938bf89b