### PR TITLE
Handle null image sources in HtmlOptimizer

### DIFF
--- a/Examples/EmbedImagesExample.cs
+++ b/Examples/EmbedImagesExample.cs
@@ -1,0 +1,7 @@
+// Sample demonstrating HtmlOptimizer.EmbedImagesAsDataUriAsync
+using System.Net.Http;
+using HtmlTinkerX;
+
+string html = "<html><body><img src=\"https://example.com/image.png\" /></body></html>";
+string result = await HtmlOptimizer.EmbedImagesAsDataUriAsync(html, client: new HttpClient());
+Console.WriteLine(result);

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
@@ -57,4 +57,13 @@ public class HtmlOptimizerTests {
         Assert.Contains("data:image/png;base64", result);
         Assert.DoesNotContain("image.png", result);
     }
+
+    [Fact]
+    public async Task EmbedImagesAsDataUriAsync_IgnoresMissingOrDataSources() {
+        const string html = "<html><body><img /><img src=\"data:image/png;base64,AAA=\" /></body></html>";
+
+        string result = await HtmlOptimizer.EmbedImagesAsDataUriAsync(html);
+
+        Assert.Equal(html, result);
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlOptimizer.cs
+++ b/Sources/HtmlTinkerX/HtmlOptimizer.cs
@@ -156,7 +156,11 @@ public static class HtmlOptimizer {
 
         foreach (var element in document.Images) {
             string? src = element.GetAttribute("src");
-            if (string.IsNullOrEmpty(src) || src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
+            if (src is null) {
+                continue;
+            }
+
+            if (src.Length == 0 || src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- guard against null and data URI image sources in HtmlOptimizer.EmbedImagesAsDataUriAsync
- add regression test for skipping invalid image sources
- document EmbedImagesAsDataUriAsync usage example

## Testing
- `dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_68a3909b6ad8832e9ffd9353452306c4