### PR TITLE
Use invariant culture for cookie date parsing

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -100,12 +100,40 @@ public class HtmlCookieParserTests {
     }
 
     [Fact]
+    public void ParseSetCookieHeader_ParsesSpecificDate() {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            string header = "Set-Cookie: id=1; Path=/; Expires=Tue, 05 Mar 2024 15:00:00 GMT";
+            HtmlCookie c = HtmlCookieParser.ParseSetCookieHeader(header);
+            Assert.Equal(1709650800L, c.Expires);
+        }
+        finally {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
     public void ParseOrgJsonCookie_ParsesJson() {
         string json = "{\"Path\":\"/\",\"Secure\":\"false\",\"name\":\"sessionId\",\"Expires\":\"Sun, 31 Dec 2023 23:59:59 GMT\",\"Domain\":\"example.com\",\"value\":\"abc123xyz\"}";
         HtmlCookie c = HtmlCookieParser.ParseOrgJsonCookie(json);
         Assert.Equal("sessionId", c.Name);
         Assert.Equal("abc123xyz", c.Value);
         Assert.Equal("example.com", c.Domain);
+    }
+
+    [Fact]
+    public void ParseOrgJsonCookie_ParsesDateRegardlessOfCulture() {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            string json = "{\"name\":\"id\",\"value\":\"1\",\"Expires\":\"Tue, 05 Mar 2024 15:00:00 GMT\"}";
+            HtmlCookie c = HtmlCookieParser.ParseOrgJsonCookie(json);
+            Assert.Equal(1709650800L, c.Expires);
+        }
+        finally {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -140,7 +140,7 @@ public static class HtmlCookieParser {
                 Secure = CookieHelpers.TryGetPropertyIgnoreCase(root, "Secure", out var s) ? s.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null,
                 HttpOnly = CookieHelpers.TryGetPropertyIgnoreCase(root, "HttpOnly", out var h) ? h.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null
             };
-            if (root.TryGetProperty("Expires", out var e) && DateTime.TryParse(e.GetString(), out DateTime dt)) {
+            if (root.TryGetProperty("Expires", out var e) && DateTime.TryParse(e.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime dt)) {
                 cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
             }
             return cookie;


### PR DESCRIPTION
## Summary
- use invariant culture and assume UTC when parsing Org.json cookie expiration
- add coverage for parsing "Tue, 05 Mar 2024 15:00:00 GMT" dates

## Testing
- `dotnet build Sources/HtmlTinkerX.sln`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlCookieParserTests`


------
https://chatgpt.com/codex/tasks/task_e_689e179ed7fc832eacc6551b96ca285c