### PR TITLE
Ensure video temp files are cleaned after failures

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserVideoRecordingTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserVideoRecordingTests.cs
@@ -75,4 +75,55 @@ public class HtmlBrowserVideoRecordingTests {
 
         HtmlBrowser.PlaywrightFactory = null;
     }
+
+    [Fact]
+    public async Task StartVideoRecordingAsync_RemovesTempStorageFileOnFailure() {
+        string? statePath = null;
+
+        var page = new Mock<IPage>();
+        page.SetupGet(p => p.Url).Returns("https://example.com");
+
+        var context = new Mock<IBrowserContext>();
+        context.Setup(c => c.StorageStateAsync(It.IsAny<BrowserContextStorageStateOptions>()))
+            .Callback<BrowserContextStorageStateOptions>(o => {
+                statePath = o.Path;
+                if (statePath != null) {
+                    File.WriteAllText(statePath, "{}");
+                }
+            })
+            .ReturnsAsync("{}");
+        context.Setup(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions>())).Returns(Task.CompletedTask);
+
+        var browserType = new Mock<IBrowserType>();
+        browserType.SetupGet(bt => bt.Name).Returns("chromium");
+
+        var browser = new Mock<IBrowser>();
+        browser.SetupGet(b => b.BrowserType).Returns(browserType.Object);
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions>())).Returns(Task.CompletedTask);
+
+        var existingPlaywright = new Mock<IPlaywright>();
+
+        HtmlBrowserSession session = new(existingPlaywright.Object, browser.Object, context.Object, page.Object);
+
+        var failingBrowserType = new Mock<IBrowserType>();
+        failingBrowserType.Setup(bt => bt.LaunchAsync(It.IsAny<BrowserTypeLaunchOptions>()))
+            .ThrowsAsync(new SerializationException("Launch failed"));
+
+        var playwright = new Mock<IPlaywright>();
+        playwright.SetupGet(p => p.Chromium).Returns(failingBrowserType.Object);
+
+        HtmlBrowser.PlaywrightFactory = () => Task.FromResult(playwright.Object);
+
+        try {
+            await Assert.ThrowsAsync<SerializationException>(() => HtmlBrowser.StartVideoRecordingAsync(session, "video.webm"));
+            Assert.NotNull(statePath);
+            Assert.False(File.Exists(statePath!));
+        } finally {
+            HtmlBrowser.PlaywrightFactory = null;
+            await session.DisposeAsync();
+            if (statePath != null && File.Exists(statePath)) {
+                File.Delete(statePath);
+            }
+        }
+    }
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Video.cs
@@ -86,41 +86,50 @@ public static partial class HtmlBrowser {
         string? timezone = null,
         CancellationToken cancellationToken = default) {
         string temp = Path.GetTempFileName();
-        await session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = temp }).ConfigureAwait(false);
-        string url = session.Page.Url;
-        HtmlBrowserEngine engine = session.Browser.BrowserType.Name switch {
-            "firefox" => HtmlBrowserEngine.Firefox,
-            "webkit" => HtmlBrowserEngine.WebKit,
-            _ => HtmlBrowserEngine.Chromium
-        };
+        try {
+            await session.Context.StorageStateAsync(new BrowserContextStorageStateOptions { Path = temp }).ConfigureAwait(false);
+            string url = session.Page.Url;
+            HtmlBrowserEngine engine = session.Browser.BrowserType.Name switch {
+                "firefox" => HtmlBrowserEngine.Firefox,
+                "webkit" => HtmlBrowserEngine.WebKit,
+                _ => HtmlBrowserEngine.Chromium
+            };
 
-        HtmlBrowserSession newSession = await OpenSessionAsync(
-            url,
-            engine,
-            clean: false,
-            username: null,
-            password: null,
-            formLogin: null,
-            headless: headless,
-            slowMo: slowMo,
-            videoPath: videoPath,
-            videoWidth: width,
-            videoHeight: height,
-            storageStatePath: temp,
-            userAgent: userAgent,
-            viewportWidth: viewportWidth,
-            viewportHeight: viewportHeight,
-            deviceScaleFactor: deviceScaleFactor,
-            proxy: null,
-            proxyUsername: null,
-            proxyPassword: null,
-            geoLatitude: geoLatitude,
-            geoLongitude: geoLongitude,
-            timezone: timezone,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            HtmlBrowserSession newSession = await OpenSessionAsync(
+                url,
+                engine,
+                clean: false,
+                username: null,
+                password: null,
+                formLogin: null,
+                headless: headless,
+                slowMo: slowMo,
+                videoPath: videoPath,
+                videoWidth: width,
+                videoHeight: height,
+                storageStatePath: temp,
+                userAgent: userAgent,
+                viewportWidth: viewportWidth,
+                viewportHeight: viewportHeight,
+                deviceScaleFactor: deviceScaleFactor,
+                proxy: null,
+                proxyUsername: null,
+                proxyPassword: null,
+                geoLatitude: geoLatitude,
+                geoLongitude: geoLongitude,
+                timezone: timezone,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        File.Delete(temp);
-        return newSession;
+            return newSession;
+        } finally {
+            try {
+                if (!string.IsNullOrEmpty(temp) && File.Exists(temp)) {
+                    File.Delete(temp);
+                }
+            } catch (IOException) {
+            } catch (System.UnauthorizedAccessException) {
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- wrap the StartVideoRecordingAsync temp storage file handling in a try/finally so cleanup happens even when session creation fails
- add a regression test that simulates OpenSessionAsync throwing and verifies the temp storage file is removed

## Testing
- dotnet test Sources/HtmlTinkerX.sln *(net472 target aborts because the test host requires mono; net8.0 tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ce93c543dc832eb57ec91dda70a328