### PR TITLE
Fix parser nullability warnings

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlFormFieldExtractorTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormFieldExtractorTests.cs
@@ -19,4 +19,9 @@ public class HtmlFormFieldExtractorTests {
         Assert.Equal("user", fields[0].Name);
         Assert.Equal(HtmlFormFieldType.Text, fields[0].Type);
     }
+
+    [Fact]
+    public void ExtractFields_NullHtml_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlFormFieldExtractor.ExtractFields(null));
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlOpenGraphTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOpenGraphTests.cs
@@ -18,4 +18,9 @@ public class HtmlOpenGraphTests {
         Assert.Equal("Open Graph Title", og.Properties.Find(p => p.Name == "title")?.Values[0]);
         Assert.Equal("https://example.com/img.png", og.Properties.Find(p => p.Name == "image")?.Values[0]);
     }
+
+    [Fact]
+    public void ParseOpenGraph_NullHtml_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlParser.ParseOpenGraph(null));
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlParserExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserExtensionsTests.cs
@@ -71,6 +71,14 @@ public class HtmlParserExtensionsTests {
 
     [Fact]
     /// <summary>
+    /// Throws when html content is null.
+    /// </summary>
+    public void GetElements_NullHtml_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlParserExtensions.GetElements(null));
+    }
+
+    [Fact]
+    /// <summary>
     /// Validates combined selection filters produce correct counts.
     /// </summary>
     public void GetElements_ByClassTagIdName_CombinedCounts() {

--- a/Sources/HtmlTinkerX.Tests/HtmlParserFormTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserFormTests.cs
@@ -27,4 +27,12 @@ public class HtmlParserFormTests {
         Assert.Equal(2, forms[0].Fields.Count);
         Assert.Equal("user", forms[0].Fields[0].Name);
     }
+
+    [Fact]
+    /// <summary>
+    /// Throws when html content is null.
+    /// </summary>
+    public void ParseFormsWithAngleSharp_NullHtml_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlParser.ParseFormsWithAngleSharp(null));
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlParserListTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserListTests.cs
@@ -61,4 +61,9 @@ public class HtmlParserListTests {
         Assert.Equal(1, lists[1].Metadata.ListIndex);
         Assert.Equal(2, lists[1].Items.Count);
     }
+
+    [Fact]
+    public void ParseListsWithAngleSharpDetailed_NullHtml_Throws() {
+        Assert.Throws<ArgumentNullException>(() => HtmlParser.ParseListsWithAngleSharpDetailed(null, " "));
+    }
 }

