### PR TITLE
Ensure Playwright sessions clean up asynchronously

### DIFF
--- a/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using System.Threading.Tasks;
 using System.Linq;
 using System;
+using System.Diagnostics;
 using Moq;
 using Microsoft.Playwright;
 
@@ -140,15 +141,75 @@ public class HtmlBrowserTesterTests {
     public async Task TestPerformanceAsync_ReturnsMetrics() {
         // Arrange
         var url = "data:text/html,<html><body>Test</body></html>";
-        
+
         // Act
         var metrics = await HtmlBrowserTester.TestPerformanceAsync(url);
-        
+
         // Assert
         Assert.NotNull(metrics);
         Assert.NotNull(metrics.TotalLoadTime);
         Assert.True(metrics.TotalRequests >= 0); // May be 0 for data URLs
         Assert.NotNull(metrics.ResourceBreakdown);
+    }
+
+    [Fact]
+    public async Task TestUrlAsync_DoesNotAccumulatePlaywrightProcesses() {
+        // Arrange
+        var url = "data:text/html,<html><body>Resource Cleanup</body></html>";
+        var initialProcessCount = CountPlaywrightProcesses();
+
+        // Act
+        for (var i = 0; i < 3; i++) {
+            var result = await HtmlBrowserTester.TestUrlAsync(url);
+            Assert.NotNull(result);
+            await Task.Delay(250);
+        }
+
+        await Task.Delay(1000);
+        var finalProcessCount = CountPlaywrightProcesses();
+
+        // Assert
+        Assert.True(finalProcessCount <= initialProcessCount, $"Expected Playwright processes to remain at or below the initial count. Initial: {initialProcessCount}, Final: {finalProcessCount}.");
+    }
+
+    private static int CountPlaywrightProcesses() {
+        var processes = Process.GetProcesses();
+        var count = 0;
+
+        foreach (var process in processes) {
+            try {
+                if (IsPlaywrightProcess(process)) {
+                    count++;
+                }
+            } catch (InvalidOperationException) {
+                // Process exited while enumerating; ignore.
+            } catch (System.ComponentModel.Win32Exception) {
+                // Access denied on process details; ignore this instance.
+            } finally {
+                process.Dispose();
+            }
+        }
+
+        return count;
+    }
+
+    private static bool IsPlaywrightProcess(Process process) {
+        var name = process.ProcessName;
+
+        if (name.IndexOf("playwright", StringComparison.OrdinalIgnoreCase) >= 0) {
+            return true;
+        }
+
+        try {
+            var mainModuleName = process.MainModule?.ModuleName;
+            if (mainModuleName is string moduleName && moduleName.IndexOf("playwright", StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        } catch (System.ComponentModel.Win32Exception) {
+            // Access denied retrieving module information; fall back to name checks.
+        }
+
+        return false;
     }
     
     [Fact]

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -34,67 +34,70 @@ public static class HtmlBrowserTester {
         var result = new HtmlBrowserTestResult { Url = url };
         var startTime = DateTimeOffset.UtcNow;
 
+        IPlaywright? playwright = null;
         try {
             // Ensure Playwright and browser are installed
             await HtmlBrowser.EnsureInstalledAsync(engine);
 
             // Create a browser session without navigating first
-            var playwright = await Playwright.CreateAsync();
+            playwright = await Playwright.CreateAsync();
             try {
                 var browserType = engine switch {
                     HtmlBrowserEngine.Firefox => playwright.Firefox,
                     HtmlBrowserEngine.WebKit => playwright.Webkit,
                     _ => playwright.Chromium
                 };
-            
-            var launchOptions = new BrowserTypeLaunchOptions { Headless = headless };
-            if (!string.IsNullOrEmpty(proxy)) {
-                launchOptions.Proxy = new Proxy {
-                    Server = proxy!,
-                    Username = proxyUsername,
-                    Password = proxyPassword
-                };
-            }
-            
-                var browser = await browserType.LaunchAsync(launchOptions);
-            try {
-                var contextOptions = new BrowserNewContextOptions { IgnoreHTTPSErrors = true };
-                var context = await browser.NewContextAsync(contextOptions);
-                try {
-                    var page = await context.NewPageAsync();
-                    
-                    // Set timeout
-                    page.SetDefaultTimeout(timeout);
-                    
-                    // Enhanced network and console monitoring - set up BEFORE navigation
-                    var networkEntries = InitNetworkListeners(page, result);
-                    
-                    // Navigate and measure
-                    try {
-                        await page.GotoAsync(url, new PageGotoOptions {
-                            WaitUntil = WaitUntilState.NetworkIdle,
-                            Timeout = timeout
-                        });
-                    } catch (Exception ex) {
-                        result.ConsoleEntries.Add(new HtmlConsoleEntryDetailed {
-                            Text = ex.Message,
-                            Type = HtmlConsoleMessageType.Error,
-                            Timestamp = DateTimeOffset.UtcNow
-                        });
-                    } finally {
-                        result.PageLoadTime = DateTimeOffset.UtcNow - startTime;
-                    }
 
-                    // Wait a bit for any delayed console messages or network requests
-                    await page.WaitForTimeoutAsync(1000);
-                } finally {
-                    await context.CloseAsync();
+                var launchOptions = new BrowserTypeLaunchOptions { Headless = headless };
+                if (!string.IsNullOrEmpty(proxy)) {
+                    launchOptions.Proxy = new Proxy {
+                        Server = proxy!,
+                        Username = proxyUsername,
+                        Password = proxyPassword
+                    };
                 }
-            } finally {
-                await browser.CloseAsync();
-            }
+
+                var browser = await browserType.LaunchAsync(launchOptions);
+                try {
+                    var contextOptions = new BrowserNewContextOptions { IgnoreHTTPSErrors = true };
+                    var context = await browser.NewContextAsync(contextOptions);
+                    try {
+                        var page = await context.NewPageAsync();
+
+                        // Set timeout
+                        page.SetDefaultTimeout(timeout);
+
+                        // Enhanced network and console monitoring - set up BEFORE navigation
+                        var networkEntries = InitNetworkListeners(page, result);
+
+                        // Navigate and measure
+                        try {
+                            await page.GotoAsync(url, new PageGotoOptions {
+                                WaitUntil = WaitUntilState.NetworkIdle,
+                                Timeout = timeout
+                            });
+                        } catch (Exception ex) {
+                            result.ConsoleEntries.Add(new HtmlConsoleEntryDetailed {
+                                Text = ex.Message,
+                                Type = HtmlConsoleMessageType.Error,
+                                Timestamp = DateTimeOffset.UtcNow
+                            });
+                        } finally {
+                            result.PageLoadTime = DateTimeOffset.UtcNow - startTime;
+                        }
+
+                        // Wait a bit for any delayed console messages or network requests
+                        await page.WaitForTimeoutAsync(1000);
+                    } finally {
+                        await context.CloseAsync();
+                    }
+                } finally {
+                    await browser.CloseAsync();
+                }
         } finally {
-            playwright.Dispose();
+            if (playwright is not null) {
+                await playwright.DisposeAsync();
+            }
         }
     } catch (Exception ex) {
         result.ConsoleEntries.Add(new HtmlConsoleEntryDetailed {

--- a/Sources/HtmlTinkerX/Playwright/PlaywrightExtensions.cs
+++ b/Sources/HtmlTinkerX/Playwright/PlaywrightExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace HtmlTinkerX;
+
+internal static class PlaywrightExtensions {
+    public static Task DisposeAsync(this IPlaywright playwright) {
+        if (playwright == null) {
+            return Task.CompletedTask;
+        }
+
+        if (playwright is IAsyncDisposable asyncDisposable) {
+            return asyncDisposable.DisposeAsync().AsTask();
+        }
+
+        playwright.Dispose();
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- dispose Playwright instances in HtmlBrowserTester asynchronously with null checks
- add an internal extension to bridge asynchronous disposal support across target frameworks
- expand HtmlBrowserTesterTests with a regression case guarding against lingering Playwright processes

## Testing
- dotnet test Sources/HtmlTinkerX.sln

------
https://chatgpt.com/codex/tasks/task_e_68ce93cb17a4832ebd3634c1346fd1df