### PR TITLE
Relax performance benchmark tolerance in HtmlUtilitiesTests

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
@@ -187,7 +187,8 @@ public class HtmlUtilitiesTests {
 
         _output.WriteLine($"Old: {oldWatch.ElapsedMilliseconds} ms, New: {newWatch.ElapsedMilliseconds} ms");
 
-        TimeSpan tolerance = TimeSpan.FromMilliseconds(oldWatch.Elapsed.TotalMilliseconds * 0.05 + 1);
+        double toleranceMs = oldWatch.Elapsed.TotalMilliseconds * 0.05 + 1;
+        TimeSpan tolerance = TimeSpan.FromMilliseconds(toleranceMs);
         Assert.True(newWatch.Elapsed <= oldWatch.Elapsed + tolerance);
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
@@ -187,6 +187,7 @@ public class HtmlUtilitiesTests {
 
         _output.WriteLine($"Old: {oldWatch.ElapsedMilliseconds} ms, New: {newWatch.ElapsedMilliseconds} ms");
 
-        Assert.True(newWatch.Elapsed <= oldWatch.Elapsed);
+        TimeSpan tolerance = TimeSpan.FromMilliseconds(oldWatch.Elapsed.TotalMilliseconds * 0.05 + 1);
+        Assert.True(newWatch.Elapsed <= oldWatch.Elapsed + tolerance);
     }
 }

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -173,15 +173,22 @@
     }
 
     It 'Parses Wikipedia escape sequence table with correct columns' {
-        $Tables = ConvertFrom-HtmlTable -Url 'https://en.wikipedia.org/wiki/PowerShell'
-        $Tables.Count | Should -BeGreaterOrEqual 2
+        [HtmlTinkerX.HtmlHttpClientFactory]::DefaultHeaders['User-Agent'] = 'HtmlTinkerX.Tests'
+        try {
+            $Tables = ConvertFrom-HtmlTable -Url 'https://en.wikipedia.org/wiki/PowerShell'
+            $Tables.Count | Should -BeGreaterOrEqual 2
 
-        $Table = $Tables[1]
-        $Columns = $Table[0].PSObject.Properties.Name
-        $Columns[0] | Should -Be 'Sequence'
-        $Columns[1] | Should -Be 'Meaning'
+            $Table = $Tables[1]
+            $Columns = $Table[0].PSObject.Properties.Name
+            $Columns[0] | Should -Be 'Sequence'
+            $Columns[1] | Should -Be 'Meaning'
 
-        ($Table | Where-Object Sequence -eq '`n').Meaning | Should -Be 'Newline'
-        $Table.Count | Should -BeGreaterOrEqual 10
+            ($Table | Where-Object Sequence -eq '`n').Meaning | Should -Be 'Newline'
+            $Table.Count | Should -BeGreaterOrEqual 10
+        }
+        finally {
+            [HtmlTinkerX.HtmlHttpClientFactory]::DefaultHeaders.Remove('User-Agent') | Out-Null
+            [HtmlTinkerX.HtmlHttpClientFactory]::ResetShared()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow small time variance in `RemoveRedundantWhitespace` performance test to reduce flakiness

## Testing
- `dotnet build Sources/HtmlTinkerX.sln --configuration Release`
- `dotnet test Sources/HtmlTinkerX.sln --configuration Release --no-build --framework net8.0 --verbosity minimal --logger "console;verbosity=minimal" --logger trx --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68a3551ece64832ea172fa1e4a4f8c70