### PR TITLE
Preserve network log order and add tests

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserNetworkLogTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserNetworkLogTests.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using Microsoft.Playwright;
 using Moq;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace HtmlTinkerX.Tests;
@@ -41,5 +42,48 @@ public class HtmlBrowserNetworkLogTests {
         Assert.Equal("v2", entry.ResponseHeaders!["h2"]);
         Assert.NotNull(entry.Duration);
         await session.DisposeAsync();
+    }
+
+#if NETFRAMEWORK
+    [Fact]
+    public Task NetworkLog_PreservesRequestOrder_NetFramework() => VerifyNetworkLogOrderAsync();
+#else
+    [Fact]
+    public Task NetworkLog_PreservesRequestOrder() => VerifyNetworkLogOrderAsync();
+#endif
+
+    private static async Task VerifyNetworkLogOrderAsync() {
+        var playwright = new Mock<IPlaywright>();
+        var browser = new Mock<IBrowser>();
+        var context = new Mock<IBrowserContext>();
+        var page = new Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        List<Mock<IRequest>> requests = new List<Mock<IRequest>> {
+            CreateRequest("https://1.example.com"),
+            CreateRequest("https://2.example.com"),
+            CreateRequest("https://3.example.com")
+        };
+
+        foreach (Mock<IRequest> request in requests) {
+            page.Raise(p => p.Request += null!, page.Object, request.Object);
+        }
+
+        List<HtmlNetworkEntry> sessionLog = session.NetworkLog.ToList();
+        Assert.Equal(requests.Select(r => r.Object.Url), sessionLog.Select(e => e.Url));
+
+        List<HtmlNetworkEntry> browserLog = HtmlBrowser.GetNetworkLog(session).ToList();
+        Assert.Equal(requests.Select(r => r.Object.Url), browserLog.Select(e => e.Url));
+
+        await session.DisposeAsync();
+    }
+
+    private static Mock<IRequest> CreateRequest(string url) {
+        var request = new Mock<IRequest>();
+        request.SetupGet(r => r.Url).Returns(url);
+        request.SetupGet(r => r.Method).Returns("GET");
+        request.SetupGet(r => r.Headers).Returns(new Dictionary<string, string>());
+        return request;
     }
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -2,6 +2,7 @@ using Microsoft.Playwright;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace HtmlTinkerX;
@@ -40,7 +41,10 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// </summary>
     public string? VideoPath { get; internal set; }
     private readonly ConcurrentDictionary<IRequest, HtmlNetworkEntry> _network;
-    private readonly ConcurrentQueue<IRequest> _order = new();
+    private ConcurrentQueue<IRequest>? _order;
+    private object? _networkSync;
+    private ConcurrentQueue<IRequest> RequestOrder => LazyInitializer.EnsureInitialized(ref _order, () => new ConcurrentQueue<IRequest>())!;
+    private object NetworkSync => LazyInitializer.EnsureInitialized(ref _networkSync, () => new object())!;
     private readonly ConcurrentQueue<HtmlConsoleEntry> _console = new();
     private int? _networkLogLimit;
     /// <summary>
@@ -51,12 +55,45 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
         set {
             _networkLogLimit = value;
             if (value.HasValue) {
-                TrimNetworkLog(value.Value);
+                lock (NetworkSync) {
+                    TrimNetworkLog(value.Value);
+                }
             }
         }
     }
     /// <summary>Captured network log entries.</summary>
-    public IEnumerable<HtmlNetworkEntry> NetworkLog => _network.Values;
+    public IEnumerable<HtmlNetworkEntry> NetworkLog {
+        get {
+            ConcurrentDictionary<IRequest, HtmlNetworkEntry>? network = _network;
+            if (network is null) {
+                return Array.Empty<HtmlNetworkEntry>();
+            }
+
+            List<IRequest> orderedRequests = new List<IRequest>();
+            List<HtmlNetworkEntry> orderedEntries = new List<HtmlNetworkEntry>();
+
+            lock (NetworkSync) {
+                ConcurrentQueue<IRequest> requestOrder = RequestOrder;
+
+                while (requestOrder.TryDequeue(out IRequest? request)) {
+                    orderedRequests.Add(request);
+                }
+
+                if (orderedRequests.Count == 0) {
+                    orderedEntries.AddRange(network.Values);
+                } else {
+                    foreach (IRequest request in orderedRequests) {
+                        requestOrder.Enqueue(request);
+                        if (network.TryGetValue(request, out HtmlNetworkEntry? entry)) {
+                            orderedEntries.Add(entry);
+                        }
+                    }
+                }
+            }
+
+            return orderedEntries;
+        }
+    }
     /// <summary>Captured console log entries.</summary>
     public IEnumerable<HtmlConsoleEntry> ConsoleLog => _console;
 
@@ -88,10 +125,13 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
                 RequestHeaders = new Dictionary<string, string>(req.Headers),
                 Started = System.DateTimeOffset.UtcNow
             };
-            _network[req] = entry;
-            _order.Enqueue(req);
-            if (NetworkLogLimit.HasValue) {
-                TrimNetworkLog(NetworkLogLimit.Value);
+
+            lock (NetworkSync) {
+                _network[req] = entry;
+                RequestOrder.Enqueue(req);
+                if (NetworkLogLimit.HasValue) {
+                    TrimNetworkLog(NetworkLogLimit.Value);
+                }
             }
         };
 
@@ -121,8 +161,9 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     }
 
     private void TrimNetworkLog(int limit) {
-        while (_order.Count > limit && _order.TryDequeue(out IRequest? oldReq)) {
-            _network.TryRemove(oldReq, out _);
+        ConcurrentQueue<IRequest> requestOrder = RequestOrder;
+        while (requestOrder.Count > limit && requestOrder.TryDequeue(out IRequest? oldReq)) {
+            _network?.TryRemove(oldReq, out _);
         }
     }
 


### PR DESCRIPTION
## Summary
- update `HtmlBrowserSession` to lazily initialize its ordering structures, lock around mutations, and return network log entries in the order requests were observed while trimming with the same queue
- fall back to the backing dictionary when no queued ordering data exists so existing consumers (such as HAR export) continue to work
- add unit coverage that verifies the reported network log order for every target, including net472

## Testing
- `dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj` *(net472 test host requires mono; net8.0 tests passed)*
- `dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ce93e51b24832e8de4277639241970