### PR TITLE
Default to fragment mode and expose NUglify options

### DIFF
--- a/Examples/OptimizeImagesExample.cs
+++ b/Examples/OptimizeImagesExample.cs
@@ -2,6 +2,6 @@ using HtmlTinkerX;
 
 const string html = "<html><body><img src=\"https://via.placeholder.com/1x1.png\" /></body></html>";
 
-string optimized = await HtmlOptimizer.OptimizeHtmlAsync(html, cssDecodeEscapes: false, embedImages: true);
+string optimized = await HtmlOptimizer.OptimizeHtmlAsync(html, cssDecodeEscapes: false, treatAsDocument: true, embedImages: true);
 
 Console.WriteLine(optimized);

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerAsyncTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerAsyncTests.cs
@@ -9,9 +9,15 @@ namespace HtmlTinkerX.Tests;
 /// </summary>
 public class HtmlOptimizerAsyncTests {
     [Fact]
-    public async Task OptimizeHtmlAsync_MinifiesContent() {
+    public async Task OptimizeHtmlAsync_TreatAsDocumentMinifiesContent() {
         const string input = "<html><!--c--><body> <p>Hi</p></body></html>";
-        string result = await HtmlOptimizer.OptimizeHtmlAsync(input, false);
+        string result = await HtmlOptimizer.OptimizeHtmlAsync(input, false, treatAsDocument: true, removeComments: true);
         Assert.Equal("<html><body><p>Hi</p></body></html>", result);
+    }
+
+    [Fact]
+    public async Task OptimizeHtmlAsync_DoesNotWrapFragmentsByDefault() {
+        string result = await HtmlOptimizer.OptimizeHtmlAsync("<tr></tr>", false);
+        Assert.Equal("<tr></tr>", result);
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerFileAsyncTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerFileAsyncTests.cs
@@ -37,7 +37,7 @@ public class HtmlOptimizerFileAsyncTests {
         await File.WriteAllTextAsync(path, "<html><!--c--><body> <p>Hi</p></body></html>");
 #endif
         try {
-            string result = await HtmlOptimizer.OptimizeHtmlFileAsync(path, false);
+            string result = await HtmlOptimizer.OptimizeHtmlFileAsync(path, false, treatAsDocument: true, removeComments: true);
             Assert.Equal("<html><body><p>Hi</p></body></html>", result);
         } finally {
             File.Delete(path);

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerFileTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerFileTests.cs
@@ -32,7 +32,7 @@ public class HtmlOptimizerFileTests {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".html");
         File.WriteAllText(path, "<html><!--c--><body> <p>Hi</p></body></html>");
         try {
-            string result = HtmlOptimizer.OptimizeHtmlFile(path, false);
+            string result = HtmlOptimizer.OptimizeHtmlFile(path, false, treatAsDocument: true, removeComments: true);
             Assert.Equal("<html><body><p>Hi</p></body></html>", result);
         } finally {
             File.Delete(path);

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
@@ -17,17 +17,45 @@ public class HtmlOptimizerTests {
     }
 
     [Fact]
-    public void OptimizeHtml_MinifiesContent() {
+    public void OptimizeHtml_TreatAsDocumentMinifiesContent() {
         const string input = "<html><!--c--><body> <p>Hi</p></body></html>";
-        string result = HtmlOptimizer.OptimizeHtml(input, false);
+        string result = HtmlOptimizer.OptimizeHtml(input, false, treatAsDocument: true, removeComments: true);
         Assert.Equal("<html><body><p>Hi</p></body></html>", result);
     }
 
     [Fact]
     public void OptimizeHtml_PreservesMotw() {
         const string input = "<!-- saved from url=(0014)about:internet --><html><body>test</body></html>";
-        string result = HtmlOptimizer.OptimizeHtml(input, false);
+        string result = HtmlOptimizer.OptimizeHtml(input, false, treatAsDocument: true);
         Assert.StartsWith("<!-- saved from url=(0014)about:internet -->", result);
+    }
+
+    [Fact]
+    public void OptimizeHtml_DoesNotWrapFragmentsByDefault() {
+        const string input = "<tr></tr>";
+        string result = HtmlOptimizer.OptimizeHtml(input, false);
+        Assert.Equal("<tr></tr>", result);
+    }
+
+    [Fact]
+    public void OptimizeHtml_PreservesCommentsByDefault() {
+        const string input = "<html><!--c--><body>Hi</body></html>";
+        string result = HtmlOptimizer.OptimizeHtml(input, false, treatAsDocument: true);
+        Assert.Contains("<!--c-->", result);
+    }
+
+    [Fact]
+    public void OptimizeHtml_RemoveCommentsWhenRequested() {
+        const string input = "<html><!--c--><body>Hi</body></html>";
+        string result = HtmlOptimizer.OptimizeHtml(input, false, treatAsDocument: true, removeComments: true);
+        Assert.DoesNotContain("<!--c-->", result);
+    }
+
+    [Fact]
+    public void OptimizeHtml_RemoveOptionalTagsWhenRequested() {
+        const string input = "<html><body><p>Hi</p></body></html>";
+        string result = HtmlOptimizer.OptimizeHtml(input, false, treatAsDocument: true, removeOptionalTags: true);
+        Assert.DoesNotContain("</p>", result);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/HtmlOptimizer.cs
+++ b/Sources/HtmlTinkerX/HtmlOptimizer.cs
@@ -69,13 +69,20 @@ public static class HtmlOptimizer {
     /// </summary>
     /// <param name="html">HTML string to optimize.</param>
     /// <param name="cssDecodeEscapes">Whether to decode CSS escape sequences.</param>
+    /// <param name="treatAsDocument">When set, NUglify treats the input as a full HTML document.</param>
+    /// <param name="removeComments">Remove HTML comments while minifying.</param>
+    /// <param name="removeOptionalTags">Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</param>
     /// <returns>Optimized HTML output.</returns>
-    public static string OptimizeHtml(string html, bool cssDecodeEscapes) {
+    public static string OptimizeHtml(string html, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
 
-        HtmlSettings settings = new() { RemoveOptionalTags = false, RemoveComments = true };
+        HtmlSettings settings = new() {
+            RemoveOptionalTags = removeOptionalTags,
+            RemoveComments = removeComments,
+            IsFragmentOnly = !treatAsDocument
+        };
         settings.CssSettings.DecodeEscapes = cssDecodeEscapes;
 
         bool hasMotw =
@@ -96,13 +103,16 @@ public static class HtmlOptimizer {
     /// </summary>
     /// <param name="html">HTML string to optimize.</param>
     /// <param name="cssDecodeEscapes">Whether to decode CSS escape sequences.</param>
+    /// <param name="treatAsDocument">When set, NUglify treats the input as a full HTML document.</param>
+    /// <param name="removeComments">Remove HTML comments while minifying.</param>
+    /// <param name="removeOptionalTags">Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</param>
     /// <param name="embedImages">When set, downloads external images and embeds them using data URIs.</param>
     /// <param name="baseUrl">Optional base URL used to resolve relative image paths.</param>
     /// <param name="client">Optional <see cref="HttpClient"/> used for downloads.</param>
     /// <param name="cancellationToken">Token used to cancel download operations.</param>
     /// <returns>Optimized HTML output.</returns>
-    public static async Task<string> OptimizeHtmlAsync(string html, bool cssDecodeEscapes, bool embedImages = false, string? baseUrl = null, HttpClient? client = null, CancellationToken cancellationToken = default) {
-        string optimized = await Task.Run(() => OptimizeHtml(html, cssDecodeEscapes), cancellationToken).ConfigureAwait(false);
+    public static async Task<string> OptimizeHtmlAsync(string html, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false, bool embedImages = false, string? baseUrl = null, HttpClient? client = null, CancellationToken cancellationToken = default) {
+        string optimized = await Task.Run(() => OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags), cancellationToken).ConfigureAwait(false);
         if (!embedImages) {
             return optimized;
         }
@@ -115,25 +125,28 @@ public static class HtmlOptimizer {
     /// </summary>
     /// <param name="filePath">Path to the HTML file.</param>
     /// <param name="cssDecodeEscapes">Whether to decode CSS escape sequences.</param>
+    /// <param name="treatAsDocument">When set, NUglify treats the input as a full HTML document.</param>
+    /// <param name="removeComments">Remove HTML comments while minifying.</param>
+    /// <param name="removeOptionalTags">Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</param>
     /// <returns>Optimized HTML output.</returns>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
-    public static string OptimizeHtmlFile(string filePath, bool cssDecodeEscapes) {
+    public static string OptimizeHtmlFile(string filePath, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false) {
         string html = HtmlUtilities.ReadFileChecked(filePath);
-        return OptimizeHtml(html, cssDecodeEscapes);
+        return OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags);
     }
 
     /// <summary>
     /// Asynchronously minifies HTML content from a file.
     /// </summary>
-    /// <inheritdoc cref="OptimizeHtmlFile(string,bool)"/>
-    public static async Task<string> OptimizeHtmlFileAsync(string filePath, bool cssDecodeEscapes, bool embedImages = false, HttpClient? client = null, CancellationToken cancellationToken = default) {
+    /// <inheritdoc cref="OptimizeHtmlFile(string,bool,bool,bool,bool)"/>
+    public static async Task<string> OptimizeHtmlFileAsync(string filePath, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false, bool embedImages = false, HttpClient? client = null, CancellationToken cancellationToken = default) {
         string html = await HtmlUtilities.ReadFileCheckedAsync(filePath, cancellationToken).ConfigureAwait(false);
         string? baseUrl = null;
         try {
             baseUrl = new Uri(Path.GetFullPath(filePath)).AbsoluteUri;
         } catch {
         }
-        return await OptimizeHtmlAsync(html, cssDecodeEscapes, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
+        return await OptimizeHtmlAsync(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -34,11 +34,23 @@ public sealed class CmdletOptimizeHtml : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter CSSDecodeEscapes { get; set; }
 
+    /// <summary>Treat the input as a full HTML document.</summary>
+    [Parameter]
+    public SwitchParameter TreatAsDocument { get; set; }
+
+    /// <summary>Remove HTML comments during optimization.</summary>
+    [Parameter]
+    public SwitchParameter RemoveComments { get; set; }
+
+    /// <summary>Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</summary>
+    [Parameter]
+    public SwitchParameter RemoveOptionalTags { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string result = ParameterSetName == ParameterSetFile
-            ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), CSSDecodeEscapes.IsPresent).ConfigureAwait(false)
-            : await HtmlOptimizer.OptimizeHtmlAsync(Content, CSSDecodeEscapes.IsPresent).ConfigureAwait(false);
+            ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent).ConfigureAwait(false)
+            : await HtmlOptimizer.OptimizeHtmlAsync(Content, CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(OutputFile)) {
             string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK

--- a/Tests/Optimize-HTML.Tests.ps1
+++ b/Tests/Optimize-HTML.Tests.ps1
@@ -55,12 +55,42 @@
 <html><head><meta charset=utf-8 /><meta content="width=device-width, initial-scale=1" name=viewport /><meta name=author /><meta content="2019-08-09 11:26:37" name=revised /><title>My title</title><link href="https://fonts.googleapis.com/css?family=Roboto|Hammersmith+One|Questrial|Oswald" type=text/css rel=stylesheet /><link href=https://use.fontawesome.com/releases/v5.7.2/css/all.css type=text/css rel=stylesheet /></head><body><div class="flexElement overflowHidden"><table id=DT-hZRTQIVT class="display compact"><thead><tr><th>Name</th><th class=none>Id</th><th class=none>HandleCount</th><th>WorkingSet</th></tr></thead><tbody><tr><td>1Password</td><td>22268</td><td>1007</td><td>87146496</td></tr><tr><td>aesm_service</td><td>25340</td><td>189</td><td>3948544</td></tr></tbody></table></div><footer></footer></body></html>
 "@
 
-        $Minimized = Optimize-HTML -Content $HTMLContentFormatted -CSSDecodeEscapes:$false
+        $Minimized = Optimize-HTML -Content $HTMLContentFormatted -CSSDecodeEscapes:$false -TreatAsDocument -RemoveComments
         $Minimized | Should -Be $ExpectedOutput
 
         $file = Join-Path $TestDrive 'test.html'
         $HTMLContentFormatted | Set-Content -Path $file
-        $fromFile = Optimize-HTML -File $file
+        $fromFile = Optimize-HTML -File $file -TreatAsDocument -RemoveComments
         $fromFile | Should -Be $ExpectedOutput
+    }
+
+    It 'Defaults to fragment mode' {
+        $fragment = '<tr></tr>'
+        $result = Optimize-HTML -Content $fragment -CSSDecodeEscapes:$false
+        $result | Should -Be $fragment
+    }
+
+    It 'Can treat input as document' {
+        $content = '<html><!--c--><body> <p>Hi</p></body></html>'
+        $result = Optimize-HTML -Content $content -TreatAsDocument -RemoveComments
+        $result | Should -Be '<html><body><p>Hi</p></body></html>'
+    }
+
+    It 'Keeps comments by default' {
+        $content = '<html><!--c--><body>Hi</body></html>'
+        $result = Optimize-HTML -Content $content -TreatAsDocument
+        $result | Should -Match '<!--c-->'
+    }
+
+    It 'Removes comments when requested' {
+        $content = '<html><!--c--><body>Hi</body></html>'
+        $result = Optimize-HTML -Content $content -TreatAsDocument -RemoveComments
+        $result | Should -Not -Match '<!--c-->'
+    }
+
+    It 'Removes optional tags when requested' {
+        $content = '<html><body><p>Hi</p></body></html>'
+        $result = Optimize-HTML -Content $content -TreatAsDocument -RemoveOptionalTags
+        $result | Should -Not -Match '</p>'
     }
 }


### PR DESCRIPTION
## Summary
- default HTML optimizer to fragment mode with optional document processing
- expose NUglify HTML options to callers and Optimize-HTML cmdlet
- make RemoveComments switch opt-in and update tests

## Testing
- `dotnet test Sources/HtmlTinkerX.sln --filter HtmlOptimizer`
- `pwsh -NoLogo -Command "Import-Module ./PSParseHTML.psd1; Invoke-Pester -Path Tests/Optimize-HTML.Tests.ps1 -PassThru"`
- `dotnet test Sources/HtmlTinkerX.sln` *(fails: PreMailerClientPathTests & HtmlHttpClientFactoryTests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a1a0d1d0832e966880d718a100f9