### PR TITLE
Await Playwright disposal in HtmlBrowserSession

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -18,7 +18,8 @@ public class HtmlBrowserSessionDisposeTests {
     [Fact]
     public async Task DisposeAsync_DisposesAllPlaywrightObjects() {
         var playwright = new Mock<IPlaywright>();
-        playwright.Setup(p => p.Dispose()).Verifiable();
+        var asyncPlaywright = playwright.As<IAsyncDisposable>();
+        asyncPlaywright.Setup(p => p.DisposeAsync()).Returns(new ValueTask(Task.CompletedTask)).Verifiable();
         var browser = new Mock<IBrowser>();
         browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
         var context = new Mock<IBrowserContext>();
@@ -29,7 +30,34 @@ public class HtmlBrowserSessionDisposeTests {
 
         await session.DisposeAsync();
 
-        playwright.Verify();
+        asyncPlaywright.Verify(p => p.DisposeAsync(), Times.Once);
+        browser.Verify();
+        context.Verify();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WaitsForPlaywrightDisposal() {
+        var playwrightDispose = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var playwright = new Mock<IPlaywright>();
+        var asyncPlaywright = playwright.As<IAsyncDisposable>();
+        asyncPlaywright.Setup(p => p.DisposeAsync()).Returns(new ValueTask(playwrightDispose.Task)).Verifiable();
+        var browser = new Mock<IBrowser>();
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var context = new Mock<IBrowserContext>();
+        context.Setup(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var page = new Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        Task disposeTask = session.DisposeAsync().AsTask();
+
+        Assert.False(disposeTask.IsCompleted);
+
+        playwrightDispose.SetResult(true);
+
+        await disposeTask;
+
+        asyncPlaywright.Verify(p => p.DisposeAsync(), Times.Once);
         browser.Verify();
         context.Verify();
     }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -152,8 +152,9 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
         if (Browser != null) {
             await Browser.CloseAsync().ConfigureAwait(false);
         }
+
         if (Playwright != null) {
-            Playwright.Dispose();
+            await Playwright.DisposeAsync().ConfigureAwait(false);
         }
     }
 }

--- a/Sources/HtmlTinkerX/Playwright/PlaywrightExtensions.cs
+++ b/Sources/HtmlTinkerX/Playwright/PlaywrightExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Playwright;
+using System;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX;
+
+internal static class PlaywrightExtensions {
+    public static ValueTask DisposeAsync(this IPlaywright playwright) {
+        if (playwright is IAsyncDisposable asyncDisposable) {
+            return asyncDisposable.DisposeAsync();
+        }
+
+        playwright.Dispose();
+        return new ValueTask(Task.CompletedTask);
+    }
+}


### PR DESCRIPTION
## Summary
- await `Playwright.DisposeAsync()` when releasing `HtmlBrowserSession`
- add an extension method that bridges to `IAsyncDisposable` while falling back to the synchronous disposer
- update the disposal tests to validate the awaited path and ensure asynchronous completion is honored

## Testing
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj *(net472 leg aborts because Mono is unavailable in the container, net8.0 passes)*
- dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj


------
https://chatgpt.com/codex/tasks/task_e_68ce93da1a74832ebb3ec5600c8fb9e7