### PR TITLE
Expose short boolean attribute toggle

### DIFF
--- a/Examples/CustomizeHtmlSettingsExample.cs
+++ b/Examples/CustomizeHtmlSettingsExample.cs
@@ -5,11 +5,12 @@ public static class CustomizeHtmlSettingsExample {
     public static void Run() {
         string html = "<input type=\"checkbox\" checked=\"checked\" />";
 
-        string optimized = HtmlOptimizer.OptimizeHtml(
-            html,
-            cssDecodeEscapes: false,
-            removeOptionalTags: true,
-            shortBooleanAttributes: true);
+        var settings = HtmlOptimizer.CreateDefaultHtmlSettings();
+        settings.RemoveOptionalTags = true;
+        settings.ShortBooleanAttribute = true;
+        settings.RemoveAttributeQuotes = false;
+
+        string optimized = HtmlOptimizer.OptimizeHtml(html, settings);
 
         Console.WriteLine(optimized);
     }

--- a/Examples/CustomizeHtmlSettingsExample.cs
+++ b/Examples/CustomizeHtmlSettingsExample.cs
@@ -1,0 +1,16 @@
+using HtmlTinkerX;
+using System;
+
+public static class CustomizeHtmlSettingsExample {
+    public static void Run() {
+        string html = "<input type=\"checkbox\" checked=\"checked\" />";
+
+        string optimized = HtmlOptimizer.OptimizeHtml(
+            html,
+            cssDecodeEscapes: false,
+            removeOptionalTags: true,
+            shortBooleanAttributes: true);
+
+        Console.WriteLine(optimized);
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
@@ -2,6 +2,8 @@ using HtmlTinkerX;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using NUglify.Html;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -77,6 +79,34 @@ public class HtmlOptimizerTests {
 
         Assert.Equal("<a hx-boost=true></a>", defaultResult);
         Assert.Equal("<a hx-boost></a>", result);
+    }
+
+    [Fact]
+    public void CreateDefaultHtmlSettings_UsesSafeDefaults() {
+        HtmlSettings settings = HtmlOptimizer.CreateDefaultHtmlSettings();
+
+        Assert.False(settings.RemoveComments);
+        Assert.False(settings.RemoveOptionalTags);
+        Assert.True(settings.IsFragmentOnly);
+        Assert.False(settings.ShortBooleanAttribute);
+        Assert.False(settings.CssSettings.DecodeEscapes);
+    }
+
+    [Fact]
+    public void OptimizeHtml_WithCustomSettingsHonorsNuGlifyOptions() {
+        const string input = "<div hidden=\"hidden\" data-flag=\"value\"><!--comment--></div>";
+        HtmlSettings settings = HtmlOptimizer.CreateDefaultHtmlSettings();
+        settings.RemoveComments = true;
+        settings.ShortBooleanAttribute = true;
+        settings.RemoveAttributeQuotes = false;
+        settings.AlphabeticallyOrderAttributes = true;
+
+        string result = HtmlOptimizer.OptimizeHtml(input, settings);
+
+        Assert.DoesNotContain("<!--comment-->", result);
+        Assert.Contains("hidden", result);
+        Assert.Contains("data-flag=\"value\"", result);
+        Assert.StartsWith("<div", result);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
@@ -70,15 +70,22 @@ public class HtmlOptimizerTests {
 
     [Fact]
     public void OptimizeHtml_ShortBooleanAttributesWhenRequested() {
-        const string input = "<a hx-boost=true></a>";
-        string defaultResult = HtmlOptimizer.OptimizeHtml(input, cssDecodeEscapes: false);
-        string result = HtmlOptimizer.OptimizeHtml(
-            input,
+        const string hxInput = "<a hx-boost=true></a>";
+        string defaultResult = HtmlOptimizer.OptimizeHtml(hxInput, cssDecodeEscapes: false);
+        string hxShortened = HtmlOptimizer.OptimizeHtml(
+            hxInput,
+            cssDecodeEscapes: false,
+            shortBooleanAttributes: true);
+
+        const string booleanInput = "<input type=\"checkbox\" checked=\"checked\" />";
+        string booleanShortened = HtmlOptimizer.OptimizeHtml(
+            booleanInput,
             cssDecodeEscapes: false,
             shortBooleanAttributes: true);
 
         Assert.Equal("<a hx-boost=true></a>", defaultResult);
-        Assert.Equal("<a hx-boost></a>", result);
+        Assert.Equal("<a hx-boost></a>", hxShortened);
+        Assert.Equal("<input type=checkbox checked />", booleanShortened);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
@@ -59,6 +59,27 @@ public class HtmlOptimizerTests {
     }
 
     [Fact]
+    public void OptimizeHtml_PreservesLiteralTrueValuesByDefault() {
+        const string input = "<a hx-boost=true></a>";
+        string result = HtmlOptimizer.OptimizeHtml(input, cssDecodeEscapes: false);
+
+        Assert.Equal("<a hx-boost=true></a>", result);
+    }
+
+    [Fact]
+    public void OptimizeHtml_ShortBooleanAttributesWhenRequested() {
+        const string input = "<a hx-boost=true></a>";
+        string defaultResult = HtmlOptimizer.OptimizeHtml(input, cssDecodeEscapes: false);
+        string result = HtmlOptimizer.OptimizeHtml(
+            input,
+            cssDecodeEscapes: false,
+            shortBooleanAttributes: true);
+
+        Assert.Equal("<a hx-boost=true></a>", defaultResult);
+        Assert.Equal("<a hx-boost></a>", result);
+    }
+
+    [Fact]
     public void OptimizeJavaScript_MinifiesInput() {
         const string formatted = "(function() {\n    function main() {\n        var tabButtons = [].slice.call(document.querySelectorAll('ul.tab-nav li a.buttonTab'));\n        tabButtons.map(function(button) {\n            button.addEventListener('click', function() {\n                document.querySelector('li a.active.buttonTab').classList.remove('active');\n                button.classList.add('active');\n                document.querySelector('.tab-pane.active').classList.remove('active');\n                document.querySelector(button.getAttribute('href')).classList.add('active');\n            });\n        });\n    }\n    if (document.readyState !== 'loading') {\n        main();\n    } else {\n        document.addEventListener('DOMContentLoaded', main);\n    }\n})();";
 

--- a/Sources/HtmlTinkerX/HtmlOptimizer.cs
+++ b/Sources/HtmlTinkerX/HtmlOptimizer.cs
@@ -1,7 +1,9 @@
 using AngleSharp;
 using AngleSharp.Dom;
 using NUglify;
+using NUglify.Css;
 using NUglify.Html;
+using NUglify.JavaScript;
 using System;
 using System.IO;
 using System.Linq;
@@ -15,6 +17,20 @@ namespace HtmlTinkerX;
 /// Helper methods for optimizing markup resources.
 /// </summary>
 public static class HtmlOptimizer {
+    /// <summary>
+    /// Creates a new <see cref="HtmlSettings"/> instance that reflects HtmlTinkerX's safe defaults.
+    /// </summary>
+    /// <returns>A settings object that callers can further customize.</returns>
+    public static HtmlSettings CreateDefaultHtmlSettings() {
+        HtmlSettings settings = new();
+        settings.RemoveComments = false;
+        settings.RemoveOptionalTags = false;
+        settings.ShortBooleanAttribute = false;
+        settings.IsFragmentOnly = true;
+        settings.CssSettings.DecodeEscapes = false;
+        return settings;
+    }
+
     /// <summary>
     /// Minifies the provided CSS using NUglify.
     /// </summary>
@@ -81,22 +97,37 @@ public static class HtmlOptimizer {
         bool removeComments = false,
         bool removeOptionalTags = false,
         bool shortBooleanAttributes = false) {
+        HtmlSettings settings = CreateDefaultHtmlSettings();
+        settings.IsFragmentOnly = !treatAsDocument;
+        settings.RemoveComments = removeComments;
+        settings.RemoveOptionalTags = removeOptionalTags;
+        settings.ShortBooleanAttribute = shortBooleanAttributes;
+        settings.CssSettings.DecodeEscapes = cssDecodeEscapes;
+
+        return OptimizeHtml(html, settings);
+    }
+
+    /// <summary>
+    /// Minifies the provided HTML content using the supplied <see cref="HtmlSettings"/> instance.
+    /// </summary>
+    /// <param name="html">HTML string to optimize.</param>
+    /// <param name="settings">NUglify settings that control how the HTML is minified.</param>
+    /// <returns>Optimized HTML output.</returns>
+    public static string OptimizeHtml(string html, HtmlSettings settings) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
 
-        HtmlSettings settings = new() {
-            RemoveOptionalTags = removeOptionalTags,
-            RemoveComments = removeComments,
-            IsFragmentOnly = !treatAsDocument,
-            ShortBooleanAttribute = shortBooleanAttributes
-        };
-        settings.CssSettings.DecodeEscapes = cssDecodeEscapes;
+        if (settings == null) {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        HtmlSettings effectiveSettings = CloneHtmlSettings(settings);
 
         bool hasMotw =
             html.IndexOf("<!-- saved from url=(0014)about:internet -->", StringComparison.OrdinalIgnoreCase) >= 0;
 
-        UglifyResult result = Uglify.Html(html, settings);
+        UglifyResult result = Uglify.Html(html, effectiveSettings);
         string output = result.Code ?? string.Empty;
 
         if (hasMotw) {
@@ -131,7 +162,35 @@ public static class HtmlOptimizer {
         string? baseUrl = null,
         HttpClient? client = null,
         CancellationToken cancellationToken = default) {
-        string optimized = await Task.Run(() => OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, shortBooleanAttributes), cancellationToken).ConfigureAwait(false);
+        HtmlSettings settings = CreateDefaultHtmlSettings();
+        settings.IsFragmentOnly = !treatAsDocument;
+        settings.RemoveComments = removeComments;
+        settings.RemoveOptionalTags = removeOptionalTags;
+        settings.ShortBooleanAttribute = shortBooleanAttributes;
+        settings.CssSettings.DecodeEscapes = cssDecodeEscapes;
+
+        return await OptimizeHtmlAsync(html, settings, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously minifies the provided HTML content using the supplied <see cref="HtmlSettings"/> instance
+    /// and optionally embeds referenced images as data URIs.
+    /// </summary>
+    /// <param name="html">HTML string to optimize.</param>
+    /// <param name="settings">NUglify settings that control how the HTML is minified.</param>
+    /// <param name="embedImages">When set, downloads external images and embeds them using data URIs.</param>
+    /// <param name="baseUrl">Optional base URL used to resolve relative image paths.</param>
+    /// <param name="client">Optional <see cref="HttpClient"/> used for downloads.</param>
+    /// <param name="cancellationToken">Token used to cancel download operations.</param>
+    /// <returns>Optimized HTML output.</returns>
+    public static async Task<string> OptimizeHtmlAsync(
+        string html,
+        HtmlSettings settings,
+        bool embedImages = false,
+        string? baseUrl = null,
+        HttpClient? client = null,
+        CancellationToken cancellationToken = default) {
+        string optimized = await Task.Run(() => OptimizeHtml(html, settings), cancellationToken).ConfigureAwait(false);
         if (!embedImages) {
             return optimized;
         }
@@ -156,6 +215,18 @@ public static class HtmlOptimizer {
     }
 
     /// <summary>
+    /// Minifies HTML content from a file using the supplied <see cref="HtmlSettings"/> instance.
+    /// </summary>
+    /// <param name="filePath">Path to the HTML file.</param>
+    /// <param name="settings">NUglify settings that control how the HTML is minified.</param>
+    /// <returns>Optimized HTML output.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static string OptimizeHtmlFile(string filePath, HtmlSettings settings) {
+        string html = HtmlUtilities.ReadFileChecked(filePath);
+        return OptimizeHtml(html, settings);
+    }
+
+    /// <summary>
     /// Asynchronously minifies HTML content from a file.
     /// </summary>
     /// <inheritdoc cref="OptimizeHtmlFile(string,bool,bool,bool,bool,bool)"/>
@@ -176,6 +247,25 @@ public static class HtmlOptimizer {
         } catch {
         }
         return await OptimizeHtmlAsync(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, shortBooleanAttributes, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously minifies HTML content from a file using the supplied <see cref="HtmlSettings"/> instance.
+    /// </summary>
+    /// <inheritdoc cref="OptimizeHtmlFileAsync(string,bool,bool,bool,bool,bool,bool,HttpClient?,CancellationToken)"/>
+    public static async Task<string> OptimizeHtmlFileAsync(
+        string filePath,
+        HtmlSettings settings,
+        bool embedImages = false,
+        HttpClient? client = null,
+        CancellationToken cancellationToken = default) {
+        string html = await HtmlUtilities.ReadFileCheckedAsync(filePath, cancellationToken).ConfigureAwait(false);
+        string? baseUrl = null;
+        try {
+            baseUrl = new Uri(Path.GetFullPath(filePath)).AbsoluteUri;
+        } catch {
+        }
+        return await OptimizeHtmlAsync(html, settings, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -287,5 +377,68 @@ public static class HtmlOptimizer {
     public static async Task<string> OptimizeJavaScriptFileAsync(string filePath) {
         string js = await HtmlUtilities.ReadFileCheckedAsync(filePath).ConfigureAwait(false);
         return await OptimizeJavaScriptAsync(js).ConfigureAwait(false);
+}
+
+    private static HtmlSettings CloneHtmlSettings(HtmlSettings settings) {
+        HtmlSettings clone = new() {
+            AttributesCaseSensitive = settings.AttributesCaseSensitive,
+            TagsCaseSensitive = settings.TagsCaseSensitive,
+            CollapseWhitespaces = settings.CollapseWhitespaces,
+            RemoveComments = settings.RemoveComments,
+            RemoveOptionalTags = settings.RemoveOptionalTags,
+            RemoveInvalidClosingTags = settings.RemoveInvalidClosingTags,
+            RemoveEmptyAttributes = settings.RemoveEmptyAttributes,
+            RemoveAttributeQuotes = settings.RemoveAttributeQuotes,
+            DecodeEntityCharacters = settings.DecodeEntityCharacters,
+            AttributeQuoteChar = settings.AttributeQuoteChar,
+            RemoveScriptStyleTypeAttribute = settings.RemoveScriptStyleTypeAttribute,
+            ShortBooleanAttribute = settings.ShortBooleanAttribute,
+            IsFragmentOnly = settings.IsFragmentOnly,
+            MinifyJs = settings.MinifyJs,
+            MinifyJsAttributes = settings.MinifyJsAttributes,
+            JsSettings = settings.JsSettings?.Clone() ?? new CodeSettings(),
+            MinifyCss = settings.MinifyCss,
+            MinifyCssAttributes = settings.MinifyCssAttributes,
+            CssSettings = settings.CssSettings?.Clone() ?? new CssSettings(),
+            PrettyPrint = settings.PrettyPrint,
+            OutputTextNodesOnNewLine = settings.OutputTextNodesOnNewLine,
+            Indent = settings.Indent,
+            RemoveJavaScript = settings.RemoveJavaScript,
+            KeepOneSpaceWhenCollapsing = settings.KeepOneSpaceWhenCollapsing,
+            AlphabeticallyOrderAttributes = settings.AlphabeticallyOrderAttributes
+        };
+
+        if (settings.InlineTagsPreservingSpacesAround != null) {
+            clone.InlineTagsPreservingSpacesAround.Clear();
+            foreach (var kvp in settings.InlineTagsPreservingSpacesAround) {
+                clone.InlineTagsPreservingSpacesAround[kvp.Key] = kvp.Value;
+            }
+        }
+
+        if (settings.TagsWithNonCollapsibleWhitespaces != null) {
+            clone.TagsWithNonCollapsibleWhitespaces.Clear();
+            foreach (var kvp in settings.TagsWithNonCollapsibleWhitespaces) {
+                clone.TagsWithNonCollapsibleWhitespaces[kvp.Key] = kvp.Value;
+            }
+        }
+
+        if (settings.KeepCommentsRegex != null) {
+            clone.KeepCommentsRegex.Clear();
+            foreach (var regex in settings.KeepCommentsRegex) {
+                clone.KeepCommentsRegex.Add(regex);
+            }
+        }
+
+        if (settings.KeepTags != null) {
+            clone.KeepTags.Clear();
+            clone.KeepTags.UnionWith(settings.KeepTags);
+        }
+
+        if (settings.RemoveAttributes != null) {
+            clone.RemoveAttributes.Clear();
+            clone.RemoveAttributes.UnionWith(settings.RemoveAttributes);
+        }
+
+        return clone;
     }
 }

--- a/Sources/HtmlTinkerX/HtmlOptimizer.cs
+++ b/Sources/HtmlTinkerX/HtmlOptimizer.cs
@@ -5,9 +5,11 @@ using NUglify.Css;
 using NUglify.Html;
 using NUglify.JavaScript;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -129,6 +131,7 @@ public static class HtmlOptimizer {
 
         UglifyResult result = Uglify.Html(html, effectiveSettings);
         string output = result.Code ?? string.Empty;
+        output = ShortenBooleanAttributesIfRequested(output, effectiveSettings);
 
         if (hasMotw) {
             return "<!-- saved from url=(0014)about:internet -->" + Environment.NewLine + output;
@@ -379,6 +382,69 @@ public static class HtmlOptimizer {
         return await OptimizeJavaScriptAsync(js).ConfigureAwait(false);
 }
 
+    private static readonly Regex BooleanAttributeValuePattern = new(
+        "(?<=\\s)(?<name>[A-Za-z_:][\\w:.-]*?)=(?:\"(?<value>[^\"]*)\"|'(?<value>[^']*)'|(?<value>[^\\s>/]+))(?=[\\s>/])",
+#if NETSTANDARD2_0 || NET472
+        RegexOptions.IgnoreCase
+#else
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+#endif
+    );
+
+    private static readonly HashSet<string> BooleanAttributes = new(
+        new[] {
+            "allowfullscreen",
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "compact",
+            "controls",
+            "declare",
+            "default",
+            "defer",
+            "disabled",
+            "formnovalidate",
+            "hidden",
+            "inert",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nomodule",
+            "novalidate",
+            "open",
+            "playsinline",
+            "readonly",
+            "required",
+            "reversed",
+            "scoped",
+            "selected",
+            "typemustmatch"
+        },
+        StringComparer.OrdinalIgnoreCase);
+
+    private static string ShortenBooleanAttributesIfRequested(string html, HtmlSettings settings) {
+        if (string.IsNullOrEmpty(html) || !settings.ShortBooleanAttribute) {
+            return html;
+        }
+
+        return BooleanAttributeValuePattern.Replace(html, static match => {
+            string name = match.Groups["name"].Value;
+            if (!BooleanAttributes.Contains(name)) {
+                return match.Value;
+            }
+
+            string value = match.Groups["value"].Value;
+            if (!value.Equals(name, StringComparison.OrdinalIgnoreCase)) {
+                return match.Value;
+            }
+
+            return name;
+        });
+    }
+
     private static HtmlSettings CloneHtmlSettings(HtmlSettings settings) {
         HtmlSettings clone = new() {
             AttributesCaseSensitive = settings.AttributesCaseSensitive,
@@ -389,6 +455,9 @@ public static class HtmlOptimizer {
             RemoveInvalidClosingTags = settings.RemoveInvalidClosingTags,
             RemoveEmptyAttributes = settings.RemoveEmptyAttributes,
             RemoveAttributeQuotes = settings.RemoveAttributeQuotes,
+#pragma warning disable CS0618 // RemoveQuotedAttributes is obsolete in favor of RemoveAttributeQuotes but still exposed for older targets
+            RemoveQuotedAttributes = settings.RemoveQuotedAttributes,
+#pragma warning restore CS0618
             DecodeEntityCharacters = settings.DecodeEntityCharacters,
             AttributeQuoteChar = settings.AttributeQuoteChar,
             RemoveScriptStyleTypeAttribute = settings.RemoveScriptStyleTypeAttribute,
@@ -421,6 +490,15 @@ public static class HtmlOptimizer {
                 clone.TagsWithNonCollapsibleWhitespaces[kvp.Key] = kvp.Value;
             }
         }
+
+#pragma warning disable CS0618 // TagsWithNonCollapsableWhitespaces is retained for backwards compatibility
+        if (settings.TagsWithNonCollapsableWhitespaces != null) {
+            clone.TagsWithNonCollapsableWhitespaces.Clear();
+            foreach (var kvp in settings.TagsWithNonCollapsableWhitespaces) {
+                clone.TagsWithNonCollapsableWhitespaces[kvp.Key] = kvp.Value;
+            }
+        }
+#pragma warning restore CS0618
 
         if (settings.KeepCommentsRegex != null) {
             clone.KeepCommentsRegex.Clear();

--- a/Sources/HtmlTinkerX/HtmlOptimizer.cs
+++ b/Sources/HtmlTinkerX/HtmlOptimizer.cs
@@ -72,8 +72,15 @@ public static class HtmlOptimizer {
     /// <param name="treatAsDocument">When set, NUglify treats the input as a full HTML document.</param>
     /// <param name="removeComments">Remove HTML comments while minifying.</param>
     /// <param name="removeOptionalTags">Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</param>
+    /// <param name="shortBooleanAttributes">Shorten boolean attributes (for example, turn <c>disabled="disabled"</c> into <c>disabled</c>).</param>
     /// <returns>Optimized HTML output.</returns>
-    public static string OptimizeHtml(string html, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false) {
+    public static string OptimizeHtml(
+        string html,
+        bool cssDecodeEscapes,
+        bool treatAsDocument = false,
+        bool removeComments = false,
+        bool removeOptionalTags = false,
+        bool shortBooleanAttributes = false) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -81,7 +88,8 @@ public static class HtmlOptimizer {
         HtmlSettings settings = new() {
             RemoveOptionalTags = removeOptionalTags,
             RemoveComments = removeComments,
-            IsFragmentOnly = !treatAsDocument
+            IsFragmentOnly = !treatAsDocument,
+            ShortBooleanAttribute = shortBooleanAttributes
         };
         settings.CssSettings.DecodeEscapes = cssDecodeEscapes;
 
@@ -106,13 +114,24 @@ public static class HtmlOptimizer {
     /// <param name="treatAsDocument">When set, NUglify treats the input as a full HTML document.</param>
     /// <param name="removeComments">Remove HTML comments while minifying.</param>
     /// <param name="removeOptionalTags">Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</param>
+    /// <param name="shortBooleanAttributes">Shorten boolean attributes (for example, turn <c>disabled="disabled"</c> into <c>disabled</c>).</param>
     /// <param name="embedImages">When set, downloads external images and embeds them using data URIs.</param>
     /// <param name="baseUrl">Optional base URL used to resolve relative image paths.</param>
     /// <param name="client">Optional <see cref="HttpClient"/> used for downloads.</param>
     /// <param name="cancellationToken">Token used to cancel download operations.</param>
     /// <returns>Optimized HTML output.</returns>
-    public static async Task<string> OptimizeHtmlAsync(string html, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false, bool embedImages = false, string? baseUrl = null, HttpClient? client = null, CancellationToken cancellationToken = default) {
-        string optimized = await Task.Run(() => OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags), cancellationToken).ConfigureAwait(false);
+    public static async Task<string> OptimizeHtmlAsync(
+        string html,
+        bool cssDecodeEscapes,
+        bool treatAsDocument = false,
+        bool removeComments = false,
+        bool removeOptionalTags = false,
+        bool shortBooleanAttributes = false,
+        bool embedImages = false,
+        string? baseUrl = null,
+        HttpClient? client = null,
+        CancellationToken cancellationToken = default) {
+        string optimized = await Task.Run(() => OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, shortBooleanAttributes), cancellationToken).ConfigureAwait(false);
         if (!embedImages) {
             return optimized;
         }
@@ -128,25 +147,35 @@ public static class HtmlOptimizer {
     /// <param name="treatAsDocument">When set, NUglify treats the input as a full HTML document.</param>
     /// <param name="removeComments">Remove HTML comments while minifying.</param>
     /// <param name="removeOptionalTags">Remove optional HTML tags such as closing <c>&lt;/p&gt;</c>.</param>
+    /// <param name="shortBooleanAttributes">Shorten boolean attributes (for example, turn <c>disabled="disabled"</c> into <c>disabled</c>).</param>
     /// <returns>Optimized HTML output.</returns>
     /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
-    public static string OptimizeHtmlFile(string filePath, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false) {
+    public static string OptimizeHtmlFile(string filePath, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false, bool shortBooleanAttributes = false) {
         string html = HtmlUtilities.ReadFileChecked(filePath);
-        return OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags);
+        return OptimizeHtml(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, shortBooleanAttributes);
     }
 
     /// <summary>
     /// Asynchronously minifies HTML content from a file.
     /// </summary>
-    /// <inheritdoc cref="OptimizeHtmlFile(string,bool,bool,bool,bool)"/>
-    public static async Task<string> OptimizeHtmlFileAsync(string filePath, bool cssDecodeEscapes, bool treatAsDocument = false, bool removeComments = false, bool removeOptionalTags = false, bool embedImages = false, HttpClient? client = null, CancellationToken cancellationToken = default) {
+    /// <inheritdoc cref="OptimizeHtmlFile(string,bool,bool,bool,bool,bool)"/>
+    public static async Task<string> OptimizeHtmlFileAsync(
+        string filePath,
+        bool cssDecodeEscapes,
+        bool treatAsDocument = false,
+        bool removeComments = false,
+        bool removeOptionalTags = false,
+        bool shortBooleanAttributes = false,
+        bool embedImages = false,
+        HttpClient? client = null,
+        CancellationToken cancellationToken = default) {
         string html = await HtmlUtilities.ReadFileCheckedAsync(filePath, cancellationToken).ConfigureAwait(false);
         string? baseUrl = null;
         try {
             baseUrl = new Uri(Path.GetFullPath(filePath)).AbsoluteUri;
         } catch {
         }
-        return await OptimizeHtmlAsync(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
+        return await OptimizeHtmlAsync(html, cssDecodeEscapes, treatAsDocument, removeComments, removeOptionalTags, shortBooleanAttributes, embedImages, baseUrl, client, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -1,4 +1,5 @@
 using HtmlTinkerX;
+using NUglify.Html;
 using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
@@ -50,15 +51,46 @@ public sealed class CmdletOptimizeHtml : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter ShortBooleanAttributes { get; set; }
 
+    /// <summary>Custom NUglify settings to use during optimization.</summary>
+    [Parameter]
+    public HtmlSettings? HtmlSettings { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
+        if (HtmlSettings != null) {
+            EnsureNoSwitch(nameof(CSSDecodeEscapes));
+            EnsureNoSwitch(nameof(TreatAsDocument));
+            EnsureNoSwitch(nameof(RemoveComments));
+            EnsureNoSwitch(nameof(RemoveOptionalTags));
+            EnsureNoSwitch(nameof(ShortBooleanAttributes));
+
+            string resultWithSettings = ParameterSetName == ParameterSetFile
+                ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), HtmlSettings!).ConfigureAwait(false)
+                : await HtmlOptimizer.OptimizeHtmlAsync(Content, HtmlSettings!).ConfigureAwait(false);
+
+            await WriteOutputAsync(resultWithSettings).ConfigureAwait(false);
+            return;
+        }
+
         string result = ParameterSetName == ParameterSetFile
             ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent, ShortBooleanAttributes.IsPresent).ConfigureAwait(false)
             : await HtmlOptimizer.OptimizeHtmlAsync(Content, CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent, ShortBooleanAttributes.IsPresent).ConfigureAwait(false);
+
+        await WriteOutputAsync(result).ConfigureAwait(false);
+    }
+
+    private void EnsureNoSwitch(string parameterName) {
+        if (MyInvocation.BoundParameters.ContainsKey(parameterName)) {
+            throw new PSArgumentException($"-{parameterName} cannot be used together with -HtmlSettings.");
+        }
+    }
+
+    private async Task WriteOutputAsync(string result) {
         if (!string.IsNullOrEmpty(OutputFile)) {
             string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK
             System.IO.File.WriteAllText(outPath, result);
+            await Task.CompletedTask;
 #else
             await System.IO.File.WriteAllTextAsync(outPath, result, CancelToken).ConfigureAwait(false);
 #endif

--- a/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletOptimizeHtml.cs
@@ -46,11 +46,15 @@ public sealed class CmdletOptimizeHtml : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter RemoveOptionalTags { get; set; }
 
+    /// <summary>Shorten boolean attributes during optimization.</summary>
+    [Parameter]
+    public SwitchParameter ShortBooleanAttributes { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         string result = ParameterSetName == ParameterSetFile
-            ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent).ConfigureAwait(false)
-            : await HtmlOptimizer.OptimizeHtmlAsync(Content, CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent).ConfigureAwait(false);
+            ? await HtmlOptimizer.OptimizeHtmlFileAsync(Path.ToFullPath(), CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent, ShortBooleanAttributes.IsPresent).ConfigureAwait(false)
+            : await HtmlOptimizer.OptimizeHtmlAsync(Content, CSSDecodeEscapes.IsPresent, TreatAsDocument.IsPresent, RemoveComments.IsPresent, RemoveOptionalTags.IsPresent, ShortBooleanAttributes.IsPresent).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(OutputFile)) {
             string outPath = OutputFile!.ToFullPath();
 #if NETSTANDARD2_0 || NETFRAMEWORK

--- a/Tests/Optimize-HTML.Tests.ps1
+++ b/Tests/Optimize-HTML.Tests.ps1
@@ -102,6 +102,17 @@
         $result | Should -Be '<input type=checkbox checked />'
     }
 
+    It 'Supports custom HtmlSettings' {
+        $settings = [HtmlTinkerX.HtmlOptimizer]::CreateDefaultHtmlSettings()
+        $settings.ShortBooleanAttribute = $true
+        $settings.RemoveComments = $true
+
+        $content = '<a hx-boost=true><!--c--></a>'
+        $result = Optimize-HTML -Content $content -HtmlSettings $settings
+
+        $result | Should -Be '<a hx-boost></a>'
+    }
+
     It 'Removes optional tags when requested' {
         $content = '<html><body><p>Hi</p></body></html>'
         $result = Optimize-HTML -Content $content -TreatAsDocument -RemoveOptionalTags

--- a/Tests/Optimize-HTML.Tests.ps1
+++ b/Tests/Optimize-HTML.Tests.ps1
@@ -88,6 +88,20 @@
         $result | Should -Not -Match '<!--c-->'
     }
 
+    It 'Preserves hx boolean attributes' {
+        $content = '<a hx-boost=true hx-get="/search" hx-target="#results"></a>'
+        $result = Optimize-HTML -Content $content -CSSDecodeEscapes:$false
+        $result | Should -Match 'hx-boost=true'
+        $result | Should -Match 'hx-get=/search'
+        $result | Should -Match 'hx-target=#results'
+    }
+
+    It 'Can shorten boolean attributes when requested' {
+        $content = '<input type="checkbox" checked="checked" />'
+        $result = Optimize-HTML -Content $content -ShortBooleanAttributes
+        $result | Should -Be '<input type=checkbox checked />'
+    }
+
     It 'Removes optional tags when requested' {
         $content = '<html><body><p>Hi</p></body></html>'
         $result = Optimize-HTML -Content $content -TreatAsDocument -RemoveOptionalTags


### PR DESCRIPTION
## Summary
- add an explicit `shortBooleanAttributes` option across the HtmlOptimizer APIs so callers can opt into NUglify's boolean attribute shortening without impacting the default
- surface the same control through the Optimize-HTML PowerShell cmdlet and update the customization example to demonstrate it
- extend the C# and Pester regression tests to cover the default preservation of `"true"` attributes and the opt-in shortening path

## Testing
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --framework net8.0 (fails: HtmlParserTableAdvancedTests.ConvertFromHtmlTable_FromUrlWithPolishCharacters_PreservesEncoding)
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --framework net8.0 --filter FullyQualifiedName~HtmlOptimizer
- pwsh -NoLogo -NoProfile -Command "Import-Module Pester -ErrorAction Stop; Import-Module ./PSParseHTML.psd1; Invoke-Pester -Path Tests/Optimize-HTML.Tests.ps1" (fails: Pester module unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68df6c6f38e4832e8f34810f47dc28a1