### PR TITLE
Use invariant culture for table span parsing

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlParserTableAdvancedTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserTableAdvancedTests.cs
@@ -153,4 +153,18 @@ public class HtmlParserTableAdvancedTests {
         }
 //#endif
     }
+
+    [Fact]
+    public void ParseTablesDetailed_NonUSCulture_ParsesSpans() {
+        const string html = "<table><tr><th>A</th><th>B</th></tr><tr><td rowspan=\"2\">1</td><td>2</td></tr><tr><td>3</td></tr></table>";
+        TestHelpers.WithCulture("fr-FR", () => {
+            var angle = HtmlParser.ParseTablesWithAngleSharpDetailed(html, null, null, false, false, false, null);
+            Assert.Single(angle);
+            Assert.Equal("3", angle[0].Data[1]["B"]);
+
+            var agility = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, false, false, false, null);
+            Assert.Single(agility);
+            Assert.Equal("3", agility[0].Data[1]["B"]);
+        });
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlParserTableAzureTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserTableAzureTests.cs
@@ -47,4 +47,17 @@ public class HtmlParserTableAzureTests {
         Assert.Contains("East US", first.Metadata.Headers);
         Assert.Equal("Compute", first.Data[0]["Products and services"]);
     }
+
+    [Fact]
+    public void ParseAzureStatus_NonUSCulture() {
+        TestHelpers.WithCulture("fr-FR", () => {
+            string html = GetAzureStatusHtml();
+
+            var agility = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html);
+            var angle = HtmlParser.ParseTablesWithAngleSharpDetailed(html);
+
+            Assert.True(agility.Count >= 7);
+            Assert.True(angle.Count >= 7);
+        });
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlParserTableSimpleTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserTableSimpleTests.cs
@@ -6,6 +6,7 @@ namespace HtmlTinkerX.Tests;
 
 public class HtmlParserTableSimpleTests {
     private const string SimpleTable = "<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>";
+    private const string SpanTable = "<table><tr><th>A</th><th>B</th></tr><tr><td colspan=\"2\">1</td></tr></table>";
 
     [Fact]
     public void ParseTablesWithAngleSharp_ReturnsData() {
@@ -34,5 +35,27 @@ public class HtmlParserTableSimpleTests {
         var row = tables[0][0];
         Assert.Equal("V", row["K"]);
         Assert.Equal("Y", row["X"]);
+    }
+
+    [Fact]
+    public void ParseTablesWithAngleSharp_NonUSCulture_ParsesSpans() {
+        TestHelpers.WithCulture("fr-FR", () => {
+            var tables = HtmlParser.ParseTablesWithAngleSharp(SpanTable);
+            Assert.Single(tables);
+            Assert.Single(tables[0]);
+            Assert.Equal("1", tables[0][0]["A"]);
+            Assert.Equal("1", tables[0][0]["B"]);
+        });
+    }
+
+    [Fact]
+    public void ParseTablesWithHtmlAgilityPack_NonUSCulture_ParsesSpans() {
+        TestHelpers.WithCulture("fr-FR", () => {
+            var tables = HtmlParser.ParseTablesWithHtmlAgilityPack(SpanTable);
+            Assert.Single(tables);
+            Assert.Single(tables[0]);
+            Assert.Equal("1", tables[0][0]["A"]);
+            Assert.Equal("1", tables[0][0]["B"]);
+        });
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlParserTableSkipFooterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserTableSkipFooterTests.cs
@@ -23,4 +23,22 @@ public class HtmlParserTableSkipFooterTests {
         Assert.Single(table.Data);
         Assert.Equal("1", table.Data[0]["A"]);
     }
+
+    [Fact]
+    public void ParseTablesWithDetailedParsers_NonUSCulture_ParsesSpans() {
+        const string html = "<table><tr><th>A</th><th>B</th></tr><tr><td colspan=\"2\">1</td></tr><tfoot><tr><td colspan=\"2\">2</td></tr></tfoot></table>";
+        TestHelpers.WithCulture("fr-FR", () => {
+            var angle = HtmlParser.ParseTablesWithAngleSharpDetailed(html, null, null, false, true, false, null);
+            Assert.Single(angle);
+            Assert.Single(angle[0].Data);
+            Assert.Equal("1", angle[0].Data[0]["A"]);
+            Assert.Equal("1", angle[0].Data[0]["B"]);
+
+            var agility = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, false, true, false, null);
+            Assert.Single(agility);
+            Assert.Single(agility[0].Data);
+            Assert.Equal("1", agility[0].Data[0]["A"]);
+            Assert.Equal("1", agility[0].Data[0]["B"]);
+        });
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/TestHelpers.cs
+++ b/Sources/HtmlTinkerX.Tests/TestHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Globalization;
 using Xunit;
 
 namespace HtmlTinkerX.Tests;
@@ -33,5 +34,24 @@ internal static class TestHelpers {
     /// <param name="actual">The actual string.</param>
     public static void EqualIgnoringLineEndings(string expected, string actual) {
         Assert.Equal(NormalizeLineEndings(expected), NormalizeLineEndings(actual));
+    }
+
+    /// <summary>
+    /// Executes an action using the specified culture and restores the original culture afterwards.
+    /// </summary>
+    /// <param name="cultureName">The culture to apply for the duration of the action.</param>
+    /// <param name="action">The action to execute.</param>
+    public static void WithCulture(string cultureName, Action action) {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUICulture = CultureInfo.CurrentUICulture;
+        try {
+            var culture = new CultureInfo(cultureName);
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+            action();
+        } finally {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
     }
 }

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace HtmlTinkerX;
 
@@ -136,7 +137,7 @@ public static class HtmlParserFromTable {
                     header = HtmlParser.CleanHeaderName(header);
                 }
                 int colspan = 1;
-                if (int.TryParse(cell.GetAttribute("colspan"), out int cs)) {
+                if (int.TryParse(cell.GetAttribute("colspan"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs)) {
                     colspan = cs;
                 }
                 for (int c = 0; c < colspan; c++) {
@@ -199,10 +200,10 @@ public static class HtmlParserFromTable {
                     }
                     int colspan = 1;
                     int rowspan = 1;
-                    if (int.TryParse(cell.GetAttribute("colspan"), out int cs)) {
+                    if (int.TryParse(cell.GetAttribute("colspan"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs)) {
                         colspan = cs;
                     }
-                    if (int.TryParse(cell.GetAttribute("rowspan"), out int rs)) {
+                    if (int.TryParse(cell.GetAttribute("rowspan"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int rs)) {
                         rowspan = rs;
                     }
                     for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
@@ -284,7 +285,7 @@ public static class HtmlParserFromTable {
                         }
                     }
                     int colspan = 1;
-                    if (int.TryParse(cell.GetAttribute("colspan"), out int cs)) {
+                    if (int.TryParse(cell.GetAttribute("colspan"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs)) {
                         colspan = cs;
                     }
                     for (int c = 0; c < colspan; c++) {
@@ -330,10 +331,10 @@ public static class HtmlParserFromTable {
                         }
                         int colspan = 1;
                         int rowspan = 1;
-                        if (int.TryParse(cell.GetAttribute("colspan"), out int cs2)) {
+                        if (int.TryParse(cell.GetAttribute("colspan"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs2)) {
                             colspan = cs2;
                         }
-                        if (int.TryParse(cell.GetAttribute("rowspan"), out int rs2)) {
+                        if (int.TryParse(cell.GetAttribute("rowspan"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int rs2)) {
                             rowspan = rs2;
                         }
                         for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
@@ -546,7 +547,7 @@ public static class HtmlParserFromTable {
                         header = HtmlParser.CleanHeaderName(header);
                     }
                     int colspan = 1;
-                    if (int.TryParse(cell.GetAttributeValue("colspan", "1"), out int cs)) {
+                    if (int.TryParse(cell.GetAttributeValue("colspan", "1"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs)) {
                         colspan = cs;
                     }
                     for (int c = 0; c < colspan; c++) {
@@ -602,10 +603,10 @@ public static class HtmlParserFromTable {
                         }
                         int colspan = 1;
                         int rowspan = 1;
-                        if (int.TryParse(cell.GetAttributeValue("colspan", "1"), out int cs2)) {
+                        if (int.TryParse(cell.GetAttributeValue("colspan", "1"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs2)) {
                             colspan = cs2;
                         }
-                        if (int.TryParse(cell.GetAttributeValue("rowspan", "1"), out int rs2)) {
+                        if (int.TryParse(cell.GetAttributeValue("rowspan", "1"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int rs2)) {
                             rowspan = rs2;
                         }
                         for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
@@ -737,7 +738,7 @@ public static class HtmlParserFromTable {
                         }
                     }
                     int colspan = 1;
-                    if (int.TryParse(cell.GetAttributeValue("colspan", "1"), out int cs)) {
+                    if (int.TryParse(cell.GetAttributeValue("colspan", "1"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs)) {
                         colspan = cs;
                     }
                     for (int c = 0; c < colspan; c++) {
@@ -786,10 +787,10 @@ public static class HtmlParserFromTable {
                         }
                         int colspan = 1;
                         int rowspan = 1;
-                        if (int.TryParse(cell.GetAttributeValue("colspan", "1"), out int cs2)) {
+                        if (int.TryParse(cell.GetAttributeValue("colspan", "1"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int cs2)) {
                             colspan = cs2;
                         }
-                        if (int.TryParse(cell.GetAttributeValue("rowspan", "1"), out int rs2)) {
+                        if (int.TryParse(cell.GetAttributeValue("rowspan", "1"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int rs2)) {
                             rowspan = rs2;
                         }
                         for (int c = 0; c < colspan && col < headers.Count; c++, col++) {


### PR DESCRIPTION
## Summary
- parse `colspan`/`rowspan` values with `NumberStyles.Integer` and `CultureInfo.InvariantCulture` across both AngleSharp and HtmlAgilityPack table readers
- add culture-switch helper and expand table parsing tests to run under a non-US culture

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: PreMailerClientPathTests, EncodingDebugTest, HtmlParserExtensionsTests, HtmlAgilityPackEncodingTest, HtmlParserTableAdvancedTests.ConvertFromHtmlTable_FromUrlWithPolishCharacters_PreservesEncoding)*

------
https://chatgpt.com/codex/tasks/task_e_689e17a47f1c832e921f09270d10db91