### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ HtmlTinkerX is available as NuGet from the Nuget Gallery and PSParseHTML PowerSh
 
 ## 💻 PowerShell Module
 [![powershell gallery version](https://img.shields.io/powershellgallery/v/PSParseHTML.svg)](https://www.powershellgallery.com/packages/PSParseHTML)
-[![powershell gallery preview](https://img.shields.io/powershellgallery/vpre/PSParseHTML.svg?label=powershell%20gallery%20preview&colorB=yellow)](https://www.powershellgallery.com/packages/PSParseHTML)
+[![powershell gallery preview](https://img.shields.io/powershellgallery/v/PSParseHTML.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases)](https://www.powershellgallery.com/packages/PSParseHTML)
 [![powershell gallery platforms](https://img.shields.io/powershellgallery/p/PSParseHTML.svg)](https://www.powershellgallery.com/packages/PSParseHTML)
 [![powershell gallery downloads](https://img.shields.io/powershellgallery/dt/PSParseHTML.svg)](https://www.powershellgallery.com/packages/PSParseHTML)
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583