### PR TITLE
Stabilize HTML video recording smoke test

### DIFF
--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -5,6 +5,8 @@ describe 'HTML Video Recording' {
         $out = Join-Path $TestDrive 'video.webm'
         $session = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240
         Invoke-HTMLNavigation -Session $session -Url $uri
+        $null = $session.Page.WaitForSelectorAsync('#loaded').GetAwaiter().GetResult()
+        $null = $session.Page.WaitForTimeoutAsync(250).GetAwaiter().GetResult()
         Stop-HtmlBrowserVideoCapture -Session $session
         (Test-Path $out) | Should -BeTrue
     }


### PR DESCRIPTION
## Summary
- wait for dynamic content to render before ending the recording
- add a short delay to ensure frames are captured before stopping the session

## Testing
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester Tests/StartStop-HTMLVideoRecording.Tests.ps1 -EnableExit" *(fails: The term 'Invoke-Pester' is not recognized as a name of a cmdlet, function, script file, or executable program.)*


------
https://chatgpt.com/codex/tasks/task_e_68d034807edc832ea8a8a005aa053a88