### PR TITLE
Parse cookie expiration using invariant culture

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserCookiesTests.cs
@@ -43,7 +43,7 @@ public class HtmlBrowserCookiesTests {
         Assert.Equal("value", c.Value);
         Assert.Equal("domain", c.Domain);
         Assert.Equal("/path", c.Path);
-        Assert.Equal(123d, c.Expires);
+        Assert.Equal(123L, c.Expires);
         Assert.True(c.HttpOnly);
         Assert.False(c.Secure);
         Assert.Equal(SameSiteAttribute.Lax, c.SameSite);

--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -1,5 +1,6 @@
 using HtmlTinkerX;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.Playwright;
 using Xunit;
 
@@ -17,7 +18,7 @@ public class HtmlCookieParserTests {
         Assert.Equal("example.com", c.Domain);
         Assert.Equal("/", c.Path);
         Assert.True(c.Secure);
-        Assert.Equal(1704067199d, c.Expires);
+        Assert.Equal(1704067199L, c.Expires);
     }
 
     [Fact]
@@ -31,13 +32,29 @@ public class HtmlCookieParserTests {
         Assert.Equal("example.com", c.Domain);
         Assert.Equal("/", c.Path);
         Assert.True(c.Secure);
-        Assert.True(c.Expires > 1e18d);
+        Assert.True(c.Expires > 1_000_000_000_000_000_000L);
+    }
+
+    [Fact]
+    public void ParseNetscapeFile_ParsesCookie_WithCommaCulture() {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            string data = "example.com\tFALSE\t/\tTRUE\t1704067199\tsessionId\tabc123xyz";
+            List<HtmlCookie> result = HtmlCookieParser.ParseNetscapeFile(data);
+            Assert.Single(result);
+            HtmlCookie c = result[0];
+            Assert.Equal(1704067199L, c.Expires);
+        }
+        finally {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     [Fact]
     public void ToNetscapeFile_FormatsCookie() {
         List<HtmlCookie> cookies = new() {
-            new HtmlCookie { Domain = "example.com", Path = "/", Secure = true, Expires = 1704067199d, Name = "sessionId", Value = "abc123xyz" }
+            new HtmlCookie { Domain = "example.com", Path = "/", Secure = true, Expires = 1704067199L, Name = "sessionId", Value = "abc123xyz" }
         };
         string file = HtmlCookieParser.ToNetscapeFile(cookies);
         string[] lines = file.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -56,7 +73,7 @@ public class HtmlCookieParserTests {
     [Fact]
     public void ToNetscapeFile_RoundTrips() {
         List<HtmlCookie> cookies = new() {
-            new HtmlCookie { Domain = ".example.com", Path = "/", Secure = false, Expires = 1704067200d, Name = "id", Value = "1" }
+            new HtmlCookie { Domain = ".example.com", Path = "/", Secure = false, Expires = 1704067200L, Name = "id", Value = "1" }
         };
         string file = HtmlCookieParser.ToNetscapeFile(cookies);
         Assert.Contains("\tTRUE\t", file);
@@ -66,7 +83,7 @@ public class HtmlCookieParserTests {
         Assert.Equal(".example.com", c.Domain);
         Assert.Equal("/", c.Path);
         Assert.False(c.Secure);
-        Assert.Equal(1704067200d, c.Expires);
+        Assert.Equal(1704067200L, c.Expires);
         Assert.Equal("id", c.Name);
         Assert.Equal("1", c.Value);
     }

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -51,8 +51,8 @@ public static class HtmlCookieParser {
             if (parts.Length < 7) {
                 continue;
             }
-            double? expires = null;
-            if (double.TryParse(parts[4], out double d) && d != 0) {
+            long? expires = null;
+            if (long.TryParse(parts[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out long d) && d != 0) {
                 expires = d;
             }
             list.Add(new HtmlCookie {
@@ -168,7 +168,8 @@ public static class HtmlCookieParser {
         };
         if (root.TryGetProperty("expires", out var e)) {
             double exp = e.GetDouble();
-            cookie.Expires = exp >= 1e12 ? exp / 1000.0 : exp;
+            long seconds = (long)(exp >= 1e12 ? exp / 1000.0 : exp);
+            cookie.Expires = seconds;
         }
         return cookie;
     }
@@ -194,7 +195,7 @@ public static class HtmlCookieParser {
                     HttpOnly = el.TryGetProperty("httpOnly", out var h) ? h.GetBoolean() : (bool?)null
                 };
                 if (el.TryGetProperty("expires", out var e)) {
-                    c.Expires = e.GetDouble();
+                    c.Expires = (long)e.GetDouble();
                 }
                 list.Add(c);
             }

--- a/Sources/HtmlTinkerX/Models/HtmlCookie.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCookie.cs
@@ -22,7 +22,7 @@ public sealed class HtmlCookie {
     public string? Path { get; set; }
 
     /// <summary>Expiration time as UNIX timestamp.</summary>
-    public double? Expires { get; set; }
+    public long? Expires { get; set; }
 
     /// <summary>True when the cookie is HTTP only.</summary>
     public bool? HttpOnly { get; set; }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Cookies.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Cookies.cs
@@ -25,7 +25,7 @@ public static partial class HtmlBrowser {
                 Value = c.Value,
                 Domain = c.Domain,
                 Path = c.Path,
-                Expires = c.Expires,
+                Expires = c.Expires != 0 ? (long)c.Expires : (long?)null,
                 HttpOnly = c.HttpOnly,
                 Secure = c.Secure,
                 SameSite = c.SameSite
@@ -61,7 +61,7 @@ public static partial class HtmlBrowser {
                 Url = c.Url,
                 Domain = c.Domain,
                 Path = c.Path,
-                Expires = c.Expires.HasValue ? (float?)c.Expires.Value : null,
+                Expires = c.Expires.HasValue ? (float)c.Expires.Value : null,
                 HttpOnly = c.HttpOnly,
                 Secure = c.Secure,
                 SameSite = c.SameSite

--- a/Sources/PSParseHTML.PowerShell/CmdletNewHtmlBrowserCookie.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletNewHtmlBrowserCookie.cs
@@ -33,7 +33,7 @@ public sealed class CmdletNewHtmlBrowserCookie : PSCmdlet {
 
     /// <summary>Cookie expiration time as UNIX timestamp.</summary>
     [Parameter]
-    public float? Expires { get; set; }
+    public long? Expires { get; set; }
 
     /// <summary>Mark cookie as HTTP only.</summary>
     [Parameter]


### PR DESCRIPTION
## Summary
- ensure Netscape cookie parsing uses invariant culture and integer expiration
- store cookie expiration as nullable long across the library
- add locale-aware tests for Netscape parsing

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter ParseNetscapeFile_ParsesCookie_WithCommaCulture --framework net8.0`
- `dotnet test Sources/HtmlTinkerX.sln --framework net8.0` *(fails: HtmlUtilitiesTests.RemoveRedundantWhitespace_PerformanceBenchmark)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c0cdb98832eb69beab970b71c47