### PR TITLE
fix(tests): 🐛 Bind server to IPv4 and update connection logic

### DIFF
--- a/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
+++ b/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
@@ -1,12 +1,14 @@
 Describe 'Save-HTMLAttachment streaming' {
     It 'Outputs file paths as downloads complete' -Skip:(-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
-        $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', '8010' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
+        # Bind explicitly to IPv4 to avoid macOS IPv6-only listener issues
+        $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', '8010', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
         Start-Sleep -Seconds 1
         $timeout = [System.Diagnostics.Stopwatch]::StartNew()
         while ($true) {
             try {
                 $socket = New-Object Net.Sockets.TcpClient
-                $socket.Connect('127.0.0.1', 8010)
+                # Use localhost to allow IPv4/IPv6 resolution as needed
+                $socket.Connect('localhost', 8010)
                 $socket.Dispose()
                 break
             } catch {
@@ -17,7 +19,8 @@ Describe 'Save-HTMLAttachment streaming' {
             }
         }
         try {
-            $uri = 'http://localhost:8010/multi_download.html'
+            # Match the server bind address to avoid IPv6/IPv4 mismatch
+            $uri = 'http://127.0.0.1:8010/multi_download.html'
             $dest = Join-Path $TestDrive 'stream'
             $results = @()
             foreach ($file in Save-HTMLAttachment -Url $uri -Path $dest) {


### PR DESCRIPTION
* Explicitly bind the server to `127.0.0.1` to avoid macOS IPv6-only listener issues.
* Update socket connection to use `localhost` for better IPv4/IPv6 resolution.
* Adjust URI to match the server bind address for consistency.