### PR TITLE
feat(tests): 🎥 Enhance video recording tests with frame capture

### DIFF
--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Video.cs
@@ -147,6 +147,17 @@ public static partial class HtmlBrowser {
             throw new System.ArgumentException("Output path required.");
         }
 
+        // Give Playwright a chance to produce at least one frame before closing.
+        if (session.Video != null) {
+            try {
+                // Two rAFs + tiny delay to ensure a rendered frame is captured
+                await session.Page.EvaluateAsync("new Promise(r=>requestAnimationFrame(()=>requestAnimationFrame(r)))").ConfigureAwait(false);
+                await Task.Delay(75, cancellationToken).ConfigureAwait(false);
+            } catch (System.Exception) {
+                // Best-effort only
+            }
+        }
+
         cancellationToken.ThrowIfCancellationRequested();
         await session.DisposeAsync().ConfigureAwait(false);
     }

--- a/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
+++ b/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
@@ -1,14 +1,17 @@
 Describe 'Save-HTMLAttachment streaming' {
     It 'Outputs file paths as downloads complete' -Skip:(-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
+        . (Join-Path $PSScriptRoot '_TestUtils.ps1')
+        $address = '127.0.0.1'
+        $port = Get-FreeTcpPort -Address $address
         # Bind explicitly to IPv4 to avoid macOS IPv6-only listener issues
-        $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', '8010', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
+        $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', "$port", '--bind', $address -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
         Start-Sleep -Seconds 1
         $timeout = [System.Diagnostics.Stopwatch]::StartNew()
         while ($true) {
             try {
                 $socket = New-Object Net.Sockets.TcpClient
-                # Use localhost to allow IPv4/IPv6 resolution as needed
-                $socket.Connect('localhost', 8010)
+                # Probe the exact IPv4 address and randomized port we bound to
+                $socket.Connect($address, $port)
                 $socket.Dispose()
                 break
             } catch {
@@ -20,7 +23,7 @@ Describe 'Save-HTMLAttachment streaming' {
         }
         try {
             # Match the server bind address to avoid IPv6/IPv4 mismatch
-            $uri = 'http://127.0.0.1:8010/multi_download.html'
+            $uri = "http://$address:$port/multi_download.html"
             $dest = Join-Path $TestDrive 'stream'
             $results = @()
             foreach ($file in Save-HTMLAttachment -Url $uri -Path $dest) {

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -1,6 +1,9 @@
-. (Join-Path $PSScriptRoot '_TestUtils.ps1')
+try { . (Join-Path $PSScriptRoot '_TestUtils.ps1') } catch {}
 
 describe 'HTML Video Recording' {
+    BeforeAll {
+        try { . (Join-Path $PSScriptRoot '_TestUtils.ps1') } catch {}
+    }
     it 'Records a short video' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
@@ -10,6 +13,7 @@ describe 'HTML Video Recording' {
         Invoke-HTMLNavigation -Session $session -Url $uri
         Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session
+        $null = Wait-FileReady -Path $out
         (Test-Path $out) | Should -BeTrue
     }
 
@@ -22,6 +26,7 @@ describe 'HTML Video Recording' {
         $defaultSession = Get-Variable -Name 'PSParseHTML_DefaultSession' -ValueOnly -ErrorAction SilentlyContinue
         Wait-RecordedFrame $defaultSession
         Stop-HtmlBrowserVideoCapture
+        $null = Wait-FileReady -Path $out
         (Test-Path $out) | Should -BeTrue
     }
 
@@ -34,6 +39,7 @@ describe 'HTML Video Recording' {
         Invoke-HTMLNavigation -Session $record -Url $uri
         Wait-RecordedFrame $record
         Stop-HtmlBrowserVideoCapture -Session $record
+        $null = Wait-FileReady -Path $out
         (Test-Path $out) | Should -BeTrue
     }
 
@@ -47,6 +53,7 @@ describe 'HTML Video Recording' {
         $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
         Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session
+        $null = Wait-FileReady -Path $out
         $ua | Should -Be 'VideoUA'
         $w | Should -Be 200
         [double]$d | Should -Be 2
@@ -61,6 +68,7 @@ describe 'HTML Video Recording' {
         $tz = $session.Page.EvaluateAsync('Intl.DateTimeFormat().resolvedOptions().timeZone',$null).GetAwaiter().GetResult()
         Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session
+        $null = Wait-FileReady -Path $out
         [math]::Round($lat,0) | Should -Be 40
         $tz | Should -Be 'America/New_York'
     }
@@ -73,6 +81,7 @@ describe 'HTML Video Recording' {
         Invoke-HTMLNavigation -Session $session -Url $uri
         Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session -OutFile $out
+        $null = Wait-FileReady -Path $out
         (Test-Path $out) | Should -BeTrue
     }
 
@@ -84,6 +93,7 @@ describe 'HTML Video Recording' {
         Invoke-HTMLNavigation -Session $session -Url $uri
         Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session -OutFile $out
+        $null = Wait-FileReady -Path $out
         (Test-Path $out) | Should -BeTrue
     }
 }

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -1,10 +1,14 @@
+. (Join-Path $PSScriptRoot '_TestUtils.ps1')
+
 describe 'HTML Video Recording' {
     it 'Records a short video' {
         $path = Join-Path $PSScriptRoot 'Documents/dynamic.html'
         $uri = [System.Uri]::new($path).AbsoluteUri
         $out = Join-Path $TestDrive 'video.webm'
         $session = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240
+        # Navigate to trigger activity after recorder starts
         Invoke-HTMLNavigation -Session $session -Url $uri
+        Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session
         (Test-Path $out) | Should -BeTrue
     }
@@ -15,6 +19,8 @@ describe 'HTML Video Recording' {
         $out = Join-Path $TestDrive 'default.webm'
         $null = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240
         Invoke-HTMLNavigation -Url $uri
+        $defaultSession = Get-Variable -Name 'PSParseHTML_DefaultSession' -ValueOnly -ErrorAction SilentlyContinue
+        Wait-RecordedFrame $defaultSession
         Stop-HtmlBrowserVideoCapture
         (Test-Path $out) | Should -BeTrue
     }
@@ -26,6 +32,7 @@ describe 'HTML Video Recording' {
         $out = Join-Path $TestDrive 'existing.webm'
         $record = Start-HtmlBrowserVideoCapture -Session $session -OutFile $out -Width 320 -Height 240
         Invoke-HTMLNavigation -Session $record -Url $uri
+        Wait-RecordedFrame $record
         Stop-HtmlBrowserVideoCapture -Session $record
         (Test-Path $out) | Should -BeTrue
     }
@@ -38,6 +45,7 @@ describe 'HTML Video Recording' {
         $ua = $session.Page.EvaluateAsync('navigator.userAgent',$null).GetAwaiter().GetResult()
         $w = [int]($session.Page.EvaluateAsync('window.innerWidth',$null).GetAwaiter().GetResult().ToString())
         $d = [double]($session.Page.EvaluateAsync('window.devicePixelRatio',$null).GetAwaiter().GetResult().ToString())
+        Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session
         $ua | Should -Be 'VideoUA'
         $w | Should -Be 200
@@ -51,6 +59,7 @@ describe 'HTML Video Recording' {
         $session = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240 -GeoLatitude 40.0 -GeoLongitude -74.0 -Timezone 'America/New_York'
         $lat = [double]($session.Page.EvaluateAsync('new Promise(r=>navigator.geolocation.getCurrentPosition(p=>r(p.coords.latitude)))',$null).GetAwaiter().GetResult().ToString())
         $tz = $session.Page.EvaluateAsync('Intl.DateTimeFormat().resolvedOptions().timeZone',$null).GetAwaiter().GetResult()
+        Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session
         [math]::Round($lat,0) | Should -Be 40
         $tz | Should -Be 'America/New_York'
@@ -62,6 +71,7 @@ describe 'HTML Video Recording' {
         $out = Join-Path $TestDrive 'caps.WebM'
         $session = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240
         Invoke-HTMLNavigation -Session $session -Url $uri
+        Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session -OutFile $out
         (Test-Path $out) | Should -BeTrue
     }
@@ -72,6 +82,7 @@ describe 'HTML Video Recording' {
         $out = Join-Path $TestDrive 'lower.webm'
         $session = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240
         Invoke-HTMLNavigation -Session $session -Url $uri
+        Wait-RecordedFrame $session
         Stop-HtmlBrowserVideoCapture -Session $session -OutFile $out
         (Test-Path $out) | Should -BeTrue
     }

--- a/Tests/_TestUtils.ps1
+++ b/Tests/_TestUtils.ps1
@@ -38,3 +38,23 @@ function Wait-RecordedFrame {
     if ($ExtraDelayMs -gt 0) { Start-Sleep -Milliseconds $ExtraDelayMs }
 }
 
+function Wait-FileReady {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Path,
+        [int]$TimeoutSeconds = 5
+    )
+    if (-not (Test-Path $Path)) { return $false }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.Elapsed -lt [TimeSpan]::FromSeconds($TimeoutSeconds)) {
+        try {
+            $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+            $fs.Dispose()
+            return $true
+        } catch {
+            Start-Sleep -Milliseconds 100
+        }
+    }
+    return $false
+}

--- a/Tests/_TestUtils.ps1
+++ b/Tests/_TestUtils.ps1
@@ -1,0 +1,40 @@
+function Get-FreeTcpPort {
+    [CmdletBinding()]
+    param(
+        [string]$Address = '127.0.0.1'
+    )
+    $listener = $null
+    try {
+        $ip = [System.Net.IPAddress]::Parse($Address)
+        $listener = [System.Net.Sockets.TcpListener]::new($ip, 0)
+        $listener.Start()
+        $port = ($listener.LocalEndpoint -as [System.Net.IPEndPoint]).Port
+        return $port
+    } finally {
+        if ($listener) { $listener.Stop() }
+    }
+}
+
+function Wait-RecordedFrame {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        $Session,
+        [int]$ExtraDelayMs = 150
+    )
+    if (-not $Session) { return }
+    try {
+        # Prefer a deterministic DOM change used by our test page
+        $null = $Session.Page.WaitForSelectorAsync('#loaded').GetAwaiter().GetResult()
+    } catch {}
+    try {
+        # Nudge layout slightly to encourage a fresh frame
+        $null = $Session.Page.EvaluateAsync('()=>{ window.scrollTo(0,1); return 0; }', $null).GetAwaiter().GetResult()
+    } catch {}
+    try {
+        # Ensure at least one render tick has happened
+        $null = $Session.Page.EvaluateAsync('new Promise(r=>requestAnimationFrame(()=>requestAnimationFrame(r)))', $null).GetAwaiter().GetResult()
+    } catch {}
+    if ($ExtraDelayMs -gt 0) { Start-Sleep -Milliseconds $ExtraDelayMs }
+}
+


### PR DESCRIPTION
* Added `Wait-RecordedFrame` function to ensure at least one frame is captured before stopping video recording.
* Updated tests to utilize the new function for improved reliability.
* Introduced `_TestUtils.ps1` for shared test utilities, including `Get-FreeTcpPort` and `Wait-RecordedFrame`.