### PR TITLE
Support numeric cookie expiry parsing

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCookieParserTests.cs
@@ -114,6 +114,27 @@ public class HtmlCookieParserTests {
     }
 
     [Fact]
+    public void ParseSetCookieHeader_ParsesIso8601Expiration() {
+        string header = "sessionId=abc; Expires=2024-03-05T15:00:00Z";
+        HtmlCookie cookie = HtmlCookieParser.ParseSetCookieHeader(header);
+        Assert.Equal(1709650800L, cookie.Expires);
+    }
+
+    [Fact]
+    public void ParseSetCookieHeader_ParsesUnixSecondsExpiration() {
+        string header = "sessionId=abc; Expires=1709650800";
+        HtmlCookie cookie = HtmlCookieParser.ParseSetCookieHeader(header);
+        Assert.Equal(1709650800L, cookie.Expires);
+    }
+
+    [Fact]
+    public void ParseSetCookieHeader_ParsesUnixMillisecondsExpiration() {
+        string header = "sessionId=abc; Expires=1709650800000";
+        HtmlCookie cookie = HtmlCookieParser.ParseSetCookieHeader(header);
+        Assert.Equal(1709650800L, cookie.Expires);
+    }
+
+    [Fact]
     public void ParseOrgJsonCookie_ParsesJson() {
         string json = "{\"Path\":\"/\",\"Secure\":\"false\",\"name\":\"sessionId\",\"Expires\":\"Sun, 31 Dec 2023 23:59:59 GMT\",\"Domain\":\"example.com\",\"value\":\"abc123xyz\"}";
         HtmlCookie c = HtmlCookieParser.ParseOrgJsonCookie(json);

--- a/Sources/HtmlTinkerX/HtmlCookieParser.cs
+++ b/Sources/HtmlTinkerX/HtmlCookieParser.cs
@@ -31,6 +31,57 @@ public static class HtmlCookieParser {
             value = default;
             return false;
         }
+
+        public static bool TryParseUnixTimestamp(string? value, out long seconds) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                seconds = default;
+                return false;
+            }
+
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue)) {
+                seconds = NormalizeUnixTimestamp(longValue);
+                return true;
+            }
+
+            if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue)) {
+                seconds = NormalizeUnixTimestamp(doubleValue);
+                return true;
+            }
+
+            seconds = default;
+            return false;
+        }
+
+        public static bool TryParseUnixTimestamp(JsonElement element, out long seconds) {
+            switch (element.ValueKind) {
+                case JsonValueKind.Number:
+                    if (element.TryGetInt64(out long longValue)) {
+                        seconds = NormalizeUnixTimestamp(longValue);
+                        return true;
+                    }
+
+                    if (element.TryGetDouble(out double doubleValue)) {
+                        seconds = NormalizeUnixTimestamp(doubleValue);
+                        return true;
+                    }
+
+                    break;
+                case JsonValueKind.String:
+                    return TryParseUnixTimestamp(element.GetString(), out seconds);
+            }
+
+            seconds = default;
+            return false;
+        }
+
+        private static long NormalizeUnixTimestamp(long value) {
+            return value >= 1_000_000_000_000 ? value / 1000L : value;
+        }
+
+        private static long NormalizeUnixTimestamp(double value) {
+            double normalized = value >= 1_000_000_000_000d ? value / 1000d : value;
+            return (long)Math.Round(normalized, MidpointRounding.AwayFromZero);
+        }
     }
 
     /// <summary>
@@ -103,8 +154,13 @@ public static class HtmlCookieParser {
                     cookie.Domain = val;
                     break;
                 case "expires":
-                    if (DateTime.TryParse(val, out DateTime dt)) {
-                        cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
+                    if (val is not null) {
+                        if (CookieHelpers.TryParseUnixTimestamp(val, out long unixTimestamp)) {
+                            cookie.Expires = unixTimestamp;
+                        } else if (DateTime.TryParse(val, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime dt) ||
+                            DateTime.TryParse(val, out dt)) {
+                            cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
+                        }
                     }
                     break;
                 case "secure":
@@ -140,8 +196,16 @@ public static class HtmlCookieParser {
                 Secure = CookieHelpers.TryGetPropertyIgnoreCase(root, "Secure", out var s) ? s.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null,
                 HttpOnly = CookieHelpers.TryGetPropertyIgnoreCase(root, "HttpOnly", out var h) ? h.GetString()?.Equals("true", StringComparison.OrdinalIgnoreCase) : null
             };
-            if (root.TryGetProperty("Expires", out var e) && DateTime.TryParse(e.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime dt)) {
-                cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
+            if (root.TryGetProperty("Expires", out var e)) {
+                if (CookieHelpers.TryParseUnixTimestamp(e, out long unixTimestamp)) {
+                    cookie.Expires = unixTimestamp;
+                } else if (e.ValueKind == JsonValueKind.String) {
+                    string? expiresText = e.GetString();
+                    if (!string.IsNullOrEmpty(expiresText) && (DateTime.TryParse(expiresText, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime dt) ||
+                        DateTime.TryParse(expiresText, out dt))) {
+                        cookie.Expires = new DateTimeOffset(dt).ToUnixTimeSeconds();
+                    }
+                }
             }
             return cookie;
         }
@@ -166,10 +230,8 @@ public static class HtmlCookieParser {
             HttpOnly = root.TryGetProperty("httpOnly", out var h) ? h.GetBoolean() : (bool?)null,
             SameSite = root.TryGetProperty("sameSite", out var ss) ? CookieHelpers.ParseSameSite(ss.GetString()) : null
         };
-        if (root.TryGetProperty("expires", out var e)) {
-            double exp = e.GetDouble();
-            long seconds = (long)(exp >= 1e12 ? exp / 1000.0 : exp);
-            cookie.Expires = seconds;
+        if (root.TryGetProperty("expires", out var e) && CookieHelpers.TryParseUnixTimestamp(e, out long expires)) {
+            cookie.Expires = expires;
         }
         return cookie;
     }
@@ -194,8 +256,8 @@ public static class HtmlCookieParser {
                     Secure = el.TryGetProperty("secure", out var s) ? s.GetBoolean() : (bool?)null,
                     HttpOnly = el.TryGetProperty("httpOnly", out var h) ? h.GetBoolean() : (bool?)null
                 };
-                if (el.TryGetProperty("expires", out var e)) {
-                    c.Expires = (long)e.GetDouble();
+                if (el.TryGetProperty("expires", out var e) && CookieHelpers.TryParseUnixTimestamp(e, out long expires)) {
+                    c.Expires = expires;
                 }
                 list.Add(c);
             }


### PR DESCRIPTION
## Summary
- add shared helpers to parse unix timestamps (seconds and milliseconds) when reading cookie expiry values
- use the new helpers for Set-Cookie, org.json, cookie store, and Puppeteer parsing paths
- add unit tests covering ISO-8601, seconds, and milliseconds expiry formats

## Testing
- dotnet test Sources/HtmlTinkerX.sln *(fails for net472 because mono host is unavailable in the environment; net8.0 tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2492ac2c832e84fca858276e5d7e