### PR TITLE
Relax RemoveRedundantWhitespace benchmark tolerance

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlUtilitiesTests.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using System;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Text.RegularExpressions;
@@ -187,8 +188,17 @@ public class HtmlUtilitiesTests {
 
         _output.WriteLine($"Old: {oldWatch.ElapsedMilliseconds} ms, New: {newWatch.ElapsedMilliseconds} ms");
 
-        double toleranceMs = oldWatch.Elapsed.TotalMilliseconds * 0.05 + 1;
-        TimeSpan tolerance = TimeSpan.FromMilliseconds(toleranceMs);
-        Assert.True(newWatch.Elapsed <= oldWatch.Elapsed + tolerance);
+        static TimeSpan CalculateTolerance(TimeSpan baseline) {
+            // Allow for environmental noise and cross-platform timing differences.
+            // Use the larger of a relative buffer (50% of baseline) or an absolute buffer (20ms)
+            // to avoid flaky failures on slower machines while still catching significant regressions.
+            double relativeBufferMs = baseline.TotalMilliseconds * 0.5;
+            double absoluteBufferMs = 20;
+            double toleranceMs = Math.Max(relativeBufferMs, absoluteBufferMs);
+            return TimeSpan.FromMilliseconds(toleranceMs);
+        }
+
+        TimeSpan tolerance = CalculateTolerance(oldWatch.Elapsed);
+        Assert.True(newWatch.Elapsed <= oldWatch.Elapsed + tolerance, $"New implementation was slower than expected. Old: {oldWatch.Elapsed}, New: {newWatch.Elapsed}, Tolerance: {tolerance}");
     }
 }


### PR DESCRIPTION
## Summary
- loosen the tolerance in the RemoveRedundantWhitespace performance benchmark to reduce flakiness across environments

## Testing
- dotnet test Sources/HtmlTinkerX.sln --configuration Release --framework net8.0 --verbosity minimal --logger "console;verbosity=minimal" --logger trx --collect:"XPlat Code Coverage"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e3eb6e34832e96839035074e0cc8)