--- a/Sources/HtmlTinkerX/HtmlFormFieldExtractor.cs
+++ b/Sources/HtmlTinkerX/HtmlFormFieldExtractor.cs
@@ -15,7 +15,7 @@ public static class HtmlFormFieldExtractor {
     /// </summary>
     /// <param name="html">HTML content to parse.</param>
     /// <returns>List of form fields.</returns>
-    public static List<HtmlFormField> ExtractFields(string html) {
+    public static List<HtmlFormField> ExtractFields(string? html) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -25,12 +25,13 @@ public static class HtmlFormFieldExtractor {
         List<HtmlFormField> results = new();
         foreach (var field in fields) {
             string? name = field.GetAttribute("name");
-            if (string.IsNullOrEmpty(name)) {
+            if (name == null || name.Length == 0) {
                 continue;
             }
+            string nameValue = name;
             string type = field.GetAttribute("type") ?? field.NodeName.ToLowerInvariant();
             results.Add(new HtmlFormField {
-                Name = name!,
+                Name = nameValue,
                 Type = MapType(type)
             });
         }
@@ -58,7 +59,7 @@ public static class HtmlFormFieldExtractor {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="client">Optional HTTP client.</param>
     /// <returns>List of form fields.</returns>
-    public static async Task<List<HtmlFormField>> ExtractUrlFieldsAsync(string url, HttpClient? client = null) {
+    public static async Task<List<HtmlFormField>> ExtractUrlFieldsAsync(string? url, HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }

--- a/Sources/HtmlTinkerX/HtmlOptimizer.cs
+++ b/Sources/HtmlTinkerX/HtmlOptimizer.cs
@@ -156,7 +156,7 @@ public static class HtmlOptimizer {
 
         foreach (var element in document.Images) {
             string? src = element.GetAttribute("src");
-            if (string.IsNullOrEmpty(src) || src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
+            if (src == null || src.Length == 0 || src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 

--- a/Sources/HtmlTinkerX/HtmlParserExtensions.cs
+++ b/Sources/HtmlTinkerX/HtmlParserExtensions.cs
@@ -24,25 +24,29 @@ public static class HtmlParserExtensions {
     /// var divs = HtmlParserExtensions.GetElements(html, tag: "div");
     /// </code>
     /// </example>
-    public static IEnumerable<IElement> GetElements(string html, string? tag = null, string? className = null, string? id = null, string? name = null) {
+    public static IEnumerable<IElement> GetElements(string? html, string? tag = null, string? className = null, string? id = null, string? name = null) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
 
         var document = HtmlParser.ParseWithAngleSharp(html);
 
-        if (!string.IsNullOrEmpty(tag)) {
-            return document.GetElementsByTagName(tag!);
+        if (!(tag == null || tag.Length == 0)) {
+            string tagValue = tag;
+            return document.GetElementsByTagName(tagValue);
         }
-        if (!string.IsNullOrEmpty(className)) {
-            return document.GetElementsByClassName(className!);
+        if (!(className == null || className.Length == 0)) {
+            string classValue = className;
+            return document.GetElementsByClassName(classValue);
         }
-        if (!string.IsNullOrEmpty(id)) {
-            var element = document.GetElementById(id!);
+        if (!(id == null || id.Length == 0)) {
+            string idValue = id;
+            var element = document.GetElementById(idValue);
             return element != null ? new[] { element } : Array.Empty<IElement>();
         }
-        if (!string.IsNullOrEmpty(name)) {
-            return document.GetElementsByName(name!);
+        if (!(name == null || name.Length == 0)) {
+            string nameValue = name;
+            return document.GetElementsByName(nameValue);
         }
 
         return Array.Empty<IElement>();

--- a/Sources/HtmlTinkerX/HtmlParserFromForm.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromForm.cs
@@ -23,7 +23,7 @@ public static class HtmlParserFromForm {
     /// var forms = HtmlParserFromForm.ParseFormsWithAngleSharp(html);
     /// </code>
     /// </example>
-    public static List<HtmlFormResult> ParseFormsWithAngleSharp(string html) {
+    public static List<HtmlFormResult> ParseFormsWithAngleSharp(string? html) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -44,12 +44,13 @@ public static class HtmlParserFromForm {
 
             foreach (var field in form.QuerySelectorAll("input,select,textarea,button")) {
                 string? name = field.GetAttribute("name");
-                if (string.IsNullOrEmpty(name)) {
+                if (name == null || name.Length == 0) {
                     continue;
                 }
+                string nameValue = name;
                 string type = field.GetAttribute("type") ?? field.NodeName.ToLowerInvariant();
                 result.Fields.Add(new HtmlFormField {
-                    Name = name!,
+                    Name = nameValue,
                     Type = MapType(type)
                 });
             }
@@ -69,7 +70,7 @@ public static class HtmlParserFromForm {
     /// var forms = await HtmlParserFromForm.ParseUrlFormsWithAngleSharpAsync(url);
     /// </code>
     /// </example>
-    public static async Task<List<HtmlFormResult>> ParseUrlFormsWithAngleSharpAsync(string url, HttpClient? client = null) {
+    public static async Task<List<HtmlFormResult>> ParseUrlFormsWithAngleSharpAsync(string? url, HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }

--- a/Sources/HtmlTinkerX/HtmlParserFromList.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromList.cs
@@ -18,7 +18,7 @@ public static class HtmlParserFromList {
     /// <param name="html">HTML content containing lists.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
-    public static List<HtmlListResult> ParseListsWithAngleSharpDetailed(string html, string tagPlaceholder = " ") {
+    public static List<HtmlListResult> ParseListsWithAngleSharpDetailed(string? html, string tagPlaceholder = " ") {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -86,7 +86,7 @@ public static class HtmlParserFromList {
     /// <param name="html">HTML content containing lists.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with joined item texts.</returns>
-    public static List<List<string>> ParseListsWithAngleSharp(string html, string tagPlaceholder = " ") {
+    public static List<List<string>> ParseListsWithAngleSharp(string? html, string tagPlaceholder = " ") {
         var detailed = ParseListsWithAngleSharpDetailed(html, tagPlaceholder);
         List<List<string>> result = new();
         foreach (var list in detailed) {
@@ -102,7 +102,7 @@ public static class HtmlParserFromList {
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
     /// <param name="client">Optional HTTP client.</param>
-    public static async Task<List<HtmlListResult>> ParseUrlListsWithAngleSharpDetailedAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
+    public static async Task<List<HtmlListResult>> ParseUrlListsWithAngleSharpDetailedAsync(string? url, string tagPlaceholder = " ", HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
@@ -118,7 +118,7 @@ public static class HtmlParserFromList {
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with joined item texts.</returns>
     /// <param name="client">Optional HTTP client.</param>
-    public static async Task<List<List<string>>> ParseUrlListsWithAngleSharpAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
+    public static async Task<List<List<string>>> ParseUrlListsWithAngleSharpAsync(string? url, string tagPlaceholder = " ", HttpClient? client = null) {
         var detailed = await ParseUrlListsWithAngleSharpDetailedAsync(url, tagPlaceholder, client).ConfigureAwait(false);
         List<List<string>> result = new();
         foreach (var list in detailed) {
@@ -133,7 +133,7 @@ public static class HtmlParserFromList {
     /// <param name="html">HTML content containing lists.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
-    public static List<HtmlListResult> ParseListsWithHtmlAgilityPackDetailed(string html, string tagPlaceholder = " ") {
+    public static List<HtmlListResult> ParseListsWithHtmlAgilityPackDetailed(string? html, string tagPlaceholder = " ") {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -187,7 +187,7 @@ public static class HtmlParserFromList {
                 return;
             }
             if (node.NodeType == HtmlNodeType.Text) {
-                string text = HtmlEntity.DeEntitize(node.InnerText ?? string.Empty)!.Trim();
+                string text = (HtmlEntity.DeEntitize(node.InnerText ?? string.Empty) ?? string.Empty).Trim();
                 if (!string.IsNullOrWhiteSpace(text)) {
                     list.Add(text);
                 }
@@ -208,7 +208,7 @@ public static class HtmlParserFromList {
     /// <param name="html">HTML content containing lists.</param>
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with joined item texts.</returns>
-    public static List<List<string>> ParseListsWithHtmlAgilityPack(string html, string tagPlaceholder = " ") {
+    public static List<List<string>> ParseListsWithHtmlAgilityPack(string? html, string tagPlaceholder = " ") {
         var detailed = ParseListsWithHtmlAgilityPackDetailed(html, tagPlaceholder);
         List<List<string>> result = new();
         foreach (var list in detailed) {
@@ -224,7 +224,7 @@ public static class HtmlParserFromList {
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List parse results with metadata.</returns>
     /// <param name="client">Optional HTTP client.</param>
-    public static async Task<List<HtmlListResult>> ParseUrlListsWithHtmlAgilityPackDetailedAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
+    public static async Task<List<HtmlListResult>> ParseUrlListsWithHtmlAgilityPackDetailedAsync(string? url, string tagPlaceholder = " ", HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }
@@ -240,7 +240,7 @@ public static class HtmlParserFromList {
     /// <param name="tagPlaceholder">Placeholder inserted between text segments.</param>
     /// <returns>List of lists with joined item texts.</returns>
     /// <param name="client">Optional HTTP client.</param>
-    public static async Task<List<List<string>>> ParseUrlListsWithHtmlAgilityPackAsync(string url, string tagPlaceholder = " ", HttpClient? client = null) {
+    public static async Task<List<List<string>>> ParseUrlListsWithHtmlAgilityPackAsync(string? url, string tagPlaceholder = " ", HttpClient? client = null) {
         var detailed = await ParseUrlListsWithHtmlAgilityPackDetailedAsync(url, tagPlaceholder, client).ConfigureAwait(false);
         List<List<string>> result = new();
         foreach (var list in detailed) {

--- a/Sources/HtmlTinkerX/HtmlParserFromOpenGraph.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromOpenGraph.cs
@@ -21,7 +21,7 @@ public static class HtmlParserFromOpenGraph {
     /// string title = og.Properties["title"].First();
     /// </code>
     /// </example>
-    public static HtmlOpenGraph ParseOpenGraph(string html) {
+    public static HtmlOpenGraph ParseOpenGraph(string? html) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -31,10 +31,11 @@ public static class HtmlParserFromOpenGraph {
         HtmlOpenGraph result = new();
         foreach (var node in nodes) {
             string? property = node.GetAttribute("property");
-            if (string.IsNullOrEmpty(property)) {
+            if (property == null || property.Length == 0) {
                 continue;
             }
-            string key = property!.Substring(3); // remove "og:" prefix
+            string propValue = property;
+            string key = propValue.Substring(3); // remove "og:" prefix
             string content = node.GetAttribute("content") ?? string.Empty;
 
             OpenGraphProperty? existing = result.Properties.Find(p => p.Name == key);
@@ -56,7 +57,7 @@ public static class HtmlParserFromOpenGraph {
     /// <param name="url">URL of the page to download.</param>
     /// <param name="client">Optional HTTP client.</param>
     /// <returns>The parsed Open Graph metadata.</returns>
-    public static async Task<HtmlOpenGraph> ParseUrlOpenGraphAsync(string url, HttpClient? client = null) {
+    public static async Task<HtmlOpenGraph> ParseUrlOpenGraphAsync(string? url, HttpClient? client = null) {
         if (url == null) {
             throw new ArgumentNullException(nameof(url));
         }


### PR DESCRIPTION
## Summary
- allow parser helpers to accept nullable input and throw `ArgumentNullException`
- replace null-forgiving operators with explicit checks
- add unit tests for null argument handling

## Testing
- `dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlParserExtensionsTests`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlParserFormTests`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlFormFieldExtractorTests`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlOpenGraphTests`
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter HtmlParserListTests`


------
https://chatgpt.com/codex/tasks/task_e_68a390967ba4832e851e9a83dc5ad220