### PR TITLE
Log navigation failures and test error logging

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadTests.cs
@@ -38,8 +38,8 @@ public class HtmlBrowserDownloadTests {
         logger.OnErrorMessage += (_, e) => errors.Add(e);
         LoggingMessages.Logger = logger;
 
-        await Assert.ThrowsAsync<PlaywrightException>(
-            () => HtmlBrowser.OpenSessionAsync("https://invalid"));
+        var ex = await Record.ExceptionAsync(() => HtmlBrowser.OpenSessionAsync("https://invalid"));
+        Assert.IsType<PlaywrightException>(ex);
 
         Assert.Single(errors);
         Assert.Contains("https://invalid", errors[0].Message);

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadTests.cs
@@ -1,0 +1,51 @@
+using HtmlTinkerX;
+using Microsoft.Playwright;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlBrowserDownloadTests {
+    [Fact]
+    public async Task OpenSessionAsync_InvalidUrl_LogsError() {
+        var page = new Mock<IPage>();
+        page.Setup(p => p.GotoAsync(It.IsAny<string>(), It.IsAny<PageGotoOptions>()))
+            .ThrowsAsync(new PlaywrightException("boom"));
+
+        var context = new Mock<IBrowserContext>();
+        context.Setup(c => c.NewPageAsync()).ReturnsAsync(page.Object);
+
+        var browser = new Mock<IBrowser>();
+        browser.Setup(b => b.NewContextAsync(It.IsAny<BrowserNewContextOptions>()))
+            .ReturnsAsync(context.Object);
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions>()))
+            .Returns(Task.CompletedTask);
+        browser.SetupGet(b => b.BrowserType).Returns(new Mock<IBrowserType>().Object);
+
+        var browserType = new Mock<IBrowserType>();
+        browserType.Setup(bt => bt.LaunchAsync(It.IsAny<BrowserTypeLaunchOptions>()))
+            .ReturnsAsync(browser.Object);
+
+        var playwright = new Mock<IPlaywright>();
+        playwright.SetupGet(p => p.Chromium).Returns(browserType.Object);
+        HtmlBrowser.PlaywrightFactory = () => Task.FromResult(playwright.Object);
+
+        InternalLogger originalLogger = LoggingMessages.Logger;
+        InternalLogger logger = new InternalLogger();
+        List<LogEventArgs> errors = new();
+        logger.OnErrorMessage += (_, e) => errors.Add(e);
+        LoggingMessages.Logger = logger;
+
+        await Assert.ThrowsAsync<PlaywrightException>(
+            () => HtmlBrowser.OpenSessionAsync("https://invalid"));
+
+        Assert.Single(errors);
+        Assert.Contains("https://invalid", errors[0].Message);
+
+        LoggingMessages.Logger = originalLogger;
+        HtmlBrowser.PlaywrightFactory = null;
+    }
+}
+

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserDownloadTests.cs
@@ -33,19 +33,20 @@ public class HtmlBrowserDownloadTests {
         HtmlBrowser.PlaywrightFactory = () => Task.FromResult(playwright.Object);
 
         InternalLogger originalLogger = LoggingMessages.Logger;
-        InternalLogger logger = new InternalLogger();
-        List<LogEventArgs> errors = new();
-        logger.OnErrorMessage += (_, e) => errors.Add(e);
-        LoggingMessages.Logger = logger;
+        try {
+            InternalLogger logger = new InternalLogger();
+            List<LogEventArgs> errors = new();
+            logger.OnErrorMessage += (_, e) => errors.Add(e);
+            LoggingMessages.Logger = logger;
 
-        var ex = await Record.ExceptionAsync(() => HtmlBrowser.OpenSessionAsync("https://invalid"));
-        Assert.IsType<PlaywrightException>(ex);
-
-        Assert.Single(errors);
-        Assert.Contains("https://invalid", errors[0].Message);
-
-        LoggingMessages.Logger = originalLogger;
-        HtmlBrowser.PlaywrightFactory = null;
+            var ex = await Record.ExceptionAsync(() => HtmlBrowser.OpenSessionAsync("https://invalid"));
+            Assert.IsType<PlaywrightException>(ex);
+            Assert.Contains(errors, e => e.Message.Contains("https://invalid"));
+        }
+        finally {
+            LoggingMessages.Logger = originalLogger;
+            HtmlBrowser.PlaywrightFactory = null;
+        }
     }
 }
 

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserVideoRecordingTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserVideoRecordingTests.cs
@@ -52,27 +52,29 @@ public class HtmlBrowserVideoRecordingTests {
         playwright.SetupGet(p => p.Chromium).Returns(browserType.Object);
         HtmlBrowser.PlaywrightFactory = () => Task.FromResult(playwright.Object);
 
-        HtmlBrowserSession session;
-        if (useSession) {
-            var initContext = new Mock<IBrowserContext>();
-            initContext.Setup(c => c.StorageStateAsync(It.IsAny<BrowserContextStorageStateOptions>())).ReturnsAsync("{}");
-            var initBrowser = new Mock<IBrowser>();
-            initBrowser.SetupGet(b => b.BrowserType).Returns(browserType.Object);
-            var initPage = new Mock<IPage>();
-            initPage.SetupGet(p => p.Url).Returns("https://example.com");
-            session = await HtmlBrowser.StartVideoRecordingAsync(new HtmlBrowserSession(playwright.Object, initBrowser.Object, initContext.Object, initPage.Object), outFile);
-        } else {
-            session = await HtmlBrowser.StartVideoRecordingAsync("https://example.com", outFile);
+        try {
+            HtmlBrowserSession session;
+            if (useSession) {
+                var initContext = new Mock<IBrowserContext>();
+                initContext.Setup(c => c.StorageStateAsync(It.IsAny<BrowserContextStorageStateOptions>())).ReturnsAsync("{}");
+                var initBrowser = new Mock<IBrowser>();
+                initBrowser.SetupGet(b => b.BrowserType).Returns(browserType.Object);
+                var initPage = new Mock<IPage>();
+                initPage.SetupGet(p => p.Url).Returns("https://example.com");
+                session = await HtmlBrowser.StartVideoRecordingAsync(new HtmlBrowserSession(playwright.Object, initBrowser.Object, initContext.Object, initPage.Object), outFile);
+            } else {
+                session = await HtmlBrowser.StartVideoRecordingAsync("https://example.com", outFile);
+            }
+
+            await HtmlBrowser.StopVideoRecordingAsync(session);
+
+            video.Verify(v => v.SaveAsAsync(outFile.ToFullPath()), Times.Once);
+            Assert.False(File.Exists(tempVideo));
+            if (useSession) {
+                Assert.False(File.Exists(statePath!));
+            }
+        } finally {
+            HtmlBrowser.PlaywrightFactory = null;
         }
-
-        await HtmlBrowser.StopVideoRecordingAsync(session);
-
-        video.Verify(v => v.SaveAsAsync(outFile.ToFullPath()), Times.Once);
-        Assert.False(File.Exists(tempVideo));
-        if (useSession) {
-            Assert.False(File.Exists(statePath!));
-        }
-
-        HtmlBrowser.PlaywrightFactory = null;
     }
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
@@ -139,23 +139,28 @@ public static partial class HtmlBrowser {
         string? password,
         int timeout,
         CancellationToken cancellationToken) {
-        if (formLogin != null) {
-            cancellationToken.ThrowIfCancellationRequested();
-            await page.GotoAsync(formLogin.LoginUrl, new PageGotoOptions { Timeout = timeout });
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
-            if (username != null) {
-                await page.FillAsync(formLogin.UsernameSelector, username, new PageFillOptions { Timeout = timeout });
+        try {
+            if (formLogin != null) {
+                cancellationToken.ThrowIfCancellationRequested();
+                await page.GotoAsync(formLogin.LoginUrl, new PageGotoOptions { Timeout = timeout });
+                await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
+                if (username != null) {
+                    await page.FillAsync(formLogin.UsernameSelector, username, new PageFillOptions { Timeout = timeout });
+                }
+                if (password != null) {
+                    await page.FillAsync(formLogin.PasswordSelector, password, new PageFillOptions { Timeout = timeout });
+                }
+                await page.ClickAsync(formLogin.SubmitSelector, new PageClickOptions { Timeout = timeout });
+                await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
             }
-            if (password != null) {
-                await page.FillAsync(formLogin.PasswordSelector, password, new PageFillOptions { Timeout = timeout });
-            }
-            await page.ClickAsync(formLogin.SubmitSelector, new PageClickOptions { Timeout = timeout });
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
-        }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        await page.GotoAsync(url, new PageGotoOptions { Timeout = timeout });
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
+            cancellationToken.ThrowIfCancellationRequested();
+            await page.GotoAsync(url, new PageGotoOptions { Timeout = timeout });
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = timeout });
+        } catch (Exception ex) {
+            LoggingMessages.Logger.WriteError("Failed to navigate to {0}: {1}", url, ex.Message);
+            throw;
+        }
     }
     /// <summary>
     /// Creates a new Playwright browser session and navigates to the specified URL.


### PR DESCRIPTION
## Summary
- log failing URL when navigation throws in NavigateAsync
- add test verifying error logging for invalid URL navigation

## Testing
- `dotnet test Sources/HtmlTinkerX.sln` *(fails: Could not find 'mono' host)*
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --filter OpenSessionAsync_InvalidUrl_LogsError`


------
https://chatgpt.com/codex/tasks/task_e_689e17950508832e94511375d80b5796