### PR TITLE
Add offline structured crawl OpenAPI exports

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -6,20 +6,20 @@
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description            = 'Module that allows to manipulate, parse, format and optimize HTML, JavaScript and CSS'
-    DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = 'f0387960-7034-4918-a1e1-d5847cbf90df'
     ModuleVersion          = '2.0.6'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{
-            ExternalModuleDependencies = @('Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility')
+            ExternalModuleDependencies = @()
             IconUri                    = 'https://evotec.xyz/wp-content/uploads/2018/12/PSWriteHTML.png'
             ProjectUri                 = 'https://github.com/EvotecIT/PSParseHTML'
             RequireLicenseAcceptance   = $false
             Tags                       = @('HTML', 'WWW', 'JavaScript', 'CSS', 'Windows', 'MacOS', 'Linux')
         }
     }
-    RequiredModules        = @('Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility')
+    RequiredModules        = @()
     RootModule             = 'PSParseHTML.psm1'
+    ScriptsToProcess     = @()
 }

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -1,16 +1,16 @@
 ﻿@{
-    AliasesToExport        = @('Close-HTMLSession', 'Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Export-HTMLSession', 'Format-JS', 'Get-HTMLConsoleLog', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLFormField', 'Get-HTMLInteractable', 'Get-HTMLLoginForm', 'Get-HTMLNetworkLog', 'Import-HTMLSession', 'Invoke-HTMLClick', 'Invoke-HTMLDomScript', 'Invoke-HTMLLogin', 'Invoke-HTMLNavigation', 'Invoke-HTMLScript', 'Start-HTMLSession', 'Open-HTMLSession', 'Measure-HTMLPerformance', 'Measure-HTMLDocument', 'New-HTMLCookie', 'Save-HTMLAttachment', 'Save-HTMLDownload', 'Save-HTMLHar', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLHttpClientOption', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Show-HTMLHar', 'Start-HTMLTracing', 'Start-HTMLVideoRecording', 'Stop-HTMLTracing', 'Stop-HTMLVideoRecording', 'Submit-HTMLForm')
-    Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Close-HtmlBrowserSession', 'Compare-HTML', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HTMLCookie', 'ConvertFrom-HtmlForm', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlMeta', 'ConvertFrom-HtmlMicrodata', 'ConvertFrom-HtmlOpenGraph', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Export-BrowserState', 'Export-HtmlBrowserSession', 'Export-HTMLOutline', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HtmlBrowserConsoleLog', 'Get-HtmlBrowserContent', 'Get-HtmlBrowserCookie', 'Get-HtmlBrowserFormField', 'Get-HtmlBrowserInteractable', 'Get-HtmlBrowserLoginForm', 'Get-HtmlBrowserNetworkLog', 'Get-HtmlCrawlProfile', 'Get-HTMLResource', 'Import-BrowserState', 'Import-HtmlBrowserSession', 'Invoke-HtmlBrowserClick', 'Invoke-HtmlBrowserDomScript', 'Invoke-HtmlBrowserLogin', 'Invoke-HtmlBrowserNavigation', 'Invoke-HtmlBrowserScript', 'Invoke-HTMLCrawl', 'Invoke-HTMLRendering', 'Measure-HtmlBrowserPerformance', 'Measure-HtmlDocumentStructure', 'New-HtmlBrowserCookie', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HtmlBrowserAttachment', 'Save-HtmlBrowserHar', 'Save-HtmlBrowserPdf', 'Save-HtmlBrowserScreenshot', 'Set-HtmlBrowserChecked', 'Set-HtmlBrowserClientOption', 'Set-HtmlBrowserCookie', 'Set-HtmlBrowserInput', 'Set-HtmlBrowserSelectOption', 'Show-HtmlBrowserHar', 'Start-HtmlBrowserTracing', 'Start-HtmlBrowserVideoCapture', 'Stop-HtmlBrowserTracing', 'Stop-HtmlBrowserVideoCapture', 'Submit-HtmlBrowserForm', 'Test-HtmlMicrodata', 'Unregister-HTMLRoute', 'Test-HtmlBrowser', 'Clear-HtmlBrowserCache')
-    CompanyName            = 'Evotec'
-    CompatiblePSEditions   = @('Desktop', 'Core')
-    Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
-    Description            = 'Module that allows to manipulate, parse, format and optimize HTML, JavaScript and CSS'
-    FunctionsToExport      = @()
-    GUID                   = 'f0387960-7034-4918-a1e1-d5847cbf90df'
-    ModuleVersion          = '2.0.6'
-    PowerShellVersion      = '5.1'
-    PrivateData            = @{
+    AliasesToExport      = @('Close-HTMLSession', 'Stop-HTMLSession', 'ConvertFrom-HTMLTag', 'ConvertFrom-HTMLClass', 'Export-HTMLSession', 'Format-JS', 'Get-HTMLConsoleLog', 'Get-HTMLContent', 'Get-HTMLCookie', 'Get-HTMLFormField', 'Get-HTMLInteractable', 'Get-HTMLLoginForm', 'Get-HTMLNetworkLog', 'Import-HTMLSession', 'Invoke-HTMLClick', 'Invoke-HTMLDomScript', 'Invoke-HTMLLogin', 'Invoke-HTMLNavigation', 'Invoke-HTMLScript', 'Start-HTMLSession', 'Open-HTMLSession', 'Measure-HTMLPerformance', 'Measure-HTMLDocument', 'New-HTMLCookie', 'Save-HTMLAttachment', 'Save-HTMLDownload', 'Save-HTMLHar', 'Save-HTMLPdf', 'Save-HTMLScreenshot', 'Set-HTMLChecked', 'Set-HTMLHttpClientOption', 'Set-HTMLCookie', 'Set-HTMLInput', 'Set-HTMLSelectOption', 'Show-HTMLHar', 'Start-HTMLTracing', 'Start-HTMLVideoRecording', 'Stop-HTMLTracing', 'Stop-HTMLVideoRecording', 'Submit-HTMLForm')
+    Author               = 'Przemyslaw Klys'
+    CmdletsToExport      = @('Close-HtmlBrowserSession', 'Compare-HTML', 'ConvertFrom-HTML', 'ConvertFrom-HtmlAttributes', 'ConvertFrom-HTMLCookie', 'ConvertFrom-HtmlForm', 'ConvertFrom-HtmlList', 'ConvertFrom-HtmlMeta', 'ConvertFrom-HtmlMicrodata', 'ConvertFrom-HtmlOpenGraph', 'ConvertFrom-HtmlTable', 'Convert-HTMLToText', 'Export-BrowserState', 'Export-HtmlBrowserSession', 'Export-HTMLOutline', 'Format-CSS', 'Format-HTML', 'Format-JavaScript', 'Get-HtmlBrowserConsoleLog', 'Get-HtmlBrowserContent', 'Get-HtmlBrowserCookie', 'Get-HtmlBrowserFormField', 'Get-HtmlBrowserInteractable', 'Get-HtmlBrowserLoginForm', 'Get-HtmlBrowserNetworkLog', 'Get-HtmlCrawlProfile', 'Get-HTMLResource', 'Import-BrowserState', 'Import-HtmlBrowserSession', 'Invoke-HtmlBrowserClick', 'Invoke-HtmlBrowserDomScript', 'Invoke-HtmlBrowserLogin', 'Invoke-HtmlBrowserNavigation', 'Invoke-HtmlBrowserScript', 'Invoke-HTMLCrawl', 'Invoke-HTMLRendering', 'Measure-HtmlBrowserPerformance', 'Measure-HtmlDocumentStructure', 'New-HtmlBrowserCookie', 'Optimize-CSS', 'Optimize-Email', 'Optimize-HTML', 'Optimize-JavaScript', 'Register-HTMLRoute', 'Save-HtmlBrowserAttachment', 'Save-HtmlBrowserHar', 'Save-HtmlBrowserPdf', 'Save-HtmlBrowserScreenshot', 'Set-HtmlBrowserChecked', 'Set-HtmlBrowserClientOption', 'Set-HtmlBrowserCookie', 'Set-HtmlBrowserInput', 'Set-HtmlBrowserSelectOption', 'Show-HtmlBrowserHar', 'Start-HtmlBrowserTracing', 'Start-HtmlBrowserVideoCapture', 'Stop-HtmlBrowserTracing', 'Stop-HtmlBrowserVideoCapture', 'Submit-HtmlBrowserForm', 'Test-HtmlMicrodata', 'Unregister-HTMLRoute', 'Test-HtmlBrowser', 'Clear-HtmlBrowserCache')
+    CompanyName          = 'Evotec'
+    CompatiblePSEditions = @('Desktop', 'Core')
+    Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Description          = 'Module that allows to manipulate, parse, format and optimize HTML, JavaScript and CSS'
+    FunctionsToExport    = @()
+    GUID                 = 'f0387960-7034-4918-a1e1-d5847cbf90df'
+    ModuleVersion        = '2.0.6'
+    PowerShellVersion    = '5.1'
+    PrivateData          = @{
         PSData = @{
             ExternalModuleDependencies = @()
             IconUri                    = 'https://evotec.xyz/wp-content/uploads/2018/12/PSWriteHTML.png'
@@ -19,7 +19,7 @@
             Tags                       = @('HTML', 'WWW', 'JavaScript', 'CSS', 'Windows', 'MacOS', 'Linux')
         }
     }
-    RequiredModules        = @()
-    RootModule             = 'PSParseHTML.psm1'
+    RequiredModules      = @()
+    RootModule           = 'PSParseHTML.psm1'
     ScriptsToProcess     = @()
 }

--- a/README.MD
+++ b/README.MD
@@ -190,6 +190,150 @@ var crawl = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCra
 Console.WriteLine(crawl.Summary.ToReportText(crawl.SitemapUrls));
 Console.WriteLine(crawl.PagesCsvPath);
 
+// AI-ready offline dataset with Markdown alongside HTML/text
+var aiReady = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
+    Selector = "main",
+    IncludeMarkdown = true,
+    OutputPath = "crawl-output"
+});
+Console.WriteLine(aiReady.Pages[0].MarkdownPath);
+
+// Self-contained JSON document export for downstream automation
+var structured = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
+    Selector = "main",
+    IncludeStructuredJson = true,
+    OutputPath = "crawl-output"
+});
+Console.WriteLine(structured.StructuredJsonPagesJsonlPath);
+Console.WriteLine(structured.OpenApiLikePath);
+Console.WriteLine(structured.OpenApiPath);
+Console.WriteLine(structured.OpenApiDocument["openapi"]);
+Console.WriteLine(structured.OpenApiLike.StrictOpenApiEligibleOperationCount);
+Console.WriteLine(structured.OpenApiLike.StrictOpenApiSkippedOperationCount);
+Console.WriteLine(structured.OpenApiDocument.ContainsKey("x-htmltinkerx-promotion"));
+Console.WriteLine(structured.Pages[0].StructuredJson!.Document.Summary);
+Console.WriteLine(structured.Pages[0].StructuredJson!.Document.Markdown);
+Console.WriteLine(structured.Pages[0].StructuredJson!.Metadata.Description);
+Console.WriteLine(structured.Pages[0].StructuredJson!.Layout.NavigationCount);
+Console.WriteLine(structured.Pages[0].StructuredJson!.CodeBlocks.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.CodeSamples.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.ApiEndpoints.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.Breadcrumbs.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.FaqItems.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.SpecTables.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.Callouts.Count);
+Console.WriteLine(structured.Pages[0].StructuredJson!.PrimaryActions.Count);
+
+// Built-in preset fields for docs/article/product pages, with auto mode available too
+var docsJson = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
+    Selector = "main",
+    IncludeStructuredJson = true,
+    StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Docs,
+    OutputPath = "crawl-output"
+});
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ResolvedPreset);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["mainHeading"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["navigationLinks"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["codeSamples"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["apiEndpoints"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["apiCatalog"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["apiTags"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["apiResources"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["operationIds"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["openApiLike"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["openApiPaths"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["openApiServers"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["authenticationSchemes"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["rateLimitHeaders"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["operationId"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["resource"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["tags"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["requestExamples"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["requestHeaders"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["responseHeaders"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["errorResponses"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["errorCatalog"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["successResponseSchema"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["errorResponseSchema"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["requestBodyFields"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["successResponseFields"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["errorResponseFields"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].Parameters.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].OperationId);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].Resource);
+Console.WriteLine(string.Join(", ", docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].Tags));
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].BodyParameters.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].HeaderParameters.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RequestBodySchema["name"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RequestBodyFields[0].Path);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RequestBodyFields[0].Provenance[0].Kind);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RequestBodyFields[0].ConfidenceScore);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].BodyParameters[0].Format);
+Console.WriteLine(string.Join(", ", docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].BodyParameters[0].EnumValues));
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].BodyParameters[0].ExampleValue);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].Authentication.Required);
+Console.WriteLine(string.Join(", ", docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].Authentication.Schemes));
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RateLimit.Limit);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RequestExamples.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].RequestHeaders.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].ResponseHeaders.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].ErrorResponses.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].ErrorCatalog.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].SuccessResponseSchema["id"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].ErrorResponseSchema["error"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].SuccessResponseFields[0].Path);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].SuccessResponseFields[0].Provenance[0].Kind);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].SuccessResponseFields[0].ConfidenceScore);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].ErrorResponseFields[0].Path);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].SuccessResponseFields[0].Kind);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].SuccessResponseFields[0].ChildPaths.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiEndpoints[0].ResponseExamples.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.ApiCatalog.OperationCount);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.OpenApiLike.Paths["/v1/widgets"].Operations["post"].OperationId);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].OperationId);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].AuthenticationRef);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ParametersRef);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RequestHeadersRef);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ResponseExamplesRef);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].StrictOpenApiScore);
+Console.WriteLine(docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].StrictOpenApiEligible);
+Console.WriteLine(string.Join(", ", docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].Provenance.PageUrls));
+Console.WriteLine(string.Join(", ", docsJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].Provenance.SourceKinds));
+Console.WriteLine(docsJson.OpenApiLike.Components.AuthProfiles.Count);
+Console.WriteLine(docsJson.OpenApiLike.Components.FieldSets.Count);
+Console.WriteLine(docsJson.OpenApiLike.Components.ParameterSets.Count);
+Console.WriteLine(docsJson.OpenApiLike.Components.RequestHeaderSets.Count);
+Console.WriteLine(docsJson.OpenApiLike.Components.ResponseExampleSets.Count);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["breadcrumbs"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["faqItems"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["callouts"]);
+Console.WriteLine(docsJson.Pages[0].StructuredJson!.Extracted["primaryActions"]);
+
+// Caller-defined JSON fields layered on top of the built-in structured model
+var extracted = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
+    Selector = "main",
+    StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Docs,
+    StructuredJsonSchema = """
+    {
+      "title": "Metadata.Title",
+      "description": "Metadata.Description",
+      "navLinks": { "selector": "nav a", "source": "page", "mode": "text", "all": true },
+      "mainHeading": { "selector": "h1", "source": "selected", "mode": "text" }
+    }
+    """
+});
+Console.WriteLine(extracted.Pages[0].StructuredJson!.Extracted["title"]);
+Console.WriteLine(extracted.Pages[0].StructuredJson!.Extracted["mainHeading"]);
+
+// One-call dataset mode turns on Markdown + structured JSON defaults
+var dataset = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
+    Scenario = HtmlCrawlScenario.Dataset,
+    OutputPath = "crawl-output"
+});
+Console.WriteLine(dataset.Pages[0].MarkdownPath);
+Console.WriteLine(dataset.Pages[0].StructuredJsonPath);
+Console.WriteLine(dataset.Pages[0].StructuredJson!.ResolvedPreset);
+
 // Keep full tracking query strings when a site uses them as real page identity
 var exactUrls = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
     IgnoreTrackingQueryParameters = false
@@ -291,6 +435,70 @@ $crawl.Pages | Select-Object Url, Title, Depth
 $crawl.SkippedPages | Select-Object Url, SkipReason
 $crawl.Summary.ToReportText($crawl.SitemapUrls)
 
+# AI-ready offline dataset with Markdown alongside HTML/text
+$aiReady = Invoke-HTMLCrawl -Url 'https://example.com/docs' -Selector 'main' -IncludeMarkdown -OutPath '.\crawl-output'
+$aiReady.Pages | Select-Object Url, MarkdownPath
+
+# Self-contained JSON document export for downstream automation
+$structured = Invoke-HTMLCrawl -Url 'https://example.com/docs' -Selector 'main' -IncludeStructuredJson -OutPath '.\crawl-output'
+$structured.StructuredJsonPagesJsonlPath
+$structured.OpenApiLikePath
+$structured.OpenApiPath
+$structured.OpenApiDocument["openapi"]
+$structured.OpenApiLike.StrictOpenApiEligibleOperationCount
+$structured.OpenApiLike.StrictOpenApiSkippedOperationCount
+$structured.OpenApiDocument.ContainsKey("x-htmltinkerx-promotion")
+$structured.Pages | Select-Object Url, StructuredJsonPath, @{ N = 'Summary'; E = { $_.StructuredJson.Document.Summary } }
+$structured.Pages | Select-Object Url, @{ N = 'Description'; E = { $_.StructuredJson.Metadata.Description } }, @{ N = 'NavigationCount'; E = { $_.StructuredJson.Layout.NavigationCount } }
+$structured.Pages | Select-Object Url, @{ N = 'CodeBlocks'; E = { $_.StructuredJson.CodeBlocks.Count } }, @{ N = 'Breadcrumbs'; E = { $_.StructuredJson.Breadcrumbs.Count } }, @{ N = 'FaqItems'; E = { $_.StructuredJson.FaqItems.Count } }
+$structured.Pages | Select-Object Url, @{ N = 'CodeSamples'; E = { $_.StructuredJson.CodeSamples.Count } }, @{ N = 'ApiEndpoints'; E = { $_.StructuredJson.ApiEndpoints.Count } }
+$structured.Pages | Select-Object Url, @{ N = 'AuthenticatedEndpoints'; E = { $_.StructuredJson.ApiEndpoints.Where({ $_.Authentication.Required -ne $null -or $_.Authentication.Schemes.Count -gt 0 -or $_.Authentication.Headers.Count -gt 0 }).Count } }, @{ N = 'RateLimitedEndpoints'; E = { $_.StructuredJson.ApiEndpoints.Where({ $_.RateLimit.Mentioned -or $_.RateLimit.StatusCode -ne $null }).Count } }
+$structured.Pages | Select-Object Url, @{ N = 'ApiErrorResponses'; E = { $_.StructuredJson.ApiEndpoints.ForEach({ $_.ErrorResponses.Count }) | Measure-Object -Sum | Select-Object -ExpandProperty Sum } }
+$structured.Pages | Select-Object Url, @{ N = 'SpecTables'; E = { $_.StructuredJson.SpecTables.Count } }, @{ N = 'Callouts'; E = { $_.StructuredJson.Callouts.Count } }, @{ N = 'PrimaryActions'; E = { $_.StructuredJson.PrimaryActions.Count } }
+
+# Built-in preset fields for common page types
+$docs = Invoke-HTMLCrawl -Url 'https://example.com/docs' -Selector 'main' -IncludeStructuredJson -StructuredJsonPreset Docs -OutPath '.\crawl-output'
+$docs.Pages | Select-Object Url, @{ N = 'Preset'; E = { $_.StructuredJson.ResolvedPreset } }, @{ N = 'MainHeading'; E = { $_.StructuredJson.Extracted["mainHeading"] } }, @{ N = 'ApiEndpoints'; E = { $_.StructuredJson.Extracted["apiEndpoints"] } }, @{ N = 'Breadcrumbs'; E = { $_.StructuredJson.Extracted["breadcrumbs"] } }, @{ N = 'PrimaryActions'; E = { $_.StructuredJson.Extracted["primaryActions"] } }
+$docs.Pages | Select-Object Url, @{ N = 'ApiCatalog'; E = { $_.StructuredJson.Extracted["apiCatalog"] } }, @{ N = 'ApiTags'; E = { $_.StructuredJson.Extracted["apiTags"] } }, @{ N = 'ApiResources'; E = { $_.StructuredJson.Extracted["apiResources"] } }, @{ N = 'OperationIds'; E = { $_.StructuredJson.Extracted["operationIds"] } }
+$docs.Pages | Select-Object Url, @{ N = 'OpenApiLike'; E = { $_.StructuredJson.Extracted["openApiLike"] } }, @{ N = 'OpenApiPaths'; E = { $_.StructuredJson.Extracted["openApiPaths"] } }, @{ N = 'OpenApiServers'; E = { $_.StructuredJson.Extracted["openApiServers"] } }
+$docs.Pages | Select-Object Url, @{ N = 'ApiParameterCount'; E = { $_.StructuredJson.ApiEndpoints[0].Parameters.Count } }, @{ N = 'OperationId'; E = { $_.StructuredJson.ApiEndpoints[0].OperationId } }, @{ N = 'Resource'; E = { $_.StructuredJson.ApiEndpoints[0].Resource } }, @{ N = 'Tags'; E = { $_.StructuredJson.ApiEndpoints[0].Tags -join ', ' } }, @{ N = 'ResponseExampleCount'; E = { $_.StructuredJson.ApiEndpoints[0].ResponseExamples.Count } }
+$docs.OpenApiLike.Paths['/v1/widgets'].Operations['post']
+$docs.OpenApiLike.Paths['/v1/widgets'].Operations['post'].StrictOpenApiScore
+$docs.OpenApiLike.Paths['/v1/widgets'].Operations['post'].StrictOpenApiEligible
+$docs.OpenApiLike.Paths['/v1/widgets'].Operations['post'].Provenance.PageUrls
+$docs.OpenApiLike.Paths['/v1/widgets'].Operations['post'].Provenance.SourceKinds
+$docs.OpenApiLike.Components.AuthProfiles
+$docs.OpenApiLike.Components.FieldSets
+$docs.OpenApiLike.Components.ParameterSets
+$docs.OpenApiLike.Components.RequestHeaderSets
+$docs.OpenApiLike.Components.ResponseExampleSets
+$docs.Pages | Select-Object Url, @{ N = 'BodyParameterCount'; E = { $_.StructuredJson.ApiEndpoints[0].BodyParameters.Count } }, @{ N = 'HeaderParameterCount'; E = { $_.StructuredJson.ApiEndpoints[0].HeaderParameters.Count } }, @{ N = 'BodySchemaNameType'; E = { $_.StructuredJson.ApiEndpoints[0].RequestBodySchema["name"] } }
+$docs.Pages | Select-Object Url, @{ N = 'BodyParameterFormat'; E = { $_.StructuredJson.ApiEndpoints[0].BodyParameters[0].Format } }, @{ N = 'BodyParameterEnum'; E = { $_.StructuredJson.ApiEndpoints[0].BodyParameters[0].EnumValues -join ', ' } }, @{ N = 'BodyParameterExample'; E = { $_.StructuredJson.ApiEndpoints[0].BodyParameters[0].ExampleValue } }
+$docs.Pages | Select-Object Url, @{ N = 'RequestFieldSource'; E = { $_.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].Provenance[0].Kind } }, @{ N = 'SuccessFieldSource'; E = { $_.StructuredJson.ApiEndpoints[0].SuccessResponseFields[0].Provenance[0].Kind } }
+$docs.Pages | Select-Object Url, @{ N = 'RequestFieldConfidence'; E = { $_.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].ConfidenceScore } }, @{ N = 'SuccessFieldConfidence'; E = { $_.StructuredJson.ApiEndpoints[0].SuccessResponseFields[0].ConfidenceScore } }
+$docs.Pages | Select-Object Url, @{ N = 'RequestBodyFields'; E = { $_.StructuredJson.Extracted["requestBodyFields"] } }, @{ N = 'SuccessResponseFields'; E = { $_.StructuredJson.Extracted["successResponseFields"] } }, @{ N = 'ErrorResponseFields'; E = { $_.StructuredJson.Extracted["errorResponseFields"] } }
+$docs.Pages | Select-Object Url, @{ N = 'SuccessFieldKind'; E = { $_.StructuredJson.ApiEndpoints[0].SuccessResponseFields[0].Kind } }, @{ N = 'SuccessFieldChildren'; E = { $_.StructuredJson.ApiEndpoints[0].SuccessResponseFields[0].ChildPaths -join ', ' } }
+$docs.Pages | Select-Object Url, @{ N = 'AuthRequired'; E = { $_.StructuredJson.ApiEndpoints[0].Authentication.Required } }, @{ N = 'AuthSchemes'; E = { $_.StructuredJson.Extracted["authenticationSchemes"] } }, @{ N = 'RateLimit'; E = { $_.StructuredJson.ApiEndpoints[0].RateLimit.Limit } }, @{ N = 'RateLimitHeaders'; E = { $_.StructuredJson.Extracted["rateLimitHeaders"] } }
+$docs.Pages | Select-Object Url, @{ N = 'RequestExamples'; E = { $_.StructuredJson.Extracted["requestExamples"] } }, @{ N = 'RequestHeaders'; E = { $_.StructuredJson.Extracted["requestHeaders"] } }, @{ N = 'RequestExampleCount'; E = { $_.StructuredJson.Extracted["requestExampleCount"] } }
+$docs.Pages | Select-Object Url, @{ N = 'ResponseHeaders'; E = { $_.StructuredJson.Extracted["responseHeaders"] } }, @{ N = 'ErrorResponses'; E = { $_.StructuredJson.Extracted["errorResponses"] } }, @{ N = 'ErrorResponseCount'; E = { $_.StructuredJson.Extracted["errorResponseCount"] } }, @{ N = 'ErrorCatalog'; E = { $_.StructuredJson.Extracted["errorCatalog"] } }
+$docs.Pages | Select-Object Url, @{ N = 'SuccessResponseSchema'; E = { $_.StructuredJson.Extracted["successResponseSchema"] } }, @{ N = 'ErrorResponseSchema'; E = { $_.StructuredJson.Extracted["errorResponseSchema"] } }
+
+# Caller-defined JSON fields layered on top of the built-in structured model
+$schema = @'
+{
+  "title": "Metadata.Title",
+  "description": "Metadata.Description",
+  "navLinks": { "selector": "nav a", "source": "page", "mode": "text", "all": true },
+  "mainHeading": { "selector": "h1", "source": "selected", "mode": "text" }
+}
+'@
+$extracted = Invoke-HTMLCrawl -Url 'https://example.com/docs' -Selector 'main' -StructuredJsonPreset Docs -StructuredJsonSchema $schema
+$extracted.Pages | Select-Object Url, @{ N = 'Title'; E = { $_.StructuredJson.Extracted["title"] } }, @{ N = 'MainHeading'; E = { $_.StructuredJson.Extracted["mainHeading"] } }
+
+# One-call dataset mode turns on Markdown + structured JSON defaults
+$dataset = Invoke-HTMLCrawl -Url 'https://example.com/docs' -Scenario Dataset -OutPath '.\crawl-output'
+$dataset.Pages | Select-Object Url, MarkdownPath, StructuredJsonPath, @{ N = 'Preset'; E = { $_.StructuredJson.ResolvedPreset } }
+
 # Preserve full tracked URLs when query strings are meaningful
 $exactUrls = Invoke-HTMLCrawl -Url 'https://example.com/docs' -KeepTrackingQueryParameters
 
@@ -384,7 +592,7 @@ $resumed = Invoke-HTMLCrawl -Url 'https://example.com/docs' -ResumePath '.\crawl
 Persisted crawl artifacts now include:
 - `crawl-result.json` for the manifest and resume state
 - `index.html` as a browsable offline entry point into the saved dataset
-- `pages/` with per-page `.html`, `.txt`, and `.json` sidecar manifests, including extraction metadata such as content mode, selection reason, and selected element hints
+- `pages/` with per-page `.html`, `.txt`, optional `.md`, and `.json` sidecar manifests, including extraction metadata such as content mode, selection reason, and selected element hints
 - `pages.jsonl` and `pages.csv` for page-level datasets
 - `skipped-pages.jsonl` for skipped content-page candidates
 - `skipped-assets.jsonl` for discovered asset/document URLs that were intentionally not crawled as pages

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
@@ -67,7 +67,9 @@ public class HtmlCrawlerMarkdownTests {
 
             HtmlCrawlPage page = Assert.Single(result.Pages);
             Assert.Contains("# Hello", page.Markdown);
-            Assert.Contains("World with **bold** and [link](", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("World", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("**bold**", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("[link](", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("http://localhost", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("- One", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("- Two", page.Markdown, StringComparison.Ordinal);

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlCrawlerMarkdownTests {
+    private static int GetFreePort() {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static HttpListener StartServer(Dictionary<string, string> responses, out string rootUrl) {
+        int port = GetFreePort();
+        rootUrl = $"http://localhost:{port}/";
+        HttpListener listener = new();
+        listener.Prefixes.Add(rootUrl);
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    if (responses.TryGetValue(key, out string? html)) {
+                        byte[] data = Encoding.UTF8.GetBytes(html);
+                        context.Response.ContentType = "text/html; charset=utf-8";
+                        context.Response.ContentLength64 = data.Length;
+                        await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    } else {
+                        context.Response.StatusCode = 404;
+                    }
+
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        return listener;
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_PopulatesMarkdownAndPersistsFile() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = "<html><head><title>Home</title></head><body><main><h1>Hello</h1><p>World with <strong>bold</strong> and <a href='/docs/start'>link</a>.</p><ul><li>One</li><li>Two</li></ul></main></body></html>"
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains("# Hello", page.Markdown);
+            Assert.Contains("World with **bold** and [link](", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("http://localhost", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("- One", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("- Two", page.Markdown, StringComparison.Ordinal);
+            Assert.False(string.IsNullOrWhiteSpace(page.MarkdownPath));
+            Assert.True(File.Exists(page.MarkdownPath!));
+
+            string manifest = File.ReadAllText(page.ManifestPath!);
+            Assert.Contains("MarkdownPath", manifest, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -805,6 +805,15 @@ public class HtmlCrawlerStructuredJsonTests {
             Assert.Equal("3.1.0", Assert.IsType<string>(result.OpenApiDocument["openapi"]));
             Assert.True(result.OpenApiDocument.ContainsKey("components"));
             Assert.True(result.OpenApiDocument.ContainsKey("x-htmltinkerx-promotion"));
+            IDictionary<string, object?> strictPaths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> strictWidgetsPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(strictPaths["/v1/widgets"]);
+            IDictionary<string, object?> strictPostOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(strictWidgetsPath["post"]);
+            Assert.True(strictPostOperation.ContainsKey("requestBody"));
+            List<object> strictParameters = Assert.IsAssignableFrom<List<object>>(strictPostOperation["parameters"]);
+            Assert.DoesNotContain(strictParameters, parameter =>
+                parameter is IDictionary<string, object?> parameterDictionary
+                && string.Equals(parameterDictionary["name"] as string, "name", StringComparison.Ordinal)
+                && string.Equals(parameterDictionary["in"] as string, "query", StringComparison.OrdinalIgnoreCase));
             string openApiJson = File.ReadAllText(result.OpenApiPath!);
             Assert.Contains("\"openapi\": \"3.1.0\"", openApiJson, StringComparison.Ordinal);
             Assert.Contains("\"/v1/widgets\"", openApiJson, StringComparison.Ordinal);

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -1107,6 +1107,61 @@ public class HtmlCrawlerStructuredJsonTests {
     }
 
     [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_ClassifiesJsonRequestBodySamplesUnderRequestHeadingsAsRequests() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/widgets/create"] = """
+            <html>
+              <head>
+                <title>Create widget</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Create widget</h1>
+                  <h2>POST /v1/widgets</h2>
+                  <h3>Request body</h3>
+                  <pre><code class="language-json">{ "name": "Alpha" }</code></pre>
+                  <h3>Response 201</h3>
+                  <pre><code class="language-json">{ "id": "wid_123", "name": "Alpha" }</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/widgets/create", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredCodeSample requestSample = Assert.Single(structuredJson.CodeSamples,
+                sample => string.Equals(sample.Heading, "Request body", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("POST", requestSample.Method);
+            Assert.Equal("/v1/widgets", requestSample.Path);
+
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            HtmlCrawlStructuredRequestExample requestExample = Assert.Single(endpoint.RequestExamples);
+            Assert.Equal("POST", requestExample.Method);
+            Assert.Equal("/v1/widgets", requestExample.Path);
+            Assert.Contains("\"name\": \"Alpha\"", requestExample.Body, StringComparison.Ordinal);
+            HtmlCrawlStructuredResponseExample responseExample = Assert.Single(endpoint.ResponseExamples);
+            Assert.Equal(201, responseExample.StatusCode);
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> widgetsPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/widgets"]);
+            IDictionary<string, object?> postOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(widgetsPath["post"]);
+            Assert.True(postOperation.ContainsKey("requestBody"));
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
     public async Task CrawlAsync_IncludeStructuredJson_StripsQueryStringsAndPreservesCookieParameters() {
         Dictionary<string, string> responses = new() {
             ["/docs/session/get"] = """
@@ -1154,6 +1209,57 @@ public class HtmlCrawlerStructuredJsonTests {
             List<object> parameters = Assert.IsAssignableFrom<List<object>>(getOperation["parameters"]);
             IDictionary<string, object?> strictCookieParameter = Assert.IsAssignableFrom<IDictionary<string, object?>>(Assert.Single(parameters));
             Assert.Equal("session_id", strictCookieParameter["name"] as string);
+            Assert.Equal("cookie", strictCookieParameter["in"] as string);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_InfersCookieLocationFromTableHeading() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/session/delete"] = """
+            <html>
+              <head>
+                <title>Delete session</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Delete session</h1>
+                  <h2>DELETE /v1/session</h2>
+                  <h3>Cookie parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>session_id</td><td>string</td><td>Yes</td><td>Session cookie.</td></tr>
+                  </table>
+                  <h3>Response 204</h3>
+                  <pre><code class="language-http">HTTP/1.1 204 No Content</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/session/delete", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            HtmlCrawlStructuredApiParameter cookieParameter = Assert.Single(endpoint.Parameters);
+            Assert.Equal("cookie", cookieParameter.Location);
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> sessionPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/session"]);
+            IDictionary<string, object?> deleteOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(sessionPath["delete"]);
+            List<object> parameters = Assert.IsAssignableFrom<List<object>>(deleteOperation["parameters"]);
+            IDictionary<string, object?> strictCookieParameter = Assert.IsAssignableFrom<IDictionary<string, object?>>(Assert.Single(parameters));
             Assert.Equal("cookie", strictCookieParameter["in"] as string);
         } finally {
             server.Stop();

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -1053,6 +1053,237 @@ public class HtmlCrawlerStructuredJsonTests {
     }
 
     [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_DoesNotTreatJsonResponsesUnderMethodHeadingsAsRequests() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/users/list"] = """
+            <html>
+              <head>
+                <title>List users</title>
+              </head>
+              <body>
+                <main>
+                  <h1>List users</h1>
+                  <h2>GET /v1/users</h2>
+                  <p>Returns all users.</p>
+                  <pre><code class="language-json">[
+                    { "id": "usr_123", "name": "Ada" }
+                  ]</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/users/list", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredCodeSample sample = Assert.Single(structuredJson.CodeSamples);
+            Assert.Null(sample.Method);
+            Assert.Null(sample.Path);
+
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            Assert.Equal("GET", endpoint.Method);
+            Assert.Equal("/v1/users", endpoint.Path);
+            Assert.Empty(endpoint.RequestExamples);
+            HtmlCrawlStructuredResponseExample responseExample = Assert.Single(endpoint.ResponseExamples);
+            Assert.False(responseExample.IsError);
+            Assert.NotNull(responseExample.JsonBody);
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> usersPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/users"]);
+            IDictionary<string, object?> getOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(usersPath["get"]);
+            Assert.False(getOperation.ContainsKey("requestBody"));
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_StripsQueryStringsAndPreservesCookieParameters() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/session/get"] = """
+            <html>
+              <head>
+                <title>Get session</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Get session</h1>
+                  <h2>GET https://api.example.com/v1/session?expand=user</h2>
+                  <h3>Parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>In</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>session_id</td><td>cookie</td><td>string</td><td>Yes</td><td>Session cookie.</td></tr>
+                  </table>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">{ "id": "sess_123" }</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/session/get", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            Assert.Equal("/v1/session", endpoint.Path);
+            HtmlCrawlStructuredApiParameter cookieParameter = Assert.Single(endpoint.Parameters);
+            Assert.Equal("cookie", cookieParameter.Location);
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            Assert.True(paths.ContainsKey("/v1/session"));
+            Assert.False(paths.ContainsKey("/v1/session?expand=user"));
+            IDictionary<string, object?> sessionPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/session"]);
+            IDictionary<string, object?> getOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(sessionPath["get"]);
+            List<object> parameters = Assert.IsAssignableFrom<List<object>>(getOperation["parameters"]);
+            IDictionary<string, object?> strictCookieParameter = Assert.IsAssignableFrom<IDictionary<string, object?>>(Assert.Single(parameters));
+            Assert.Equal("session_id", strictCookieParameter["name"] as string);
+            Assert.Equal("cookie", strictCookieParameter["in"] as string);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_MergesResolvedParameterLocationsAndAuthEvidenceAcrossPages() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/widgets/reference"] = """
+            <html>
+              <head>
+                <title>Widget reference</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Widget reference</h1>
+                  <a href="/docs/widgets/auth">Authentication details</a>
+                  <h2>GET /v1/widgets/{id}</h2>
+                  <p>No authentication required.</p>
+                  <h3>Parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>id</td><td>string</td><td>Yes</td><td>Widget identifier.</td></tr>
+                  </table>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">{ "id": "wid_123" }</code></pre>
+                </main>
+              </body>
+            </html>
+            """,
+            ["/docs/widgets/auth"] = """
+            <html>
+              <head>
+                <title>Widget auth</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Widget auth</h1>
+                  <h2>GET /v1/widgets/{id}</h2>
+                  <p>Bearer token required for all requests.</p>
+                  <h3>Parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>In</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>id</td><td>path</td><td>string</td><td>Yes</td><td>Widget identifier.</td></tr>
+                  </table>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">{ "id": "wid_123", "name": "Alpha" }</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/widgets/reference", new HtmlCrawlOptions {
+                MaxDepth = 1,
+                MaxPages = 3,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredOpenApiOperation operation = result.OpenApiLike.Paths["/v1/widgets/{id}"].Operations["get"];
+            Assert.True(operation.Authentication.Required);
+            Assert.Contains("bearer", operation.Authentication.Schemes, StringComparer.OrdinalIgnoreCase);
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> widgetsPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/widgets/{id}"]);
+            IDictionary<string, object?> getOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(widgetsPath["get"]);
+            Assert.True(getOperation.ContainsKey("security"));
+            List<object> parameters = Assert.IsAssignableFrom<List<object>>(getOperation["parameters"]);
+            IDictionary<string, object?> idParameter = Assert.IsAssignableFrom<IDictionary<string, object?>>(Assert.Single(parameters));
+            Assert.Equal("id", idParameter["name"] as string);
+            Assert.Equal("path", idParameter["in"] as string);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_DoesNotCreateStrictRequestBodyForBodylessRequestExamples() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/items/list"] = """
+            <html>
+              <head>
+                <title>List items</title>
+              </head>
+              <body>
+                <main>
+                  <h1>List items</h1>
+                  <h2>GET /v1/items</h2>
+                  <pre><code class="language-http">GET /v1/items HTTP/1.1
+                  Host: api.example.com
+                  Accept: application/json</code></pre>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">[{ "id": "itm_123" }]</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/items/list", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            HtmlCrawlStructuredRequestExample requestExample = Assert.Single(endpoint.RequestExamples);
+            Assert.True(string.IsNullOrWhiteSpace(requestExample.Body));
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> itemsPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/items"]);
+            IDictionary<string, object?> getOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(itemsPath["get"]);
+            Assert.False(getOperation.ContainsKey("requestBody"));
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
     public async Task CrawlAsync_DatasetScenario_AutoPreset_ResolvesProductPages() {
         Dictionary<string, string> responses = new() {
             ["/products/widget"] = """

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -1036,6 +1036,10 @@ public class HtmlCrawlerStructuredJsonTests {
             HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
             Assert.Equal("GET", endpoint.Method);
             Assert.Equal("/", endpoint.Path);
+            HtmlCrawlStructuredRequestExample requestExample = Assert.Single(endpoint.RequestExamples);
+            Assert.Equal("GET", requestExample.Method);
+            Assert.Equal("/", requestExample.Path);
+            Assert.True(string.IsNullOrWhiteSpace(requestExample.Body));
 
             Assert.True(structuredJson.OpenApiLike.Paths.ContainsKey("/"));
             Assert.True(result.OpenApiLike.Paths.ContainsKey("/"));

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -1,0 +1,1033 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlCrawlerStructuredJsonTests {
+    private static int GetFreePort() {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static HttpListener StartServer(Dictionary<string, string> responses, out string rootUrl) {
+        int port = GetFreePort();
+        rootUrl = $"http://localhost:{port}/";
+        HttpListener listener = new();
+        listener.Prefixes.Add(rootUrl);
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    if (responses.TryGetValue(key, out string? html)) {
+                        byte[] data = Encoding.UTF8.GetBytes(html);
+                        context.Response.ContentType = "text/html; charset=utf-8";
+                        context.Response.ContentLength64 = data.Length;
+                        await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    } else {
+                        context.Response.StatusCode = 404;
+                    }
+
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        return listener;
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_PopulatesStructuredJsonAndPersistsFiles() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+            <html lang="en">
+              <head>
+                <title>Example</title>
+                <link rel="canonical" href="/canonical-page">
+                <meta name="description" content="Example page">
+                <meta name="author" content="Jane Doe">
+                <meta name="keywords" content="example, structured, crawl">
+                <meta property="og:title" content="OG Example">
+                <meta property="og:site_name" content="Example Docs">
+                <meta property="og:type" content="article">
+                <meta property="og:image" content="https://cdn.example.com/image.png">
+              </head>
+              <body>
+                <header class="site-header">
+                  <nav class="site-navigation" aria-label="Main menu">
+                    <a href="/home">Home</a>
+                    <a href="/docs">Docs</a>
+                  </nav>
+                </header>
+                <nav class="breadcrumbs" aria-label="Breadcrumb">
+                  <a href="/docs">Docs</a>
+                  <span aria-current="page">Example page</span>
+                </nav>
+                <div itemscope itemtype="https://schema.org/Article">
+                  <span itemprop="headline">Structured headline</span>
+                </div>
+                <main>
+                  <h1>Example page</h1>
+                  <div class="callout note">
+                    <strong>Note</strong>
+                    <p>Important offline behavior note.</p>
+                  </div>
+                  <a class="button primary" href="/install">Install now</a>
+                  <ul><li>One</li><li>Two</li></ul>
+                  <pre><code class="language-csharp">Write-Host "hello"</code></pre>
+                  <h2>POST /v1/widgets</h2>
+                  <p>Create a widget with a JSON body.</p>
+                  <p>Authenticate with your API key using the X-API-Key header. Rate limit: 60 requests per minute. Exceeding the quota returns 429 with Retry-After.</p>
+                  <h3>Headers</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Example</th><th>Description</th></tr>
+                    <tr><td>X-API-Key</td><td>string</td><td>Yes</td><td>sk_live_123</td><td>API key used for authentication.</td></tr>
+                  </table>
+                  <h3>Request body parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Nullable</th><th>Format</th><th>Enum</th><th>Example</th><th>Pattern</th><th>Description</th></tr>
+                    <tr><td>name</td><td>string</td><td>Yes</td><td>No</td><td>slug</td><td>alpha,beta</td><td>alpha</td><td>^[a-z]+$</td><td>Widget slug. One of: alpha, beta.</td></tr>
+                  </table>
+                  <pre><code class="language-http">POST /v1/widgets HTTP/1.1
+                  Content-Type: application/json
+
+                  { "name": "Alpha" }</code></pre>
+                  <h3>Response 201</h3>
+                  <pre><code class="language-json">{
+                  "id": "wid_123",
+                  "name": "Alpha",
+                  "meta": {
+                    "createdAt": "2026-03-15T10:00:00Z"
+                  },
+                  "tags": ["alpha", "beta"]
+                  }</code></pre>
+                  <h3>Error 429</h3>
+                  <pre><code class="language-http">HTTP/1.1 429 Too Many Requests
+                  Retry-After: 60
+                  X-RateLimit-Remaining: 0
+                  Content-Type: application/json
+
+                  {
+                  "error": "rate_limited",
+                  "details": {
+                    "retryAfterSeconds": 60
+                  }
+                  }</code></pre>
+                  <details>
+                    <summary>What is this page?</summary>
+                    <p>An example FAQ answer.</p>
+                  </details>
+                  <table>
+                    <tr><th>Name</th><th>Value</th></tr>
+                    <tr><td>Alpha</td><td>1</td></tr>
+                  </table>
+                  <form action="/submit" method="post">
+                    <input type="text" name="user" />
+                  </form>
+                </main>
+                <footer class="site-footer">
+                  <a href="/privacy">Privacy</a>
+                  <span>Copyright 2026</span>
+                </footer>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.NotNull(page.StructuredJson);
+            Assert.Equal(7, page.StructuredJson!.MetaTags.Count);
+            Assert.Equal(4, page.StructuredJson.OpenGraph.Properties.Count);
+            Assert.Single(page.StructuredJson.MicrodataItems);
+            Assert.Single(page.StructuredJson.Forms);
+            Assert.Single(page.StructuredJson.Lists);
+            Assert.Equal(3, page.StructuredJson.Tables.Count);
+            Assert.Equal(4, page.StructuredJson.CodeBlocks.Count);
+            Assert.Equal(4, page.StructuredJson.CodeSamples.Count);
+            Assert.Single(page.StructuredJson.Breadcrumbs);
+            Assert.Single(page.StructuredJson.FaqItems);
+            Assert.Single(page.StructuredJson.SpecTables);
+            Assert.Single(page.StructuredJson.Callouts);
+            Assert.Single(page.StructuredJson.PrimaryActions);
+            Assert.Single(page.StructuredJson.ApiEndpoints);
+            Assert.Equal(rootUrl, page.StructuredJson.Document.Url);
+            Assert.Equal("Example", page.StructuredJson.Document.Title);
+            Assert.Equal(0, page.StructuredJson.Document.Depth);
+            Assert.Contains("Example page", page.StructuredJson.Document.Text, StringComparison.Ordinal);
+            Assert.DoesNotContain("Home", page.StructuredJson.Document.Text, StringComparison.Ordinal);
+            Assert.DoesNotContain("Copyright", page.StructuredJson.Document.Text, StringComparison.Ordinal);
+            Assert.Contains("# Example page", page.StructuredJson.Document.Markdown, StringComparison.Ordinal);
+            Assert.Contains("One", page.StructuredJson.Document.Markdown, StringComparison.Ordinal);
+            Assert.Contains("example", page.StructuredJson.Document.Keywords, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("Example page", page.StructuredJson.Document.Headings, StringComparer.Ordinal);
+            Assert.Contains("Structured headline", page.StructuredJson.MicrodataItems[0].Properties["headline"], StringComparer.Ordinal);
+            Assert.Equal(page.StructuredJson.Document.WordCount, page.StructuredJson.Content.WordCount);
+            Assert.Equal(page.StructuredJson.Document.Summary, page.StructuredJson.Content.Summary);
+            Assert.Equal("Example page", page.StructuredJson.Metadata.Description);
+            Assert.Equal(rootUrl + "canonical-page", page.StructuredJson.Metadata.CanonicalUrl);
+            Assert.Equal("en", page.StructuredJson.Metadata.Language);
+            Assert.Equal("Example Docs", page.StructuredJson.Metadata.SiteName);
+            Assert.Equal("article", page.StructuredJson.Metadata.Type);
+            Assert.Equal("Jane Doe", page.StructuredJson.Metadata.Author);
+            Assert.Equal("https://cdn.example.com/image.png", page.StructuredJson.Metadata.ImageUrl);
+            Assert.Contains("structured", page.StructuredJson.Metadata.Keywords, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(1, page.StructuredJson.Layout.HeaderCount);
+            Assert.Equal(1, page.StructuredJson.Layout.NavigationCount);
+            Assert.Equal(1, page.StructuredJson.Layout.MainCount);
+            Assert.Equal(1, page.StructuredJson.Layout.FooterCount);
+            Assert.Contains(page.StructuredJson.Layout.Regions, region => string.Equals(region.Kind, "Navigation", StringComparison.OrdinalIgnoreCase) && region.LinkLabels.Contains("Home"));
+            Assert.Contains(page.StructuredJson.Layout.Regions, region => string.Equals(region.Kind, "Footer", StringComparison.OrdinalIgnoreCase) && region.Summary.Contains("Copyright", StringComparison.Ordinal));
+            Assert.Contains(page.StructuredJson.CodeBlocks, block => string.Equals(block.Language, "csharp", StringComparison.OrdinalIgnoreCase) && block.Code.Contains("Write-Host", StringComparison.Ordinal));
+            Assert.Contains(page.StructuredJson.CodeSamples, sample => string.Equals(sample.Kind, "http", StringComparison.OrdinalIgnoreCase) && string.Equals(sample.Method, "POST", StringComparison.OrdinalIgnoreCase) && string.Equals(sample.Path, "/v1/widgets", StringComparison.Ordinal));
+            Assert.Equal("POST", page.StructuredJson.ApiEndpoints[0].Method);
+            Assert.Equal("/v1/widgets", page.StructuredJson.ApiEndpoints[0].Path);
+            Assert.Contains("Create a widget", page.StructuredJson.ApiEndpoints[0].Description, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("postWidgets", page.StructuredJson.ApiEndpoints[0].OperationId);
+            Assert.Equal("widgets", page.StructuredJson.ApiEndpoints[0].Resource);
+            Assert.Contains("widgets", page.StructuredJson.ApiEndpoints[0].Tags, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(2, page.StructuredJson.ApiEndpoints[0].Parameters.Count);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].Parameters, parameter => string.Equals(parameter.Name, "name", StringComparison.Ordinal) && string.Equals(parameter.Location, "body", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].Parameters, parameter => string.Equals(parameter.Name, "X-API-Key", StringComparison.Ordinal) && string.Equals(parameter.Location, "header", StringComparison.OrdinalIgnoreCase));
+            HtmlCrawlStructuredApiParameter nameParameter = page.StructuredJson.ApiEndpoints[0].Parameters.First(parameter => string.Equals(parameter.Name, "name", StringComparison.Ordinal));
+            Assert.Equal("slug", nameParameter.Format);
+            Assert.False(nameParameter.Nullable ?? true);
+            Assert.Equal("alpha", nameParameter.ExampleValue);
+            Assert.Equal("^[a-z]+$", nameParameter.Pattern);
+            Assert.Contains("alpha", nameParameter.EnumValues, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("beta", nameParameter.EnumValues, StringComparer.OrdinalIgnoreCase);
+            HtmlCrawlStructuredApiParameter apiKeyParameter = page.StructuredJson.ApiEndpoints[0].Parameters.First(parameter => string.Equals(parameter.Name, "X-API-Key", StringComparison.Ordinal));
+            Assert.Equal("sk_live_123", apiKeyParameter.ExampleValue);
+            Assert.Empty(page.StructuredJson.ApiEndpoints[0].PathParameters);
+            Assert.Empty(page.StructuredJson.ApiEndpoints[0].QueryParameters);
+            Assert.Single(page.StructuredJson.ApiEndpoints[0].HeaderParameters);
+            Assert.Single(page.StructuredJson.ApiEndpoints[0].BodyParameters);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].RequestBodySchema["name"]);
+            Assert.Single(page.StructuredJson.ApiEndpoints[0].RequestBodyFields);
+            Assert.Equal("name", page.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].Path);
+            Assert.Equal("slug", page.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].Format);
+            Assert.Equal("alpha", page.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].ExampleValue);
+            Assert.True(page.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].ConfidenceScore > 0);
+            Assert.True(page.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].EvidenceCount > 0);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].RequestBodyFields[0].Provenance, entry => string.Equals(entry.Kind, "ParameterTable", StringComparison.OrdinalIgnoreCase) && string.Equals(entry.PageUrl, page.Url, StringComparison.OrdinalIgnoreCase) && string.Equals(entry.Label, "name", StringComparison.Ordinal));
+            Assert.True(page.StructuredJson.ApiEndpoints[0].Authentication.Required ?? false);
+            Assert.Contains("api-key", page.StructuredJson.ApiEndpoints[0].Authentication.Schemes, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("X-API-Key", page.StructuredJson.ApiEndpoints[0].Authentication.Headers, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("Authenticate with your API key", page.StructuredJson.ApiEndpoints[0].Authentication.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.True(page.StructuredJson.ApiEndpoints[0].RateLimit.Mentioned);
+            Assert.Equal(429, page.StructuredJson.ApiEndpoints[0].RateLimit.StatusCode);
+            Assert.Equal("60 requests per minute", page.StructuredJson.ApiEndpoints[0].RateLimit.Limit);
+            Assert.Equal("minute", page.StructuredJson.ApiEndpoints[0].RateLimit.Window);
+            Assert.Contains("Retry-After", page.StructuredJson.ApiEndpoints[0].RateLimit.Headers, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("Rate limit", page.StructuredJson.ApiEndpoints[0].RateLimit.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(page.StructuredJson.ApiEndpoints[0].RequestExamples);
+            Assert.Equal("POST", page.StructuredJson.ApiEndpoints[0].RequestExamples[0].Method);
+            Assert.Equal("/v1/widgets", page.StructuredJson.ApiEndpoints[0].RequestExamples[0].Path);
+            Assert.Equal("application/json", page.StructuredJson.ApiEndpoints[0].RequestExamples[0].ContentType);
+            Assert.Contains("\"name\": \"Alpha\"", page.StructuredJson.ApiEndpoints[0].RequestExamples[0].Body, StringComparison.Ordinal);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].RequestHeaders, header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase) && string.Equals(header.Value, "application/json", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].RequestHeaders, header => string.Equals(header.Name, "X-API-Key", StringComparison.OrdinalIgnoreCase) && string.Equals(header.Value, "sk_live_123", StringComparison.Ordinal));
+            Assert.Equal(2, page.StructuredJson.ApiEndpoints[0].ResponseExamples.Count);
+            Assert.Single(page.StructuredJson.ApiEndpoints[0].ErrorResponses);
+            Assert.Equal(429, page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].StatusCode);
+            Assert.Equal("Too Many Requests", page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].StatusText);
+            Assert.True(page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].IsError);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].Headers, header => string.Equals(header.Name, "Retry-After", StringComparison.OrdinalIgnoreCase) && string.Equals(header.Value, "60", StringComparison.Ordinal));
+            Assert.Contains("\"error\"", page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].Body, StringComparison.Ordinal);
+            Assert.Single(page.StructuredJson.ApiEndpoints[0].ErrorCatalog);
+            Assert.Equal(429, page.StructuredJson.ApiEndpoints[0].ErrorCatalog[0].StatusCode);
+            Assert.Equal("Too Many Requests", page.StructuredJson.ApiEndpoints[0].ErrorCatalog[0].StatusText);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ErrorCatalog[0].Headers, header => string.Equals(header.Name, "Retry-After", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ErrorCatalog[0].Schema["error"]);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ErrorCatalog[0].Fields, field => string.Equals(field.Path, "details", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseHeaders, header => string.Equals(header.Name, "Retry-After", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseHeaders, header => string.Equals(header.Name, "X-RateLimit-Remaining", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples, response => response.StatusCode == 201 && response.ContentType == "application/json" && response.Body.Contains("\"id\"", StringComparison.Ordinal));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples, response => response.StatusCode == 201 && response.TopLevelKeys.Contains("id") && response.TopLevelKeys.Contains("name"));
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodySchema["id"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodySchema["name"]);
+            Assert.Equal("object", page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodySchema["meta"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodySchema["meta.createdAt"]);
+            Assert.Equal("array", page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodySchema["tags"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodySchema["tags[]"]);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields, field => string.Equals(field.Path, "id", StringComparison.Ordinal) && string.Equals(field.ExampleValue, "wid_123", StringComparison.Ordinal));
+            Assert.True(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields.First(field => string.Equals(field.Path, "id", StringComparison.Ordinal)).ConfidenceScore > 0);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields.First(field => string.Equals(field.Path, "id", StringComparison.Ordinal)).Provenance, entry => string.Equals(entry.Kind, "JsonResponse", StringComparison.OrdinalIgnoreCase) && string.Equals(entry.PageUrl, page.Url, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields, field => string.Equals(field.Path, "meta", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields, field => string.Equals(field.Path, "meta.createdAt", StringComparison.Ordinal) && string.Equals(field.ParentPath, "meta", StringComparison.Ordinal));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields, field => string.Equals(field.Path, "tags", StringComparison.Ordinal) && string.Equals(field.Kind, "array", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ResponseExamples.First(response => response.StatusCode == 201).BodyFields, field => string.Equals(field.Path, "tags[]", StringComparison.Ordinal) && string.Equals(field.ParentPath, "tags", StringComparison.Ordinal));
+            Assert.Equal("application/json", page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].ContentType);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].BodySchema["error"]);
+            Assert.Equal("object", page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].BodySchema["details"]);
+            Assert.Equal("integer", page.StructuredJson.ApiEndpoints[0].ErrorResponses[0].BodySchema["details.retryAfterSeconds"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].SuccessResponseSchema["id"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].SuccessResponseSchema["name"]);
+            Assert.Equal("object", page.StructuredJson.ApiEndpoints[0].SuccessResponseSchema["meta"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].SuccessResponseSchema["meta.createdAt"]);
+            Assert.Equal("array", page.StructuredJson.ApiEndpoints[0].SuccessResponseSchema["tags"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].SuccessResponseSchema["tags[]"]);
+            Assert.Equal("string", page.StructuredJson.ApiEndpoints[0].ErrorResponseSchema["error"]);
+            Assert.Equal("object", page.StructuredJson.ApiEndpoints[0].ErrorResponseSchema["details"]);
+            Assert.Equal("integer", page.StructuredJson.ApiEndpoints[0].ErrorResponseSchema["details.retryAfterSeconds"]);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].SuccessResponseFields, field => string.Equals(field.Path, "id", StringComparison.Ordinal) && string.Equals(field.Type, "string", StringComparison.OrdinalIgnoreCase));
+            Assert.True(page.StructuredJson.ApiEndpoints[0].SuccessResponseFields.First(field => string.Equals(field.Path, "id", StringComparison.Ordinal)).ConfidenceScore > 0);
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].SuccessResponseFields.First(field => string.Equals(field.Path, "id", StringComparison.Ordinal)).Provenance, entry => string.Equals(entry.Kind, "JsonResponse", StringComparison.OrdinalIgnoreCase) && string.Equals(entry.PageUrl, page.Url, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].SuccessResponseFields, field => string.Equals(field.Path, "meta", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase) && field.ChildPaths.Contains("meta.createdAt"));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].SuccessResponseFields, field => string.Equals(field.Path, "tags", StringComparison.Ordinal) && string.Equals(field.Kind, "array", StringComparison.OrdinalIgnoreCase) && field.ChildPaths.Contains("tags[]"));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ErrorResponseFields, field => string.Equals(field.Path, "error", StringComparison.Ordinal) && string.Equals(field.ExampleValue, "rate_limited", StringComparison.Ordinal));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ErrorResponseFields.First(field => string.Equals(field.Path, "error", StringComparison.Ordinal)).Provenance, entry => string.Equals(entry.Kind, "JsonResponse", StringComparison.OrdinalIgnoreCase) && string.Equals(entry.PageUrl, page.Url, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.StructuredJson.ApiEndpoints[0].ErrorResponseFields, field => string.Equals(field.Path, "details", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(new[] { "Docs", "Example page" }, page.StructuredJson.Breadcrumbs[0].Labels);
+            Assert.Equal("What is this page?", page.StructuredJson.FaqItems[0].Question);
+            Assert.Contains("example FAQ answer", page.StructuredJson.FaqItems[0].Answer, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("Alpha", page.StructuredJson.SpecTables[0].Entries[0].Name);
+            Assert.Equal("1", page.StructuredJson.SpecTables[0].Entries[0].Value);
+            Assert.Equal("note", page.StructuredJson.Callouts[0].Kind);
+            Assert.Contains("offline behavior note", page.StructuredJson.Callouts[0].Text, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("Install now", page.StructuredJson.PrimaryActions[0].Label);
+            Assert.Equal(rootUrl + "install", page.StructuredJson.PrimaryActions[0].Url);
+            Assert.Equal(1, page.StructuredJson.ApiCatalog.OperationCount);
+            Assert.Equal(1, page.StructuredJson.ApiCatalog.PathCount);
+            Assert.Equal(1, page.StructuredJson.ApiCatalog.AuthenticatedOperationCount);
+            Assert.Equal(1, page.StructuredJson.ApiCatalog.RateLimitedOperationCount);
+            Assert.Equal(1, page.StructuredJson.ApiCatalog.ErrorCatalogCount);
+            Assert.Contains("widgets", page.StructuredJson.ApiCatalog.Resources, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("widgets", page.StructuredJson.ApiCatalog.Tags, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("postWidgets", page.StructuredJson.ApiCatalog.OperationIds, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(rootUrl.TrimEnd('/'), page.StructuredJson.OpenApiLike.Servers, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("widgets", page.StructuredJson.OpenApiLike.Tags, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("widgets", page.StructuredJson.OpenApiLike.Resources, StringComparer.OrdinalIgnoreCase);
+            Assert.True(page.StructuredJson.OpenApiLike.Paths.ContainsKey("/v1/widgets"));
+            Assert.True(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations.ContainsKey("post"));
+            Assert.Equal("postWidgets", page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].OperationId);
+            Assert.Equal("widgets", page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].Resource);
+            Assert.True(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].Authentication.Required ?? false);
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].AuthenticationRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RateLimitRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ParametersRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RequestHeadersRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ResponseHeadersRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RequestExamplesRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ResponseExamplesRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ErrorCatalogRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RequestBodySchemaRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RequestBodyFieldsRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].SuccessResponseSchemaRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].SuccessResponseFieldsRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ErrorResponseSchemaRef));
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ErrorResponseFieldsRef));
+            Assert.Equal("string", page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].RequestBodySchema["name"]);
+            Assert.Equal("string", page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].SuccessResponseSchema["id"]);
+            Assert.Equal("string", page.StructuredJson.OpenApiLike.Paths["/v1/widgets"].Operations["post"].ErrorResponseSchema["error"]);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.Schemas);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.FieldSets);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.AuthProfiles);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.RateLimitProfiles);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.ParameterSets);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.RequestHeaderSets);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.ResponseHeaderSets);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.RequestExampleSets);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.ResponseExampleSets);
+            Assert.NotEmpty(page.StructuredJson.OpenApiLike.Components.ErrorCatalogs);
+
+            Assert.False(string.IsNullOrWhiteSpace(page.StructuredJsonPath));
+            Assert.True(File.Exists(page.StructuredJsonPath!));
+            Assert.False(string.IsNullOrWhiteSpace(result.StructuredJsonPagesJsonlPath));
+            Assert.True(File.Exists(result.StructuredJsonPagesJsonlPath!));
+
+            string pageStructuredJson = File.ReadAllText(page.StructuredJsonPath!);
+            Assert.Contains("\"Document\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"Content\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"Metadata\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"Layout\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"CodeBlocks\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"CodeSamples\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ApiEndpoints\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"Breadcrumbs\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"FaqItems\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"SpecTables\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"Callouts\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"PrimaryActions\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ApiCatalog\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"OpenApiLike\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"Authentication\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"RateLimit\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"RequestExamples\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"RequestHeaders\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ErrorResponses\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ErrorCatalog\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ResponseHeaders\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"SuccessResponseSchema\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ErrorResponseSchema\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"RequestBodyFields\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"SuccessResponseFields\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("\"ErrorResponseFields\"", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("Example page", pageStructuredJson, StringComparison.Ordinal);
+            Assert.Contains("OG Example", pageStructuredJson, StringComparison.Ordinal);
+
+            string structuredPagesJsonl = File.ReadAllText(result.StructuredJsonPagesJsonlPath!);
+            Assert.Contains("\"StructuredJson\"", structuredPagesJsonl, StringComparison.Ordinal);
+            Assert.Equal(1, result.Summary.StructuredAuthenticatedApiEndpointCount);
+            Assert.Equal(1, result.Summary.StructuredRateLimitedApiEndpointCount);
+            Assert.Equal(1, result.Summary.StructuredApiErrorResponseCount);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_DatasetScenario_EnablesMarkdownAndStructuredJsonWithoutExplicitFlags() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+            <html>
+              <head><title>Dataset</title></head>
+              <body>
+                <main>
+                  <h1>Dataset page</h1>
+                  <p>Enough content for reader-mode dataset defaults to keep a useful offline representation.</p>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Scenario = HtmlCrawlScenario.Dataset,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Equal(HtmlCrawlScenario.Dataset, page.AppliedScenario);
+            Assert.False(string.IsNullOrWhiteSpace(page.Markdown));
+            Assert.NotNull(page.StructuredJson);
+            Assert.Contains("Dataset page", page.StructuredJson!.Document.Text, StringComparison.Ordinal);
+            Assert.Contains("# Dataset page", page.StructuredJson.Document.Markdown, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_DocsPreset_PopulatesFlattenedPresetFields() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/getting-started"] = """
+            <html>
+              <head>
+                <title>Getting Started | Example Docs</title>
+                <meta name="description" content="Install and run the example tool.">
+              </head>
+              <body>
+                <header>
+                  <nav aria-label="Primary">
+                    <a href="/docs">Docs</a>
+                    <a href="/docs/getting-started">Getting Started</a>
+                    <a href="/docs/reference">Reference</a>
+                    <a href="/blog">Blog</a>
+                  </nav>
+                </header>
+                <nav class="breadcrumbs" aria-label="Breadcrumb">
+                  <a href="/docs">Docs</a>
+                  <a href="/docs/getting-started">Getting Started</a>
+                </nav>
+                <main>
+                  <h1>Getting Started</h1>
+                  <aside class="callout tip">
+                    <strong>Tip</strong>
+                    <p>Use the dataset scenario for AI-ready exports.</p>
+                  </aside>
+                  <p>Run the command below to install the package.</p>
+                  <a class="button primary" href="/docs/install">Install package</a>
+                  <h2>POST /v1/widgets</h2>
+                  <p>Create a widget from your integration.</p>
+                  <p>Send your API key in the X-API-Key header. This endpoint is limited to 60 requests per minute and returns 429 with Retry-After when throttled.</p>
+                  <h3>Headers</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Example</th><th>Description</th></tr>
+                    <tr><td>X-API-Key</td><td>string</td><td>Yes</td><td>sk_live_123</td><td>API key used for authentication.</td></tr>
+                  </table>
+                  <h3>Body parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Nullable</th><th>Format</th><th>Enum</th><th>Example</th><th>Pattern</th><th>Description</th></tr>
+                    <tr><td>name</td><td>string</td><td>Yes</td><td>No</td><td>slug</td><td>alpha,beta</td><td>alpha</td><td>^[a-z]+$</td><td>Widget slug. One of: alpha, beta.</td></tr>
+                  </table>
+                  <pre><code class="language-http">POST /v1/widgets HTTP/1.1
+                  Content-Type: application/json
+
+                  { "name": "Widget" }</code></pre>
+                  <h3>Response 201</h3>
+                  <pre><code class="language-json">{
+                  "id": "wid_456",
+                  "name": "Widget",
+                  "meta": {
+                    "createdAt": "2026-03-15T10:00:00Z"
+                  },
+                  "tags": ["alpha", "beta"]
+                  }</code></pre>
+                  <h3>Error 429</h3>
+                  <pre><code class="language-http">HTTP/1.1 429 Too Many Requests
+                  Retry-After: 60
+                  X-RateLimit-Remaining: 0
+                  Content-Type: application/json
+
+                  {
+                  "error": "rate_limited",
+                  "details": {
+                    "retryAfterSeconds": 60
+                  }
+                  }</code></pre>
+                  <h2>Install</h2>
+                  <pre><code>dotnet add package HtmlTinkerX</code></pre>
+                  <details>
+                    <summary>Does this work offline?</summary>
+                    <p>Yes. The crawl output stays local.</p>
+                  </details>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/getting-started", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true,
+                StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Docs,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.NotNull(page.StructuredJson);
+            Assert.Equal(HtmlCrawlStructuredJsonPreset.Docs, page.StructuredJson!.ResolvedPreset);
+            Assert.Equal(4, page.StructuredJson.CodeBlocks.Count);
+            Assert.Equal(4, page.StructuredJson.CodeSamples.Count);
+            Assert.Single(page.StructuredJson.Breadcrumbs);
+            Assert.Single(page.StructuredJson.FaqItems);
+            Assert.Single(page.StructuredJson.Callouts);
+            Assert.Single(page.StructuredJson.PrimaryActions);
+            Assert.Single(page.StructuredJson.ApiEndpoints);
+            Assert.Equal("Getting Started | Example Docs", page.StructuredJson.Extracted["title"]);
+            Assert.Equal("Getting Started", page.StructuredJson.Extracted["mainHeading"]);
+            Assert.Equal(4, page.StructuredJson.Extracted["codeBlockCount"]);
+            Assert.Equal(4, page.StructuredJson.Extracted["codeSampleCount"]);
+            Assert.Equal(1, page.StructuredJson.Extracted["apiEndpointCount"]);
+            List<object?> navigationLinks = Assert.IsType<List<object?>>(page.StructuredJson.Extracted["navigationLinks"]);
+            Assert.Contains("Reference", navigationLinks);
+            IList<string> breadcrumbs = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["breadcrumbs"]);
+            Assert.Equal(new object?[] { "Docs", "Getting Started" }, breadcrumbs);
+            IList<HtmlCrawlStructuredCodeSample> codeSamples = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredCodeSample>>(page.StructuredJson.Extracted["codeSamples"]);
+            Assert.Equal(4, codeSamples.Count);
+            IList<HtmlCrawlStructuredApiEndpoint> apiEndpoints = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredApiEndpoint>>(page.StructuredJson.Extracted["apiEndpoints"]);
+            Assert.Single(apiEndpoints);
+            Assert.Equal("postWidgets", apiEndpoints[0].OperationId);
+            Assert.Equal("widgets", apiEndpoints[0].Resource);
+            Assert.Contains("widgets", apiEndpoints[0].Tags, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(2, apiEndpoints[0].Parameters.Count);
+            Assert.Single(apiEndpoints[0].HeaderParameters);
+            Assert.Single(apiEndpoints[0].BodyParameters);
+            Assert.Equal("string", apiEndpoints[0].RequestBodySchema["name"]);
+            Assert.Equal("slug", apiEndpoints[0].BodyParameters[0].Format);
+            Assert.False(apiEndpoints[0].BodyParameters[0].Nullable ?? true);
+            Assert.Equal("alpha", apiEndpoints[0].BodyParameters[0].ExampleValue);
+            Assert.Equal("^[a-z]+$", apiEndpoints[0].BodyParameters[0].Pattern);
+            Assert.Contains("alpha", apiEndpoints[0].BodyParameters[0].EnumValues, StringComparer.OrdinalIgnoreCase);
+            Assert.Single(apiEndpoints[0].RequestBodyFields);
+            Assert.True(apiEndpoints[0].Authentication.Required ?? false);
+            Assert.Contains("api-key", apiEndpoints[0].Authentication.Schemes, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("X-API-Key", apiEndpoints[0].Authentication.Headers, StringComparer.OrdinalIgnoreCase);
+            Assert.True(apiEndpoints[0].RateLimit.Mentioned);
+            Assert.Equal(429, apiEndpoints[0].RateLimit.StatusCode);
+            Assert.Equal("60 requests per minute", apiEndpoints[0].RateLimit.Limit);
+            Assert.Single(apiEndpoints[0].RequestExamples);
+            Assert.Contains(apiEndpoints[0].RequestHeaders, header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(apiEndpoints[0].RequestHeaders, header => string.Equals(header.Name, "X-API-Key", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(2, apiEndpoints[0].ResponseExamples.Count);
+            Assert.Single(apiEndpoints[0].ErrorResponses);
+            Assert.Single(apiEndpoints[0].ErrorCatalog);
+            Assert.Contains(apiEndpoints[0].ResponseHeaders, header => string.Equals(header.Name, "Retry-After", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("string", apiEndpoints[0].SuccessResponseSchema["id"]);
+            Assert.Equal("string", apiEndpoints[0].SuccessResponseSchema["name"]);
+            Assert.Equal("object", apiEndpoints[0].SuccessResponseSchema["meta"]);
+            Assert.Equal("array", apiEndpoints[0].SuccessResponseSchema["tags"]);
+            Assert.Equal("string", apiEndpoints[0].ErrorResponseSchema["error"]);
+            Assert.Equal("object", apiEndpoints[0].ErrorResponseSchema["details"]);
+            Assert.Contains(apiEndpoints[0].SuccessResponseFields, field => string.Equals(field.Path, "meta", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(apiEndpoints[0].SuccessResponseFields, field => string.Equals(field.Path, "tags", StringComparison.Ordinal) && string.Equals(field.Kind, "array", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(apiEndpoints[0].ErrorResponseFields, field => string.Equals(field.Path, "details", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(true, page.StructuredJson.Extracted["authRequired"]);
+            Assert.Equal("postWidgets", page.StructuredJson.Extracted["operationId"]);
+            Assert.Equal("widgets", page.StructuredJson.Extracted["resource"]);
+            IList<string> extractedTags = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["tags"]);
+            Assert.Contains("widgets", extractedTags, StringComparer.OrdinalIgnoreCase);
+            IList<string> apiTags = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["apiTags"]);
+            Assert.Contains("widgets", apiTags, StringComparer.OrdinalIgnoreCase);
+            IList<string> apiResources = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["apiResources"]);
+            Assert.Contains("widgets", apiResources, StringComparer.OrdinalIgnoreCase);
+            IList<string> operationIds = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["operationIds"]);
+            Assert.Contains("postWidgets", operationIds, StringComparer.OrdinalIgnoreCase);
+            HtmlCrawlStructuredApiCatalog apiCatalog = Assert.IsType<HtmlCrawlStructuredApiCatalog>(page.StructuredJson.Extracted["apiCatalog"]);
+            Assert.Equal(1, apiCatalog.OperationCount);
+            HtmlCrawlStructuredOpenApiLike openApiLike = Assert.IsType<HtmlCrawlStructuredOpenApiLike>(page.StructuredJson.Extracted["openApiLike"]);
+            Assert.True(openApiLike.Paths.ContainsKey("/v1/widgets"));
+            IDictionary<string, HtmlCrawlStructuredOpenApiPathItem> openApiPaths = Assert.IsAssignableFrom<IDictionary<string, HtmlCrawlStructuredOpenApiPathItem>>(page.StructuredJson.Extracted["openApiPaths"]);
+            Assert.True(openApiPaths.ContainsKey("/v1/widgets"));
+            IList<string> openApiServers = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["openApiServers"]);
+            Assert.Contains(rootUrl.TrimEnd('/'), openApiServers, StringComparer.OrdinalIgnoreCase);
+            IList<string> authenticationSchemes = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["authenticationSchemes"]);
+            Assert.Contains("api-key", authenticationSchemes, StringComparer.OrdinalIgnoreCase);
+            IList<string> authenticationHeaders = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["authenticationHeaders"]);
+            Assert.Contains("X-API-Key", authenticationHeaders, StringComparer.OrdinalIgnoreCase);
+            HtmlCrawlStructuredApiRateLimit rateLimit = Assert.IsType<HtmlCrawlStructuredApiRateLimit>(page.StructuredJson.Extracted["rateLimit"]);
+            Assert.Equal(429, rateLimit.StatusCode);
+            IList<string> rateLimitHeaders = Assert.IsAssignableFrom<IList<string>>(page.StructuredJson.Extracted["rateLimitHeaders"]);
+            Assert.Contains("Retry-After", rateLimitHeaders, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(429, page.StructuredJson.Extracted["rateLimitStatusCode"]);
+            IList<HtmlCrawlStructuredRequestExample> requestExamples = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredRequestExample>>(page.StructuredJson.Extracted["requestExamples"]);
+            Assert.Single(requestExamples);
+            Assert.Equal(1, page.StructuredJson.Extracted["requestExampleCount"]);
+            IList<HtmlCrawlStructuredHttpHeader> requestHeaders = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredHttpHeader>>(page.StructuredJson.Extracted["requestHeaders"]);
+            Assert.Contains(requestHeaders, header => string.Equals(header.Name, "X-API-Key", StringComparison.OrdinalIgnoreCase));
+            IList<HtmlCrawlStructuredHttpHeader> responseHeaders = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredHttpHeader>>(page.StructuredJson.Extracted["responseHeaders"]);
+            Assert.Contains(responseHeaders, header => string.Equals(header.Name, "Retry-After", StringComparison.OrdinalIgnoreCase));
+            IList<HtmlCrawlStructuredResponseExample> errorResponses = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredResponseExample>>(page.StructuredJson.Extracted["errorResponses"]);
+            Assert.Single(errorResponses);
+            Assert.Equal(1, page.StructuredJson.Extracted["errorResponseCount"]);
+            IList<HtmlCrawlStructuredApiError> errorCatalog = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredApiError>>(page.StructuredJson.Extracted["errorCatalog"]);
+            Assert.Single(errorCatalog);
+            Assert.Equal(1, page.StructuredJson.Extracted["errorCatalogCount"]);
+            IDictionary<string, string?> successResponseSchema = Assert.IsAssignableFrom<IDictionary<string, string?>>(page.StructuredJson.Extracted["successResponseSchema"]);
+            Assert.Equal("string", successResponseSchema["id"]);
+            IDictionary<string, string?> errorResponseSchema = Assert.IsAssignableFrom<IDictionary<string, string?>>(page.StructuredJson.Extracted["errorResponseSchema"]);
+            Assert.Equal("string", errorResponseSchema["error"]);
+            IList<HtmlCrawlStructuredField> requestBodyFields = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredField>>(page.StructuredJson.Extracted["requestBodyFields"]);
+            Assert.Single(requestBodyFields);
+            IList<HtmlCrawlStructuredField> successResponseFields = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredField>>(page.StructuredJson.Extracted["successResponseFields"]);
+            Assert.Contains(successResponseFields, field => string.Equals(field.Path, "meta", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            IList<HtmlCrawlStructuredField> errorResponseFields = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredField>>(page.StructuredJson.Extracted["errorResponseFields"]);
+            Assert.Contains(errorResponseFields, field => string.Equals(field.Path, "details", StringComparison.Ordinal) && string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase));
+            IList<HtmlCrawlStructuredFaqItem> faqItems = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredFaqItem>>(page.StructuredJson.Extracted["faqItems"]);
+            Assert.Single(faqItems);
+            Assert.Equal(1, page.StructuredJson.Extracted["calloutCount"]);
+            IList<HtmlCrawlStructuredCallout> callouts = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredCallout>>(page.StructuredJson.Extracted["callouts"]);
+            Assert.Single(callouts);
+            IList<HtmlCrawlStructuredPrimaryAction> primaryActions = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredPrimaryAction>>(page.StructuredJson.Extracted["primaryActions"]);
+            Assert.Single(primaryActions);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_BuildsMergedOpenApiLikeArtifactAcrossPages() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/create-widget"] = """
+            <html>
+              <head>
+                <title>Widget API</title>
+                <meta name="description" content="Widget API reference">
+              </head>
+              <body>
+                <main>
+                  <h1>Widget API</h1>
+                  <p><a href="/docs/list-widgets">List widgets</a></p>
+                  <h2>POST /v1/widgets</h2>
+                  <p>Create a widget.</p>
+                  <p>Authenticate with your API key using the X-API-Key header.</p>
+                  <h3>Headers</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Example</th><th>Description</th></tr>
+                    <tr><td>X-API-Key</td><td>string</td><td>Yes</td><td>sk_live_123</td><td>API key used for authentication.</td></tr>
+                  </table>
+                  <h3>Body parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>name</td><td>string</td><td>Yes</td><td>Name of the widget.</td></tr>
+                  </table>
+                  <pre><code class="language-http">POST /v1/widgets HTTP/1.1
+                  Content-Type: application/json
+
+                  { "name": "Alpha" }</code></pre>
+                  <h3>Response 201</h3>
+                  <pre><code class="language-json">{
+                  "id": "wid_123",
+                  "name": "Alpha"
+                  }</code></pre>
+                  <h3>Error 429</h3>
+                  <pre><code class="language-http">HTTP/1.1 429 Too Many Requests
+                  Retry-After: 60
+                  Content-Type: application/json
+
+                  {
+                  "error": "rate_limited"
+                  }</code></pre>
+                </main>
+              </body>
+            </html>
+            """,
+            ["/docs/list-widgets"] = """
+            <html>
+              <head>
+                <title>Widget API</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Widget API</h1>
+                  <h2>GET /v1/widgets</h2>
+                  <p>List widgets.</p>
+                  <p>Authenticate with your API key using the X-API-Key header.</p>
+                  <h3>Headers</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>X-API-Key</td><td>string</td><td>Yes</td><td>API key used for authentication.</td></tr>
+                  </table>
+                  <pre><code class="language-http">GET /v1/widgets HTTP/1.1
+                  Accept: application/json</code></pre>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">[
+                  { "id": "wid_123", "name": "Alpha" }
+                  ]</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/create-widget", new HtmlCrawlOptions {
+                MaxDepth = 1,
+                MaxPages = 5,
+                Selector = "main",
+                IncludeStructuredJson = true,
+                OutputPath = outputPath
+            });
+
+            Assert.Equal(2, result.Pages.Count);
+            Assert.NotNull(result.OpenApiLike);
+            Assert.Single(result.OpenApiLike.Paths);
+            Assert.True(result.OpenApiLike.Paths.ContainsKey("/v1/widgets"));
+            HtmlCrawlStructuredOpenApiPathItem pathItem = result.OpenApiLike.Paths["/v1/widgets"];
+            Assert.True(pathItem.Operations.ContainsKey("post"));
+            Assert.True(pathItem.Operations.ContainsKey("get"));
+            Assert.Equal("postWidgets", pathItem.Operations["post"].OperationId);
+            Assert.Equal("getWidgets", pathItem.Operations["get"].OperationId);
+            Assert.True(pathItem.Operations["post"].StrictOpenApiEligible);
+            Assert.True(pathItem.Operations["get"].StrictOpenApiEligible);
+            Assert.True(pathItem.Operations["post"].StrictOpenApiScore >= result.OpenApiLike.StrictOpenApiPromotionThreshold);
+            Assert.True(pathItem.Operations["get"].StrictOpenApiScore >= result.OpenApiLike.StrictOpenApiPromotionThreshold);
+            Assert.Contains(rootUrl + "docs/create-widget", pathItem.Operations["post"].Provenance.PageUrls, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("Heading", pathItem.Operations["post"].Provenance.SourceKinds, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("CodeSample", pathItem.Operations["post"].Provenance.SourceKinds, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEmpty(pathItem.Operations["post"].Provenance.Entries);
+            Assert.Equal(pathItem.Operations["post"].AuthenticationRef, pathItem.Operations["get"].AuthenticationRef);
+            Assert.Contains("widgets", result.OpenApiLike.Resources, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("widgets", result.OpenApiLike.Tags, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(rootUrl.TrimEnd('/'), result.OpenApiLike.Servers, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(2, result.OpenApiLike.StrictOpenApiEligibleOperationCount);
+            Assert.Equal(0, result.OpenApiLike.StrictOpenApiSkippedOperationCount);
+            Assert.True(result.OpenApiLike.StrictOpenApiAverageScore > 0);
+            Assert.Equal(1, result.Summary.StructuredApiPathCount);
+            Assert.Equal(1, result.Summary.StructuredApiResourceCount);
+            Assert.Equal(2, result.Summary.StructuredOpenApiPromotedOperationCount);
+            Assert.Equal(0, result.Summary.StructuredOpenApiSkippedOperationCount);
+            Assert.True(result.Summary.StructuredOpenApiAveragePromotionScore > 0);
+            Assert.True(result.Summary.StructuredApiSchemaComponentCount > 0);
+            Assert.True(result.Summary.StructuredApiFieldSetComponentCount > 0);
+            Assert.True(result.Summary.StructuredApiAuthProfileCount > 0);
+            Assert.True(result.Summary.StructuredApiRateLimitProfileCount >= 0);
+            Assert.True(result.Summary.StructuredApiParameterSetCount > 0);
+            Assert.True(result.Summary.StructuredApiHeaderSetCount > 0);
+            Assert.True(result.Summary.StructuredApiExampleSetCount > 0);
+            Assert.True(result.Summary.StructuredApiErrorCatalogComponentCount > 0);
+            Assert.NotEmpty(result.OpenApiLike.Components.Schemas);
+            Assert.NotEmpty(result.OpenApiLike.Components.FieldSets);
+            Assert.NotEmpty(result.OpenApiLike.Components.AuthProfiles);
+            Assert.NotEmpty(result.OpenApiLike.Components.ParameterSets);
+            Assert.NotEmpty(result.OpenApiLike.Components.RequestHeaderSets);
+            Assert.NotEmpty(result.OpenApiLike.Components.ResponseHeaderSets);
+            Assert.NotEmpty(result.OpenApiLike.Components.RequestExampleSets);
+            Assert.NotEmpty(result.OpenApiLike.Components.ResponseExampleSets);
+            Assert.NotEmpty(result.OpenApiLike.Components.ErrorCatalogs);
+
+            Assert.False(string.IsNullOrWhiteSpace(result.OpenApiLikePath));
+            Assert.True(File.Exists(result.OpenApiLikePath!));
+            string openApiLikeJson = File.ReadAllText(result.OpenApiLikePath!);
+            Assert.Contains("\"/v1/widgets\"", openApiLikeJson, StringComparison.Ordinal);
+            Assert.Contains("\"post\"", openApiLikeJson, StringComparison.Ordinal);
+            Assert.Contains("\"get\"", openApiLikeJson, StringComparison.Ordinal);
+
+            Assert.False(string.IsNullOrWhiteSpace(result.OpenApiPath));
+            Assert.True(File.Exists(result.OpenApiPath!));
+            Assert.Equal("3.1.0", Assert.IsType<string>(result.OpenApiDocument["openapi"]));
+            Assert.True(result.OpenApiDocument.ContainsKey("components"));
+            Assert.True(result.OpenApiDocument.ContainsKey("x-htmltinkerx-promotion"));
+            string openApiJson = File.ReadAllText(result.OpenApiPath!);
+            Assert.Contains("\"openapi\": \"3.1.0\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"/v1/widgets\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"securitySchemes\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"components\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-provenance\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-sourcePages\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-schemaProvenance\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-fieldProvenance\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-confidence\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-evidenceCount\"", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"x-htmltinkerx-confidenceSummary\"", openApiJson, StringComparison.Ordinal);
+
+            Assert.False(string.IsNullOrWhiteSpace(result.IndexHtmlPath));
+            string indexHtml = File.ReadAllText(result.IndexHtmlPath!);
+            Assert.Contains("OpenAPI JSON", indexHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_KeepsWeakEndpointsInOpenApiLikeButSkipsStrictPromotion() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/mystery-widget"] = """
+            <html>
+              <head>
+                <title>Mystery Widget API</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Mystery Widget API</h1>
+                  <h2>POST /v1/mystery-widgets</h2>
+                  <p>Create a mystery widget.</p>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/mystery-widget", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true,
+                OutputPath = outputPath
+            });
+
+            Assert.NotNull(result.OpenApiLike);
+            Assert.True(result.OpenApiLike.Paths.ContainsKey("/v1/mystery-widgets"));
+            HtmlCrawlStructuredOpenApiOperation operation = result.OpenApiLike.Paths["/v1/mystery-widgets"].Operations["post"];
+            Assert.False(operation.StrictOpenApiEligible);
+            Assert.True(operation.StrictOpenApiWarnings.Count > 0);
+            Assert.Contains(operation.StrictOpenApiWarnings, warning => string.Equals(warning, "missing success response contract", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(rootUrl + "docs/mystery-widget", operation.Provenance.PageUrls, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("Heading", operation.Provenance.SourceKinds, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEmpty(operation.Provenance.Entries);
+            Assert.Equal(0, result.OpenApiLike.StrictOpenApiEligibleOperationCount);
+            Assert.Equal(1, result.OpenApiLike.StrictOpenApiSkippedOperationCount);
+
+            IDictionary<string, object?> strictPaths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            Assert.Empty(strictPaths);
+            Assert.False(string.IsNullOrWhiteSpace(result.OpenApiPath));
+            string openApiJson = File.ReadAllText(result.OpenApiPath!);
+            Assert.Contains("\"paths\": {}", openApiJson, StringComparison.Ordinal);
+            Assert.Contains("\"skippedOperationCount\": 1", openApiJson, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_DatasetScenario_AutoPreset_ResolvesProductPages() {
+        Dictionary<string, string> responses = new() {
+            ["/products/widget"] = """
+            <html>
+              <head>
+                <title>Widget 3000</title>
+                <meta property="og:image" content="https://cdn.example.com/widget.png">
+              </head>
+              <body>
+                <nav class="breadcrumbs" aria-label="Breadcrumb">
+                  <a href="/products">Products</a>
+                  <a href="/products/widget">Widget 3000</a>
+                </nav>
+                <main itemscope itemtype="https://schema.org/Product">
+                  <h1 itemprop="name">Widget 3000</h1>
+                  <div class="price">$19.99</div>
+                  <div class="sku">SKU-3000</div>
+                  <div class="availability">In stock</div>
+                  <button>Add to cart</button>
+                  <table class="specs">
+                    <tr><th>Feature</th><th>Value</th></tr>
+                    <tr><td>Weight</td><td>1kg</td></tr>
+                    <tr><td>Color</td><td>Blue</td></tr>
+                  </table>
+                  <p>Compact widget for offline crawling demos.</p>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "products/widget", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Scenario = HtmlCrawlScenario.Dataset,
+                Selector = "main",
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.NotNull(page.StructuredJson);
+            Assert.Equal(HtmlCrawlStructuredJsonPreset.Product, page.StructuredJson!.ResolvedPreset);
+            Assert.Single(page.StructuredJson.SpecTables);
+            Assert.Single(page.StructuredJson.PrimaryActions);
+            Assert.Equal("Widget 3000", page.StructuredJson.Extracted["name"]);
+            Assert.Equal("$19.99", page.StructuredJson.Extracted["price"]);
+            Assert.Equal("SKU-3000", page.StructuredJson.Extracted["sku"]);
+            Assert.Equal("In stock", page.StructuredJson.Extracted["availability"]);
+            IList<HtmlCrawlStructuredSpecTable> specTables = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredSpecTable>>(page.StructuredJson.Extracted["specTables"]);
+            Assert.Single(specTables);
+            IList<HtmlCrawlStructuredPrimaryAction> primaryActions = Assert.IsAssignableFrom<IList<HtmlCrawlStructuredPrimaryAction>>(page.StructuredJson.Extracted["primaryActions"]);
+            Assert.Single(primaryActions);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_StructuredSchema_ExtractsCallerDefinedFields() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+            <html>
+              <head>
+                <title>Schema Example</title>
+                <meta name="description" content="Schema description">
+              </head>
+              <body>
+                <header>
+                  <nav>
+                    <a href="/home">Home</a>
+                    <a href="/docs">Docs</a>
+                  </nav>
+                </header>
+                <main>
+                  <h1>Schema page</h1>
+                  <p>Schema body.</p>
+                </main>
+                <footer>Footer text</footer>
+              </body>
+            </html>
+            """
+        };
+
+        const string schema = """
+        {
+          "title": "Metadata.Title",
+          "description": "Metadata.Description",
+          "navLinks": {
+            "selector": "nav a",
+            "source": "page",
+            "mode": "text",
+            "all": true
+          },
+          "mainHeading": {
+            "selector": "h1",
+            "source": "selected",
+            "mode": "text"
+          },
+          "firstHeading": "Document.Headings.0",
+          "hasFooter": {
+            "selector": "footer",
+            "source": "page",
+            "mode": "exists"
+          }
+        }
+        """;
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                StructuredJsonSchema = schema,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.NotNull(page.StructuredJson);
+            Assert.Equal("Schema Example", page.StructuredJson!.Extracted["title"]);
+            Assert.Equal("Schema description", page.StructuredJson.Extracted["description"]);
+            List<object?> navLinks = Assert.IsType<List<object?>>(page.StructuredJson.Extracted["navLinks"]);
+            Assert.Equal(new object?[] { "Home", "Docs" }, navLinks);
+            Assert.Equal("Schema page", page.StructuredJson.Extracted["mainHeading"]);
+            Assert.Equal("Schema page", page.StructuredJson.Extracted["firstHeading"]);
+            Assert.Equal(true, page.StructuredJson.Extracted["hasFooter"]);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -897,6 +897,62 @@ public class HtmlCrawlerStructuredJsonTests {
     }
 
     [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_StrictOpenApiInfersPathParametersAndOauth2Schemes() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/widgets/get-widget"] = """
+            <html>
+              <head>
+                <title>Get widget</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Get widget</h1>
+                  <h2>GET /v1/widgets/{id}</h2>
+                  <p>Use OAuth2 access tokens to call this endpoint.</p>
+                  <h3>Parameters</h3>
+                  <table class="parameters">
+                    <tr><th>Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+                    <tr><td>id</td><td>string</td><td>Yes</td><td>Widget identifier.</td></tr>
+                  </table>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">{ "id": "wid_123", "name": "Alpha" }</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/widgets/get-widget", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            IDictionary<string, object?> widgetsPath = Assert.IsAssignableFrom<IDictionary<string, object?>>(paths["/v1/widgets/{id}"]);
+            IDictionary<string, object?> getOperation = Assert.IsAssignableFrom<IDictionary<string, object?>>(widgetsPath["get"]);
+            Assert.False(getOperation.ContainsKey("requestBody"));
+            List<object> parameters = Assert.IsAssignableFrom<List<object>>(getOperation["parameters"]);
+            IDictionary<string, object?> idParameter = Assert.IsAssignableFrom<IDictionary<string, object?>>(Assert.Single(parameters));
+            Assert.Equal("id", idParameter["name"] as string);
+            Assert.Equal("path", idParameter["in"] as string);
+            Assert.True((bool)idParameter["required"]!);
+
+            IDictionary<string, object?> components = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["components"]);
+            IDictionary<string, object?> securitySchemes = Assert.IsAssignableFrom<IDictionary<string, object?>>(components["securitySchemes"]);
+            IDictionary<string, object?> securityScheme = Assert.IsAssignableFrom<IDictionary<string, object?>>(Assert.Single(securitySchemes).Value);
+            Assert.Equal("oauth2", securityScheme["type"] as string);
+            Assert.True(securityScheme.ContainsKey("flows"));
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
     public async Task CrawlAsync_DatasetScenario_AutoPreset_ResolvesProductPages() {
         Dictionary<string, string> responses = new() {
             ["/products/widget"] = """

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -953,6 +953,52 @@ public class HtmlCrawlerStructuredJsonTests {
     }
 
     [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_CurlSamplesPreferCommandTargetOverPayloadUrls() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/webhooks/create"] = """
+            <html>
+              <head>
+                <title>Create webhook</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Create webhook</h1>
+                  <pre><code class="language-bash">curl -X POST -H 'Referer: https://docs.example.com/reference' -H 'Content-Type: application/json' -d '{"callback":"https://hooks.example.com/incoming"}' https://api.example.com/v1/webhooks</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/webhooks/create", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredCodeSample sample = Assert.Single(structuredJson.CodeSamples);
+            Assert.Equal("POST", sample.Method);
+            Assert.Equal("/v1/webhooks", sample.Path);
+
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            Assert.Equal("POST", endpoint.Method);
+            Assert.Equal("/v1/webhooks", endpoint.Path);
+
+            HtmlCrawlStructuredRequestExample requestExample = Assert.Single(endpoint.RequestExamples);
+            Assert.Equal("POST", requestExample.Method);
+            Assert.Equal("/v1/webhooks", requestExample.Path);
+            Assert.Contains("https://hooks.example.com/incoming", requestExample.Body, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
     public async Task CrawlAsync_DatasetScenario_AutoPreset_ResolvesProductPages() {
         Dictionary<string, string> responses = new() {
             ["/products/widget"] = """

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -999,6 +999,56 @@ public class HtmlCrawlerStructuredJsonTests {
     }
 
     [Fact]
+    public async Task CrawlAsync_IncludeStructuredJson_DetectsRootPathEndpoints() {
+        Dictionary<string, string> responses = new() {
+            ["/docs/root"] = """
+            <html>
+              <head>
+                <title>Root endpoint</title>
+              </head>
+              <body>
+                <main>
+                  <h1>Root endpoint</h1>
+                  <h2>GET /</h2>
+                  <p>Returns API root metadata.</p>
+                  <pre><code class="language-http">GET / HTTP/1.1
+                  Host: api.example.com
+
+                  </code></pre>
+                  <h3>Response 200</h3>
+                  <pre><code class="language-json">{ "name": "Example API" }</code></pre>
+                </main>
+              </body>
+            </html>
+            """
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl + "docs/root", new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeStructuredJson = true
+            });
+
+            HtmlCrawlStructuredJson structuredJson = Assert.Single(result.Pages).StructuredJson!;
+            HtmlCrawlStructuredApiEndpoint endpoint = Assert.Single(structuredJson.ApiEndpoints);
+            Assert.Equal("GET", endpoint.Method);
+            Assert.Equal("/", endpoint.Path);
+
+            Assert.True(structuredJson.OpenApiLike.Paths.ContainsKey("/"));
+            Assert.True(result.OpenApiLike.Paths.ContainsKey("/"));
+
+            IDictionary<string, object?> paths = Assert.IsAssignableFrom<IDictionary<string, object?>>(result.OpenApiDocument["paths"]);
+            Assert.True(paths.ContainsKey("/"));
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
     public async Task CrawlAsync_DatasetScenario_AutoPreset_ResolvesProductPages() {
         Dictionary<string, string> responses = new() {
             ["/products/widget"] = """

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
@@ -15,6 +15,7 @@ public class HtmlCrawlerTests {
             Password = "secret",
             ProxyUsername = "proxy-user",
             ProxyPassword = "proxy-secret",
+            StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Docs,
             FormLogin = new HtmlFormLogin {
                 LoginUrl = "https://example.com/login",
                 UsernameSelector = "#user",
@@ -55,6 +56,7 @@ public class HtmlCrawlerTests {
         Assert.Equal(2, clone.ClickTexts.Count);
         Assert.Equal(2, clone.DismissSelectors.Count);
         Assert.Equal(2, clone.DismissTexts.Count);
+        Assert.Equal(HtmlCrawlStructuredJsonPreset.Docs, clone.StructuredJsonPreset);
         Assert.NotSame(options.FormLogin, clone.FormLogin);
     }
 
@@ -81,7 +83,7 @@ public class HtmlCrawlerTests {
     }
 
     [Fact]
-    public void HtmlCrawlScenarios_ApplyArchiveAndDocsScenarios_UseIntentDefaults() {
+    public void HtmlCrawlScenarios_ApplyArchiveDocsAndDatasetScenarios_UseIntentDefaults() {
         HtmlCrawlOptions archive = new();
         HtmlCrawlScenarios.Apply(archive, HtmlCrawlScenario.Archive);
         Assert.True(archive.DownloadAssets);
@@ -93,7 +95,19 @@ public class HtmlCrawlerTests {
         Assert.Equal(HtmlCrawlContentMode.Reader, docs.ContentMode);
         Assert.True(docs.CompareContentModes);
         Assert.True(docs.DeduplicatePages);
+        Assert.Equal(HtmlCrawlStructuredJsonPreset.Docs, docs.StructuredJsonPreset);
         Assert.Contains(".theme-doc-toc-desktop", docs.ExcludeSelectors);
+
+        HtmlCrawlOptions dataset = new();
+        HtmlCrawlScenarios.Apply(dataset, HtmlCrawlScenario.Dataset);
+        Assert.Equal(HtmlCrawlContentMode.Reader, dataset.ContentMode);
+        Assert.True(dataset.IncludeMarkdown);
+        Assert.True(dataset.IncludeStructuredJson);
+        Assert.Equal(HtmlCrawlStructuredJsonPreset.Auto, dataset.StructuredJsonPreset);
+        Assert.True(dataset.CompareContentModes);
+        Assert.True(dataset.UseCanonicalUrls);
+        Assert.True(dataset.DeduplicatePages);
+        Assert.Contains(".breadcrumbs", dataset.ExcludeSelectors);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX/Enums/HtmlCrawlStructuredJsonPreset.cs
+++ b/Sources/HtmlTinkerX/Enums/HtmlCrawlStructuredJsonPreset.cs
@@ -1,0 +1,21 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Applies a built-in structured JSON extraction preset on top of the base crawl document model.
+/// </summary>
+public enum HtmlCrawlStructuredJsonPreset {
+    /// <summary>Do not add any preset extracted fields.</summary>
+    None = 0,
+
+    /// <summary>Choose a preset automatically per page using lightweight content heuristics.</summary>
+    Auto = 1,
+
+    /// <summary>Flatten common documentation-page fields such as headings, navigation, and code blocks.</summary>
+    Docs = 2,
+
+    /// <summary>Flatten common article-style fields such as author, dates, lead text, and section headings.</summary>
+    Article = 3,
+
+    /// <summary>Flatten common product-page fields such as price, SKU, availability, and breadcrumbs.</summary>
+    Product = 4
+}

--- a/Sources/HtmlTinkerX/HtmlCrawlScenarios.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawlScenarios.cs
@@ -27,6 +27,9 @@ public static class HtmlCrawlScenarios {
                 if (options.ContentMode == defaults.ContentMode) {
                     options.ContentMode = HtmlCrawlContentMode.Reader;
                 }
+                if (options.StructuredJsonPreset == defaults.StructuredJsonPreset) {
+                    options.StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Article;
+                }
                 if (!options.UseCanonicalUrls && options.UseCanonicalUrls == defaults.UseCanonicalUrls) {
                     options.UseCanonicalUrls = true;
                 }
@@ -64,11 +67,23 @@ public static class HtmlCrawlScenarios {
                 if (!options.DeduplicatePages && options.DeduplicatePages == defaults.DeduplicatePages) {
                     options.DeduplicatePages = true;
                 }
+                if (options.StructuredJsonPreset == defaults.StructuredJsonPreset) {
+                    options.StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Docs;
+                }
                 break;
 
             case HtmlCrawlScenario.Dataset:
                 if (options.ContentMode == defaults.ContentMode) {
                     options.ContentMode = HtmlCrawlContentMode.Reader;
+                }
+                if (!options.IncludeMarkdown && options.IncludeMarkdown == defaults.IncludeMarkdown) {
+                    options.IncludeMarkdown = true;
+                }
+                if (!options.IncludeStructuredJson && options.IncludeStructuredJson == defaults.IncludeStructuredJson) {
+                    options.IncludeStructuredJson = true;
+                }
+                if (options.StructuredJsonPreset == defaults.StructuredJsonPreset) {
+                    options.StructuredJsonPreset = HtmlCrawlStructuredJsonPreset.Auto;
                 }
                 if (!options.CompareContentModes && options.CompareContentModes == defaults.CompareContentModes) {
                     options.CompareContentModes = true;

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -1526,8 +1526,11 @@ public static class HtmlCrawler {
     }
 
     private static object? BuildStrictOpenApiRequestBody(HtmlCrawlStructuredOpenApiOperation operation) {
+        List<HtmlCrawlStructuredRequestExample> bodyExamples = operation.RequestExamples
+            .Where(example => !string.IsNullOrWhiteSpace(example.Body))
+            .ToList();
         bool hasSchema = !string.IsNullOrWhiteSpace(operation.RequestBodyFieldsRef) || !string.IsNullOrWhiteSpace(operation.RequestBodySchemaRef);
-        bool hasExamples = operation.RequestExamples.Count > 0;
+        bool hasExamples = bodyExamples.Count > 0;
         if (!hasSchema && !hasExamples) {
             return null;
         }
@@ -1535,7 +1538,7 @@ public static class HtmlCrawler {
         string contentType = operation.RequestHeaders
             .FirstOrDefault(header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase))
             ?.Value
-            ?? operation.RequestExamples.Select(example => example.ContentType).FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
+            ?? bodyExamples.Select(example => example.ContentType).FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
             ?? "application/json";
 
         Dictionary<string, object?> mediaType = new(StringComparer.OrdinalIgnoreCase);
@@ -1544,7 +1547,7 @@ public static class HtmlCrawler {
             mediaType["schema"] = schema;
         }
 
-        Dictionary<string, object?> examples = BuildStrictOpenApiRequestExamples(operation.RequestExamples);
+        Dictionary<string, object?> examples = BuildStrictOpenApiRequestExamples(bodyExamples);
         if (examples.Count > 0) {
             mediaType["examples"] = examples;
         }
@@ -2606,9 +2609,7 @@ public static class HtmlCrawler {
             string kind = DetectStructuredCodeSampleKind(code, language);
             string? method = null;
             string? path = null;
-            if (!TryParseApiMethodAndPath(code, out method, out path) && !string.IsNullOrWhiteSpace(heading)) {
-                TryParseApiMethodAndPath(heading!, out method, out path);
-            }
+            TryParseApiMethodAndPath(code, out method, out path);
 
             samples.Add(new HtmlCrawlStructuredCodeSample {
                 Title = BuildStructuredCodeSampleTitle(heading, kind, method, path, language),
@@ -3508,11 +3509,16 @@ public static class HtmlCrawler {
         MergeStructuredApiRateLimit(target.RateLimit, source.RateLimit);
 
         foreach (HtmlCrawlStructuredApiParameter parameter in source.Parameters) {
-            if (!target.Parameters.Any(existing =>
-                    string.Equals(existing.Name, parameter.Name, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(existing.Location, parameter.Location, StringComparison.OrdinalIgnoreCase))) {
+            string incomingLocation = ResolveStructuredApiParameterLocation(target.Path, parameter);
+            HtmlCrawlStructuredApiParameter? existing = target.Parameters.FirstOrDefault(current =>
+                string.Equals(current.Name, parameter.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(ResolveStructuredApiParameterLocation(target.Path, current), incomingLocation, StringComparison.OrdinalIgnoreCase));
+            if (existing == null) {
                 target.Parameters.Add(CloneStructuredApiParameter(parameter));
+                continue;
             }
+
+            MergeStructuredApiParameter(existing, parameter);
         }
 
         foreach (HtmlCrawlStructuredHttpHeader header in source.RequestHeaders) {
@@ -4605,7 +4611,10 @@ public static class HtmlCrawler {
     private static void MergeStructuredApiAuthentication(
         HtmlCrawlStructuredApiAuthentication target,
         HtmlCrawlStructuredApiAuthentication source) {
-        if (!target.Required.HasValue && source.Required.HasValue) {
+        bool sourceIndicatesRequired = source.Required == true || source.Schemes.Count > 0 || source.Headers.Count > 0;
+        if (sourceIndicatesRequired) {
+            target.Required = true;
+        } else if (!target.Required.HasValue && source.Required.HasValue) {
             target.Required = source.Required;
         }
 
@@ -4617,6 +4626,28 @@ public static class HtmlCrawler {
         }
 
         target.Summary ??= source.Summary;
+    }
+
+    private static void MergeStructuredApiParameter(
+        HtmlCrawlStructuredApiParameter target,
+        HtmlCrawlStructuredApiParameter source) {
+        target.Type = MergeStructuredTypeValues(target.Type, source.Type);
+        target.Format ??= source.Format;
+        target.Location ??= source.Location;
+        target.Required = target.Required == true || source.Required == true
+            ? true
+            : target.Required ?? source.Required;
+        target.Nullable = target.Nullable == true || source.Nullable == true
+            ? true
+            : target.Nullable ?? source.Nullable;
+        target.Description ??= source.Description;
+        target.DefaultValue ??= source.DefaultValue;
+        target.ExampleValue ??= source.ExampleValue;
+        target.Pattern ??= source.Pattern;
+        target.SelectorHint ??= source.SelectorHint;
+        foreach (string enumValue in source.EnumValues) {
+            AppendDistinct(target.EnumValues, enumValue);
+        }
     }
 
     private static void ApplyStructuredApiParameterGrouping(HtmlCrawlStructuredApiEndpoint endpoint, string pageUrl) {
@@ -4666,7 +4697,7 @@ public static class HtmlCrawler {
     private static string ResolveStructuredApiParameterLocation(string endpointPath, HtmlCrawlStructuredApiParameter parameter) {
         if (!string.IsNullOrWhiteSpace(parameter.Location)) {
             string explicitLocation = parameter.Location!.Trim().ToLowerInvariant();
-            if (explicitLocation is "path" or "query" or "header" or "body") {
+            if (explicitLocation is "path" or "query" or "header" or "cookie" or "body") {
                 return explicitLocation;
             }
         }
@@ -6668,15 +6699,15 @@ public static class HtmlCrawler {
         if (Uri.TryCreate(trimmed, UriKind.Absolute, out Uri? uri)
             && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
                 || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))) {
-            int authorityLength = uri.GetLeftPart(UriPartial.Authority).Length;
-            if (trimmed.Length > authorityLength) {
-                return trimmed.Substring(authorityLength);
-            }
-
-            return "/";
+            return string.IsNullOrWhiteSpace(uri.AbsolutePath) ? "/" : uri.AbsolutePath;
         }
 
-        return trimmed;
+        int queryIndex = trimmed.IndexOfAny(new[] { '?', '#' });
+        if (queryIndex >= 0) {
+            trimmed = trimmed.Substring(0, queryIndex);
+        }
+
+        return string.IsNullOrWhiteSpace(trimmed) ? "/" : trimmed;
     }
 
     private static bool LooksLikeJson(string code) {

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -1,11 +1,14 @@
 using AngleSharp.Dom;
 using Microsoft.Playwright;
+using OfficeIMO.Markdown.Html;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -114,6 +117,9 @@ public static class HtmlCrawler {
         public string SkippedAssetsJsonlPath { get; set; } = string.Empty;
         public string LinksJsonlPath { get; set; } = string.Empty;
         public string AssetsJsonlPath { get; set; } = string.Empty;
+        public string StructuredJsonPagesJsonlPath { get; set; } = string.Empty;
+        public string OpenApiLikeJsonPath { get; set; } = string.Empty;
+        public string OpenApiJsonPath { get; set; } = string.Empty;
         public string ChunksJsonlPath { get; set; } = string.Empty;
         public string GraphJsonPath { get; set; } = string.Empty;
         public string SummaryJsonPath { get; set; } = string.Empty;
@@ -195,6 +201,17 @@ public static class HtmlCrawler {
         "pager"
     };
 
+    private static readonly (string Kind, string Selector)[] StructuredRegionSelectors = {
+        ("Header", "header,[role='banner'],.site-header,.page-header,#header"),
+        ("Navigation", "nav,[role='navigation'],.navbar,.navigation,.site-nav,.site-navigation,.menu,#nav,#menu"),
+        ("Main", "main,[role='main'],#main,#main-content,.main-content,.site-main,#content,.content"),
+        ("Article", "article,[itemtype*='Article'],[itemtype*='BlogPosting']"),
+        ("Aside", "aside,[role='complementary'],.sidebar,.side-nav,.toc,.table-of-contents,.on-this-page"),
+        ("Footer", "footer,[role='contentinfo'],.site-footer,.page-footer,#footer")
+    };
+
+    private const int StrictOpenApiPromotionThreshold = 45;
+
     /// <summary>
     /// Crawls a site starting from the supplied URL.
     /// </summary>
@@ -214,6 +231,10 @@ public static class HtmlCrawler {
 
         HtmlCrawlOptions resolvedOptions = options?.Clone() ?? new HtmlCrawlOptions();
         HtmlCrawlScenarios.Apply(resolvedOptions, resolvedOptions.Scenario);
+        IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema = await LoadStructuredSchemaAsync(resolvedOptions, cancellationToken).ConfigureAwait(false);
+        if (structuredSchema.Count > 0 || resolvedOptions.StructuredJsonPreset != HtmlCrawlStructuredJsonPreset.None) {
+            resolvedOptions.IncludeStructuredJson = true;
+        }
         IReadOnlyList<HtmlCrawlProfile> customProfiles = string.IsNullOrWhiteSpace(resolvedOptions.ProfilePath)
             ? Array.Empty<HtmlCrawlProfile>()
             : await HtmlCrawlProfiles.LoadFromPathAsync(resolvedOptions.ProfilePath!, cancellationToken).ConfigureAwait(false);
@@ -332,13 +353,13 @@ public static class HtmlCrawler {
 
                 HtmlCrawlPage page;
                 if (resolvedOptions.Render) {
-                    FetchedPageData fetchedPage = await FetchRenderedPageAsync(session!, next, resolvedOptions, cancellationToken).ConfigureAwait(false);
+                    FetchedPageData fetchedPage = await FetchRenderedPageAsync(session!, next, resolvedOptions, structuredSchema, cancellationToken).ConfigureAwait(false);
                     page = fetchedPage.Page;
                     page.RenderMode = HtmlCrawlRenderMode.Rendered;
                     page.RenderReasonCode = HtmlCrawlRenderReasonCode.ExplicitRender;
                     page.RenderReason = "Rendered because browser mode was explicitly requested.";
                 } else {
-                    FetchedPageData fetchedPage = await FetchHttpPageAsync(client, next, resolvedOptions, cancellationToken).ConfigureAwait(false);
+                    FetchedPageData fetchedPage = await FetchHttpPageAsync(client, next, resolvedOptions, structuredSchema, cancellationToken).ConfigureAwait(false);
                     page = fetchedPage.Page;
                     if (appliedProfile == null && string.IsNullOrWhiteSpace(resolvedOptions.ProfileName) && resolvedOptions.AutoProfile) {
                         ProfileSelectionDecision inferredProfileDecision = InferAutoProfile(startUri, fetchedPage.RawHtml, page, customProfiles);
@@ -349,7 +370,7 @@ public static class HtmlCrawler {
                             result.AppliedProfileReasonCode = inferredProfileDecision.ReasonCode;
                             result.AppliedProfileReason = inferredProfileDecision.Reason;
                             if (!string.IsNullOrWhiteSpace(fetchedPage.RawHtml)) {
-                                PopulatePageFromHtml(page, fetchedPage.RawHtml!, next.Uri, resolvedOptions);
+                                PopulatePageFromHtml(page, fetchedPage.RawHtml!, next.Uri, resolvedOptions, structuredSchema);
                             }
                         }
                     }
@@ -359,7 +380,7 @@ public static class HtmlCrawler {
                         page.RenderReasonCode = decision.ReasonCode;
                         page.RenderReason = decision.Reason;
                         if (decision.ShouldRender) {
-                            fetchedPage = await FetchRenderedPageAsync(session!, next, resolvedOptions, cancellationToken).ConfigureAwait(false);
+                            fetchedPage = await FetchRenderedPageAsync(session!, next, resolvedOptions, structuredSchema, cancellationToken).ConfigureAwait(false);
                             page = fetchedPage.Page;
                             page.RenderMode = HtmlCrawlRenderMode.AutoRendered;
                             page.RenderReasonCode = decision.ReasonCode;
@@ -417,6 +438,7 @@ public static class HtmlCrawler {
 
             result.PendingPages = SnapshotPendingPages(pending);
             result.Finished = DateTimeOffset.UtcNow;
+            UpdateDerivedResultData(result);
             if (persistSnapshots) {
                 await PersistSnapshotAsync(result, persistencePath, pending, cancellationToken, resolvedOptions).ConfigureAwait(false);
             }
@@ -950,11 +972,15 @@ public static class HtmlCrawler {
         result.SkippedAssetsJsonlPath = artifactPaths.SkippedAssetsJsonlPath;
         result.LinksJsonlPath = artifactPaths.LinksJsonlPath;
         result.AssetsJsonlPath = artifactPaths.AssetsJsonlPath;
+        result.StructuredJsonPagesJsonlPath = artifactPaths.StructuredJsonPagesJsonlPath;
+        result.OpenApiLikePath = artifactPaths.OpenApiLikeJsonPath;
+        result.OpenApiPath = artifactPaths.OpenApiJsonPath;
         result.ChunksJsonlPath = artifactPaths.ChunksJsonlPath;
         result.GraphJsonPath = artifactPaths.GraphJsonPath;
         result.SummaryPath = artifactPaths.SummaryJsonPath;
         result.SummaryTextPath = artifactPaths.SummaryTextPath;
         result.IndexHtmlPath = artifactPaths.IndexHtmlPath;
+        UpdateDerivedResultData(result);
 
         for (int i = 0; i < result.Pages.Count; i++) {
             cancellationToken.ThrowIfCancellationRequested();
@@ -968,6 +994,14 @@ public static class HtmlCrawler {
 
             if (!string.IsNullOrEmpty(page.Text)) {
                 page.TextPath = CombinePathWithinDirectory(artifactPaths.PagesDirectory, $"{slug}.txt");
+            }
+
+            if (!string.IsNullOrEmpty(page.Markdown)) {
+                page.MarkdownPath = CombinePathWithinDirectory(artifactPaths.PagesDirectory, $"{slug}.md");
+            }
+
+            if (page.StructuredJson != null) {
+                page.StructuredJsonPath = CombinePathWithinDirectory(artifactPaths.PagesDirectory, $"{slug}.structured.json");
             }
 
             page.ManifestPath = CombinePathWithinDirectory(artifactPaths.PagesDirectory, $"{slug}.json");
@@ -994,6 +1028,14 @@ public static class HtmlCrawler {
                 await WriteTextAsync(page.TextPath!, page.Text, cancellationToken).ConfigureAwait(false);
             }
 
+            if (!string.IsNullOrEmpty(page.Markdown)) {
+                await WriteTextAsync(page.MarkdownPath!, page.Markdown, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (page.StructuredJson != null) {
+                await WriteTextAsync(page.StructuredJsonPath!, JsonSerializer.Serialize(page.StructuredJson, CreateJsonOptions()), cancellationToken).ConfigureAwait(false);
+            }
+
             await WriteTextAsync(page.ManifestPath!, BuildPageManifestJson(page, result.Assets, localPageMap, assetMap), cancellationToken).ConfigureAwait(false);
         }
 
@@ -1001,7 +1043,7 @@ public static class HtmlCrawler {
 
         StringBuilder pagesJsonl = new();
         StringBuilder pagesCsv = new();
-        pagesCsv.AppendLine("Url,RequestedUrl,CanonicalUrl,ParentUrl,Depth,Status,StatusCode,ContentType,Title,HtmlPath,TextPath,ManifestPath,ContentFingerprint,DuplicateOfUrl,Rendered,RenderMode,RenderReasonCode,RenderReason,AppliedScenario,AppliedProfileName,AppliedProfileReasonCode,AppliedProfileReason,ContentModeUsed,ContentSelectionReasonCode,ContentSelectionReason,ContentElementTag,ContentElementId,ContentElementClasses,ContentElementSelectorHint,ContentSelectionScore,ReaderCandidateCount,ReaderRootElementSelectorHint,ContentComparisonCount,BestContentComparisonMode,BestContentComparisonReasonCode,BestContentComparisonWordCount,RunnerUpContentComparisonMode,BestContentComparisonWordDelta,ContentComparisonDeltaSummary,ContentComparisonPreviewSummary,Started,Finished,DurationMs,LinkCount,AssetCount,InteractionCount,Error");
+        pagesCsv.AppendLine("Url,RequestedUrl,CanonicalUrl,ParentUrl,Depth,Status,StatusCode,ContentType,Title,HtmlPath,TextPath,MarkdownPath,StructuredJsonPath,ManifestPath,ContentFingerprint,DuplicateOfUrl,Rendered,RenderMode,RenderReasonCode,RenderReason,AppliedScenario,AppliedProfileName,AppliedProfileReasonCode,AppliedProfileReason,ContentModeUsed,ContentSelectionReasonCode,ContentSelectionReason,ContentElementTag,ContentElementId,ContentElementClasses,ContentElementSelectorHint,ContentSelectionScore,ReaderCandidateCount,ReaderRootElementSelectorHint,ContentComparisonCount,BestContentComparisonMode,BestContentComparisonReasonCode,BestContentComparisonWordCount,RunnerUpContentComparisonMode,BestContentComparisonWordDelta,ContentComparisonDeltaSummary,ContentComparisonPreviewSummary,Started,Finished,DurationMs,LinkCount,AssetCount,InteractionCount,StructuredTableCount,StructuredListCount,StructuredFormCount,StructuredMicrodataCount,StructuredMetaTagCount,StructuredCodeBlockCount,StructuredCodeSampleCount,StructuredApiEndpointCount,StructuredAuthenticatedApiEndpointCount,StructuredRateLimitedApiEndpointCount,StructuredApiErrorResponseCount,StructuredBreadcrumbCount,StructuredFaqCount,StructuredSpecTableCount,StructuredCalloutCount,StructuredPrimaryActionCount,StructuredHeaderCount,StructuredNavigationCount,StructuredMainCount,StructuredArticleCount,StructuredAsideCount,StructuredFooterCount,Error");
         foreach (HtmlCrawlPage page in result.Pages) {
             cancellationToken.ThrowIfCancellationRequested();
             pagesJsonl.AppendLine(JsonSerializer.Serialize(new {
@@ -1016,6 +1058,8 @@ public static class HtmlCrawler {
                 page.Title,
                 page.HtmlPath,
                 page.TextPath,
+                page.MarkdownPath,
+                page.StructuredJsonPath,
                 page.ManifestPath,
                 page.ContentFingerprint,
                 page.DuplicateOfUrl,
@@ -1051,6 +1095,28 @@ public static class HtmlCrawler {
                 DurationMs = (long)page.Duration.TotalMilliseconds,
                 LinkCount = page.Links.Count,
                 AssetCount = page.AssetUrls.Count,
+                StructuredTableCount = page.StructuredJson?.Tables.Count ?? 0,
+                StructuredListCount = page.StructuredJson?.Lists.Count ?? 0,
+                StructuredFormCount = page.StructuredJson?.Forms.Count ?? 0,
+                StructuredMicrodataCount = page.StructuredJson?.MicrodataItems.Count ?? 0,
+                StructuredMetaTagCount = page.StructuredJson?.MetaTags.Count ?? 0,
+                StructuredCodeBlockCount = page.StructuredJson?.CodeBlocks.Count ?? 0,
+                StructuredCodeSampleCount = page.StructuredJson?.CodeSamples.Count ?? 0,
+                StructuredApiEndpointCount = page.StructuredJson?.ApiEndpoints.Count ?? 0,
+                StructuredAuthenticatedApiEndpointCount = GetStructuredAuthenticatedApiEndpointCount(page.StructuredJson),
+                StructuredRateLimitedApiEndpointCount = GetStructuredRateLimitedApiEndpointCount(page.StructuredJson),
+                StructuredApiErrorResponseCount = GetStructuredApiErrorResponseCount(page.StructuredJson),
+                StructuredBreadcrumbCount = page.StructuredJson?.Breadcrumbs.Count ?? 0,
+                StructuredFaqCount = page.StructuredJson?.FaqItems.Count ?? 0,
+                StructuredSpecTableCount = page.StructuredJson?.SpecTables.Count ?? 0,
+                StructuredCalloutCount = page.StructuredJson?.Callouts.Count ?? 0,
+                StructuredPrimaryActionCount = page.StructuredJson?.PrimaryActions.Count ?? 0,
+                StructuredHeaderCount = page.StructuredJson?.Layout.HeaderCount ?? 0,
+                StructuredNavigationCount = page.StructuredJson?.Layout.NavigationCount ?? 0,
+                StructuredMainCount = page.StructuredJson?.Layout.MainCount ?? 0,
+                StructuredArticleCount = page.StructuredJson?.Layout.ArticleCount ?? 0,
+                StructuredAsideCount = page.StructuredJson?.Layout.AsideCount ?? 0,
+                StructuredFooterCount = page.StructuredJson?.Layout.FooterCount ?? 0,
                 page.Error
             }));
 
@@ -1066,6 +1132,8 @@ public static class HtmlCrawler {
                 EscapeCsv(page.Title),
                 EscapeCsv(page.HtmlPath),
                 EscapeCsv(page.TextPath),
+                EscapeCsv(page.MarkdownPath),
+                EscapeCsv(page.StructuredJsonPath),
                 EscapeCsv(page.ManifestPath),
                 EscapeCsv(page.ContentFingerprint),
                 EscapeCsv(page.DuplicateOfUrl),
@@ -1101,6 +1169,28 @@ public static class HtmlCrawler {
                 EscapeCsv(page.Links.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 EscapeCsv(page.AssetUrls.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 EscapeCsv(page.AppliedInteractions.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Tables.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Lists.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Forms.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.MicrodataItems.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.MetaTags.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.CodeBlocks.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.CodeSamples.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.ApiEndpoints.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv(GetStructuredAuthenticatedApiEndpointCount(page.StructuredJson).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv(GetStructuredRateLimitedApiEndpointCount(page.StructuredJson).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv(GetStructuredApiErrorResponseCount(page.StructuredJson).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Breadcrumbs.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.FaqItems.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.SpecTables.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Callouts.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.PrimaryActions.Count ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Layout.HeaderCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Layout.NavigationCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Layout.MainCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Layout.ArticleCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Layout.AsideCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv((page.StructuredJson?.Layout.FooterCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 EscapeCsv(page.Error)));
         }
 
@@ -1178,6 +1268,18 @@ public static class HtmlCrawler {
             }));
         }
 
+        StringBuilder structuredPagesJsonl = new();
+        foreach (HtmlCrawlPage page in result.Pages.Where(page => page.StructuredJson != null)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            structuredPagesJsonl.AppendLine(JsonSerializer.Serialize(new {
+                page.Url,
+                page.Title,
+                page.Depth,
+                page.StructuredJsonPath,
+                page.StructuredJson
+            }, CreateJsonOptions()));
+        }
+
         List<PageChunkRecord> chunkRecords = BuildChunkRecords(result.Pages);
         result.ChunkCount = chunkRecords.Count;
         StringBuilder chunksJsonl = new();
@@ -1220,6 +1322,9 @@ public static class HtmlCrawler {
         await WriteTextAsync(artifactPaths.SkippedAssetsJsonlPath, skippedAssetsJsonl.ToString(), cancellationToken).ConfigureAwait(false);
         await WriteTextAsync(artifactPaths.LinksJsonlPath, linksJsonl.ToString(), cancellationToken).ConfigureAwait(false);
         await WriteTextAsync(artifactPaths.AssetsJsonlPath, assetsJsonl.ToString(), cancellationToken).ConfigureAwait(false);
+        await WriteTextAsync(artifactPaths.StructuredJsonPagesJsonlPath, structuredPagesJsonl.ToString(), cancellationToken).ConfigureAwait(false);
+        await WriteTextAsync(artifactPaths.OpenApiLikeJsonPath, JsonSerializer.Serialize(result.OpenApiLike, CreateJsonOptions()), cancellationToken).ConfigureAwait(false);
+        await WriteTextAsync(artifactPaths.OpenApiJsonPath, JsonSerializer.Serialize(result.OpenApiDocument, CreateJsonOptions()), cancellationToken).ConfigureAwait(false);
         await WriteTextAsync(artifactPaths.ChunksJsonlPath, chunksJsonl.ToString(), cancellationToken).ConfigureAwait(false);
         await WriteTextAsync(artifactPaths.GraphJsonPath, JsonSerializer.Serialize(graphDocument, CreateJsonOptions()), cancellationToken).ConfigureAwait(false);
         await WriteTextAsync(artifactPaths.SummaryJsonPath, JsonSerializer.Serialize(summary, CreateJsonOptions()), cancellationToken).ConfigureAwait(false);
@@ -1241,6 +1346,345 @@ public static class HtmlCrawler {
         }
 
         return snapshot;
+    }
+
+    private static void UpdateDerivedResultData(HtmlCrawlResult result) {
+        result.OpenApiLike = BuildResultOpenApiLike(result);
+        result.OpenApiDocument = BuildResultOpenApiDocument(result.OpenApiLike, result);
+    }
+
+    private static Dictionary<string, object?> BuildResultOpenApiDocument(HtmlCrawlStructuredOpenApiLike openApiLike, HtmlCrawlResult result) {
+        Dictionary<string, object?> paths = BuildStrictOpenApiPaths(openApiLike);
+        Dictionary<string, object?> document = new(StringComparer.OrdinalIgnoreCase) {
+            ["openapi"] = "3.1.0",
+            ["info"] = new Dictionary<string, object?> {
+                ["title"] = openApiLike.Title ?? "Offline API",
+                ["description"] = openApiLike.Description,
+                ["version"] = "0.0.0-offline"
+            },
+            ["servers"] = openApiLike.Servers.Select(server => new Dictionary<string, object?> {
+                ["url"] = server
+            }).ToList(),
+            ["paths"] = paths
+        };
+
+        Dictionary<string, object?> components = BuildStrictOpenApiComponents(openApiLike);
+        if (components.Count > 0) {
+            document["components"] = components;
+        }
+
+        document["x-htmltinkerx-openApiLikePath"] = result.OpenApiLikePath;
+        document["x-htmltinkerx-startUrl"] = result.StartUrl;
+        document["x-htmltinkerx-operationCount"] = openApiLike.Paths.Values.Sum(path => path.Operations.Count);
+        document["x-htmltinkerx-promotion"] = BuildStrictOpenApiPromotionMetadata(openApiLike, paths);
+        return document;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiPaths(HtmlCrawlStructuredOpenApiLike openApiLike) {
+        Dictionary<string, object?> paths = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, HtmlCrawlStructuredOpenApiPathItem> pathItem in openApiLike.Paths.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+            Dictionary<string, object?> operations = new(StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, HtmlCrawlStructuredOpenApiOperation> operationItem in pathItem.Value.Operations.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                if (!operationItem.Value.StrictOpenApiEligible) {
+                    continue;
+                }
+
+                operations[operationItem.Key] = BuildStrictOpenApiOperation(operationItem.Value);
+            }
+
+            if (operations.Count > 0) {
+                paths[pathItem.Key] = operations;
+            }
+        }
+
+        return paths;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiOperation(HtmlCrawlStructuredOpenApiOperation operation) {
+        Dictionary<string, object?> value = new(StringComparer.OrdinalIgnoreCase) {
+            ["operationId"] = operation.OperationId,
+            ["summary"] = operation.Summary,
+            ["description"] = operation.Description,
+            ["tags"] = operation.Tags
+        };
+
+        List<object> parameters = BuildStrictOpenApiParameters(operation);
+        if (parameters.Count > 0) {
+            value["parameters"] = parameters;
+        }
+
+        object? requestBody = BuildStrictOpenApiRequestBody(operation);
+        if (requestBody != null) {
+            value["requestBody"] = requestBody;
+        }
+
+        value["responses"] = BuildStrictOpenApiResponses(operation);
+
+        if (operation.Authentication.Required != false && !string.IsNullOrWhiteSpace(operation.AuthenticationRef)) {
+            value["security"] = new List<object> {
+                new Dictionary<string, object?> {
+                    [operation.AuthenticationRef!] = Array.Empty<string>()
+                }
+            };
+        }
+
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-resource", operation.Resource);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-rateLimitRef", operation.RateLimitRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-parametersRef", operation.ParametersRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-requestHeadersRef", operation.RequestHeadersRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-responseHeadersRef", operation.ResponseHeadersRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-requestExamplesRef", operation.RequestExamplesRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-responseExamplesRef", operation.ResponseExamplesRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-errorCatalogRef", operation.ErrorCatalogRef);
+        AddStrictOpenApiExtension(value, "x-htmltinkerx-promotionScore", operation.StrictOpenApiScore);
+        if (operation.StrictOpenApiWarnings.Count > 0) {
+            value["x-htmltinkerx-promotionWarnings"] = operation.StrictOpenApiWarnings.ToList();
+        }
+        if (operation.Provenance.PageUrls.Count > 0) {
+            value["x-htmltinkerx-sourcePages"] = operation.Provenance.PageUrls.ToList();
+        }
+        if (operation.Provenance.Entries.Count > 0) {
+            value["x-htmltinkerx-provenance"] = operation.Provenance.Entries
+                .Select(entry => new Dictionary<string, object?> {
+                    ["pageUrl"] = entry.PageUrl,
+                    ["kind"] = entry.Kind,
+                    ["selectorHint"] = entry.SelectorHint,
+                    ["label"] = entry.Label
+                })
+                .ToList();
+        }
+        return value;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiPromotionMetadata(
+        HtmlCrawlStructuredOpenApiLike openApiLike,
+        IReadOnlyDictionary<string, object?> strictPaths) {
+        List<Dictionary<string, object?>> skippedOperations = openApiLike.Paths
+            .SelectMany(path => path.Value.Operations.Values)
+            .Where(operation => !operation.StrictOpenApiEligible)
+            .OrderByDescending(operation => operation.StrictOpenApiScore)
+            .ThenBy(operation => operation.Path, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(operation => operation.Method, StringComparer.OrdinalIgnoreCase)
+            .Select(operation => new Dictionary<string, object?> {
+                ["operationId"] = operation.OperationId,
+                ["method"] = operation.Method,
+                ["path"] = operation.Path,
+                ["score"] = operation.StrictOpenApiScore,
+                ["warnings"] = operation.StrictOpenApiWarnings.ToList()
+            })
+            .ToList();
+
+        return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+            ["threshold"] = openApiLike.StrictOpenApiPromotionThreshold,
+            ["eligibleOperationCount"] = openApiLike.StrictOpenApiEligibleOperationCount,
+            ["skippedOperationCount"] = openApiLike.StrictOpenApiSkippedOperationCount,
+            ["promotedPathCount"] = strictPaths.Count,
+            ["averageScore"] = openApiLike.StrictOpenApiAverageScore,
+            ["skippedOperations"] = skippedOperations
+        };
+    }
+
+    private static List<object> BuildStrictOpenApiParameters(HtmlCrawlStructuredOpenApiOperation operation) {
+        return operation.Parameters
+            .OrderBy(parameter => parameter.Location, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(parameter => {
+                Dictionary<string, object?> value = new(StringComparer.OrdinalIgnoreCase) {
+                    ["name"] = parameter.Name,
+                    ["in"] = NormalizeStrictOpenApiParameterLocation(parameter.Location),
+                    ["required"] = string.Equals(parameter.Location, "path", StringComparison.OrdinalIgnoreCase) || parameter.Required == true,
+                    ["description"] = parameter.Description,
+                    ["schema"] = BuildStrictOpenApiParameterSchema(parameter)
+                };
+
+                if (!string.IsNullOrWhiteSpace(parameter.ExampleValue)) {
+                    value["example"] = ParseStrictOpenApiExampleValue(parameter.ExampleValue);
+                }
+                if (!string.IsNullOrWhiteSpace(parameter.DefaultValue)) {
+                    value["x-htmltinkerx-default"] = parameter.DefaultValue;
+                }
+                return (object)value;
+            })
+            .ToList();
+    }
+
+    private static object BuildStrictOpenApiParameterSchema(HtmlCrawlStructuredApiParameter parameter) {
+        Dictionary<string, object?> schema = new(StringComparer.OrdinalIgnoreCase);
+        ApplyStrictOpenApiType(schema, parameter.Type, parameter.Format);
+        if (parameter.Nullable == true) {
+            schema["nullable"] = true;
+        }
+        if (!string.IsNullOrWhiteSpace(parameter.Pattern)) {
+            schema["pattern"] = parameter.Pattern;
+        }
+        if (parameter.EnumValues.Count > 0) {
+            schema["enum"] = parameter.EnumValues.Cast<object>().ToList();
+        }
+
+        return schema;
+    }
+
+    private static object? BuildStrictOpenApiRequestBody(HtmlCrawlStructuredOpenApiOperation operation) {
+        bool hasSchema = !string.IsNullOrWhiteSpace(operation.RequestBodyFieldsRef) || !string.IsNullOrWhiteSpace(operation.RequestBodySchemaRef);
+        bool hasExamples = operation.RequestExamples.Count > 0;
+        if (!hasSchema && !hasExamples) {
+            return null;
+        }
+
+        string contentType = operation.RequestHeaders
+            .FirstOrDefault(header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+            ?.Value
+            ?? operation.RequestExamples.Select(example => example.ContentType).FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
+            ?? "application/json";
+
+        Dictionary<string, object?> mediaType = new(StringComparer.OrdinalIgnoreCase);
+        object? schema = BuildStrictOpenApiSchemaReference(operation.RequestBodyFieldsRef, operation.RequestBodySchemaRef);
+        if (schema != null) {
+            mediaType["schema"] = schema;
+        }
+
+        Dictionary<string, object?> examples = BuildStrictOpenApiRequestExamples(operation.RequestExamples);
+        if (examples.Count > 0) {
+            mediaType["examples"] = examples;
+        }
+
+        return new Dictionary<string, object?> {
+            ["required"] = operation.Parameters.Any(parameter => string.Equals(parameter.Location, "body", StringComparison.OrdinalIgnoreCase) && parameter.Required == true),
+            ["content"] = new Dictionary<string, object?> {
+                [contentType] = mediaType
+            }
+        };
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiResponses(HtmlCrawlStructuredOpenApiOperation operation) {
+        Dictionary<string, object?> responses = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (IGrouping<string, HtmlCrawlStructuredResponseExample> group in operation.ResponseExamples
+                     .GroupBy(example => GetStrictOpenApiResponseCode(example.StatusCode), StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)) {
+            bool isError = group.Any(example => example.IsError);
+            responses[group.Key] = BuildStrictOpenApiResponse(group.ToList(), isError, operation);
+        }
+
+        if (responses.Count == 0) {
+            responses["default"] = new Dictionary<string, object?> {
+                ["description"] = operation.Description ?? "Documented response"
+            };
+        }
+
+        return responses;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiResponse(
+        IReadOnlyList<HtmlCrawlStructuredResponseExample> examples,
+        bool isError,
+        HtmlCrawlStructuredOpenApiOperation operation) {
+        HtmlCrawlStructuredResponseExample primary = examples[0];
+        Dictionary<string, object?> response = new(StringComparer.OrdinalIgnoreCase) {
+            ["description"] = primary.StatusText ?? primary.Title ?? primary.Description ?? (isError ? "Error response" : "Successful response")
+        };
+
+        Dictionary<string, object?> headers = BuildStrictOpenApiHeaderDefinitions(examples.SelectMany(example => example.Headers));
+        if (headers.Count > 0) {
+            response["headers"] = headers;
+        }
+
+        string? contentType = examples.Select(example => example.ContentType).FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+        object? schema = BuildStrictOpenApiSchemaReference(
+            isError ? operation.ErrorResponseFieldsRef : operation.SuccessResponseFieldsRef,
+            isError ? operation.ErrorResponseSchemaRef : operation.SuccessResponseSchemaRef);
+        Dictionary<string, object?> exampleEntries = BuildStrictOpenApiResponseExamples(examples);
+        if (schema != null || exampleEntries.Count > 0) {
+            Dictionary<string, object?> mediaType = new(StringComparer.OrdinalIgnoreCase);
+            if (schema != null) {
+                mediaType["schema"] = schema;
+            }
+            if (exampleEntries.Count > 0) {
+                mediaType["examples"] = exampleEntries;
+            }
+
+            response["content"] = new Dictionary<string, object?> {
+                [contentType ?? "application/json"] = mediaType
+            };
+        }
+
+        return response;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiComponents(HtmlCrawlStructuredOpenApiLike openApiLike) {
+        Dictionary<string, object?> components = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, object?> securitySchemes = BuildStrictOpenApiSecuritySchemes(openApiLike.Components.AuthProfiles);
+        if (securitySchemes.Count > 0) {
+            components["securitySchemes"] = securitySchemes;
+        }
+
+        Dictionary<string, object?> schemas = BuildStrictOpenApiSchemas(openApiLike.Components);
+        if (schemas.Count > 0) {
+            components["schemas"] = schemas;
+        }
+
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-rateLimitProfiles", openApiLike.Components.RateLimitProfiles);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-parameterSets", openApiLike.Components.ParameterSets);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-requestHeaderSets", openApiLike.Components.RequestHeaderSets);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-responseHeaderSets", openApiLike.Components.ResponseHeaderSets);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-requestExampleSets", openApiLike.Components.RequestExampleSets);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-responseExampleSets", openApiLike.Components.ResponseExampleSets);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-errorCatalogs", openApiLike.Components.ErrorCatalogs);
+        AddStrictOpenApiComponentExtension(components, "x-htmltinkerx-schemaProvenance", BuildStrictOpenApiSchemaComponentProvenance(openApiLike.Components.FieldSets));
+        return components;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiSecuritySchemes(IDictionary<string, HtmlCrawlStructuredApiAuthentication> authProfiles) {
+        Dictionary<string, object?> securitySchemes = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, HtmlCrawlStructuredApiAuthentication> item in authProfiles.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+            Dictionary<string, object?> scheme = new(StringComparer.OrdinalIgnoreCase);
+            string? primaryHeader = item.Value.Headers.FirstOrDefault();
+            if (item.Value.Schemes.Any(schemeName => string.Equals(schemeName, "bearer", StringComparison.OrdinalIgnoreCase))) {
+                scheme["type"] = "http";
+                scheme["scheme"] = "bearer";
+            } else if (item.Value.Schemes.Any(schemeName => string.Equals(schemeName, "basic", StringComparison.OrdinalIgnoreCase))) {
+                scheme["type"] = "http";
+                scheme["scheme"] = "basic";
+            } else {
+                scheme["type"] = "apiKey";
+                scheme["in"] = "header";
+                scheme["name"] = primaryHeader ?? "Authorization";
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.Value.Summary)) {
+                scheme["description"] = item.Value.Summary;
+            }
+            securitySchemes[item.Key] = scheme;
+        }
+
+        return securitySchemes;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiSchemas(HtmlCrawlStructuredOpenApiComponents components) {
+        Dictionary<string, object?> schemas = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, IList<HtmlCrawlStructuredField>> item in components.FieldSets.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+            schemas[item.Key] = BuildStrictOpenApiSchemaFromFields(item.Value);
+        }
+
+        foreach (KeyValuePair<string, IDictionary<string, string?>> item in components.Schemas.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+            if (!schemas.ContainsKey(item.Key)) {
+                schemas[item.Key] = BuildStrictOpenApiSchemaFromFlatMap(item.Value);
+            }
+        }
+
+        return schemas;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiSchemaComponentProvenance(IDictionary<string, IList<HtmlCrawlStructuredField>> fieldSets) {
+        Dictionary<string, object?> provenance = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, IList<HtmlCrawlStructuredField>> item in fieldSets.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+            List<Dictionary<string, object?>> entries = BuildStrictOpenApiFieldProvenance(item.Value.SelectMany(field => field.Provenance));
+            if (entries.Count > 0) {
+                provenance[item.Key] = entries;
+            }
+        }
+
+        return provenance;
     }
 
     private static string BuildPageManifestJson(
@@ -1311,8 +1755,11 @@ public static class HtmlCrawler {
             DurationMs = (long)page.Duration.TotalMilliseconds,
             PageFiles = new {
                 HtmlPath = BuildRelativeOptionalPath(manifestPath, page.HtmlPath),
-                TextPath = BuildRelativeOptionalPath(manifestPath, page.TextPath)
+                TextPath = BuildRelativeOptionalPath(manifestPath, page.TextPath),
+                MarkdownPath = BuildRelativeOptionalPath(manifestPath, page.MarkdownPath),
+                StructuredJsonPath = BuildRelativeOptionalPath(manifestPath, page.StructuredJsonPath)
             },
+            page.StructuredJson,
             Search = new {
                 searchMetadata.WordCount,
                 searchMetadata.CharacterCount,
@@ -1358,10 +1805,290 @@ public static class HtmlCrawler {
         return JsonSerializer.Serialize(manifest, CreateJsonOptions());
     }
 
+    private static HtmlCrawlStructuredJson BuildStructuredJson(
+        HtmlCrawlPage page,
+        string fullHtml,
+        string selectedHtml,
+        string structuredText,
+        string structuredMarkdown,
+        IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema,
+        HtmlCrawlStructuredJsonPreset structuredPreset) {
+        IDocument document = HtmlParser.ParseWithAngleSharp(fullHtml);
+        IDocument selectedDocument = HtmlParser.ParseWithAngleSharp($"<div id=\"__htmltinkerx_structured_selected\">{selectedHtml}</div>");
+        List<HtmlMetaTag> metaTags = HtmlParser.ParseMetaTags(fullHtml);
+        HtmlOpenGraph openGraph = HtmlParser.ParseOpenGraph(fullHtml);
+        HtmlCrawlStructuredMetadata metadata = BuildStructuredMetadata(page, document, metaTags, openGraph);
+        PageSearchMetadata searchMetadata = BuildPageSearchMetadata(selectedHtml, structuredText, structuredMarkdown);
+        List<HtmlTableResult> tables = HtmlParser.ParseTablesWithAngleSharpDetailed(selectedHtml);
+        List<HtmlCrawlStructuredCodeBlock> codeBlocks = BuildStructuredCodeBlocks(selectedDocument);
+        List<HtmlCrawlStructuredCodeSample> codeSamples = BuildStructuredCodeSamples(selectedDocument);
+        List<HtmlCrawlStructuredBreadcrumbTrail> breadcrumbs = BuildStructuredBreadcrumbs(document, page.Url);
+        List<HtmlCrawlStructuredFaqItem> faqItems = BuildStructuredFaqItems(selectedDocument);
+        List<HtmlCrawlStructuredSpecTable> specTables = BuildStructuredSpecTables(selectedDocument, tables);
+        List<HtmlCrawlStructuredCallout> callouts = BuildStructuredCallouts(selectedDocument);
+        List<HtmlCrawlStructuredPrimaryAction> primaryActions = BuildStructuredPrimaryActions(selectedDocument, page.Url);
+        List<HtmlCrawlStructuredApiEndpoint> apiEndpoints = BuildStructuredApiEndpoints(selectedDocument, codeSamples, page.Url);
+        HtmlCrawlStructuredJson structuredJson = new() {
+            Document = BuildStructuredDocument(page, searchMetadata, structuredText, structuredMarkdown),
+            Content = new HtmlCrawlStructuredContent {
+                WordCount = searchMetadata.WordCount,
+                CharacterCount = searchMetadata.CharacterCount,
+                ChunkCount = searchMetadata.ChunkCount,
+                Summary = searchMetadata.Summary,
+                Headings = new List<string>(searchMetadata.Headings),
+                Keywords = new List<string>(searchMetadata.Keywords)
+            },
+            Metadata = metadata,
+            Layout = BuildStructuredLayout(document),
+            MetaTags = metaTags,
+            OpenGraph = openGraph,
+            MicrodataItems = HtmlParser.ParseMicrodataItems(fullHtml),
+            Forms = HtmlParser.ParseFormsWithAngleSharp(fullHtml),
+            Lists = HtmlParser.ParseListsWithAngleSharpDetailed(selectedHtml),
+            Tables = tables,
+            CodeBlocks = codeBlocks,
+            CodeSamples = codeSamples,
+            Breadcrumbs = breadcrumbs,
+            FaqItems = faqItems,
+            SpecTables = specTables,
+            Callouts = callouts,
+            PrimaryActions = primaryActions,
+            ApiEndpoints = apiEndpoints,
+            ApiCatalog = BuildStructuredApiCatalog(metadata, apiEndpoints),
+            OpenApiLike = BuildStructuredOpenApiLike(page, metadata, apiEndpoints)
+        };
+
+        HtmlCrawlStructuredJsonPreset resolvedPreset = ResolveStructuredJsonPreset(structuredJson, document, selectedDocument, structuredPreset);
+        structuredJson.ResolvedPreset = resolvedPreset;
+        IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> effectiveStructuredSchema = BuildEffectiveStructuredSchema(resolvedPreset, structuredSchema);
+        if (effectiveStructuredSchema.Count > 0) {
+            structuredJson.Extracted = BuildStructuredSchemaExtraction(structuredJson, document, selectedDocument, effectiveStructuredSchema);
+        }
+
+        return structuredJson;
+    }
+
+    private static IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> BuildEffectiveStructuredSchema(
+        HtmlCrawlStructuredJsonPreset structuredPreset,
+        IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema) {
+        Dictionary<string, HtmlCrawlJsonSchemaField> effectiveSchema = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, HtmlCrawlJsonSchemaField> field in GetPresetStructuredSchema(structuredPreset)) {
+            effectiveSchema[field.Key] = field.Value;
+        }
+
+        foreach (KeyValuePair<string, HtmlCrawlJsonSchemaField> field in structuredSchema) {
+            effectiveSchema[field.Key] = field.Value;
+        }
+
+        return effectiveSchema;
+    }
+
+    private static IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> GetPresetStructuredSchema(HtmlCrawlStructuredJsonPreset structuredPreset) {
+        Dictionary<string, HtmlCrawlJsonSchemaField> schema = new(StringComparer.OrdinalIgnoreCase);
+        if (structuredPreset == HtmlCrawlStructuredJsonPreset.None) {
+            return schema;
+        }
+
+        void AddPath(string name, string path) {
+            schema[name] = new HtmlCrawlJsonSchemaField {
+                Path = path
+            };
+        }
+
+        void AddSelector(string name, string selector, string source = "selected", string mode = "Text", string? attribute = null, bool all = false) {
+            schema[name] = new HtmlCrawlJsonSchemaField {
+                Selector = selector,
+                Source = source,
+                Mode = mode,
+                Attribute = attribute,
+                All = all
+            };
+        }
+
+        switch (structuredPreset) {
+            case HtmlCrawlStructuredJsonPreset.Docs:
+                AddPath("title", "Metadata.Title");
+                AddPath("description", "Metadata.Description");
+                AddPath("canonicalUrl", "Metadata.CanonicalUrl");
+                AddPath("language", "Metadata.Language");
+                AddPath("siteName", "Metadata.SiteName");
+                AddPath("summary", "Document.Summary");
+                AddPath("content", "Document.Text");
+                AddPath("markdown", "Document.Markdown");
+                AddPath("headings", "Document.Headings");
+                AddPath("keywords", "Document.Keywords");
+                AddPath("codeBlocks", "CodeBlocks");
+                AddPath("codeSamples", "CodeSamples");
+                AddPath("apiEndpoints", "ApiEndpoints");
+                AddPath("apiCatalog", "ApiCatalog");
+                AddPath("apiTags", "ApiCatalog.Tags");
+                AddPath("apiResources", "ApiCatalog.Resources");
+                AddPath("operationIds", "ApiCatalog.OperationIds");
+                AddPath("openApiLike", "OpenApiLike");
+                AddPath("openApiPaths", "OpenApiLike.Paths");
+                AddPath("openApiServers", "OpenApiLike.Servers");
+                AddPath("authentication", "ApiEndpoints.0.Authentication");
+                AddPath("authRequired", "ApiEndpoints.0.Authentication.Required");
+                AddPath("authenticationSchemes", "ApiEndpoints.0.Authentication.Schemes");
+                AddPath("authenticationHeaders", "ApiEndpoints.0.Authentication.Headers");
+                AddPath("rateLimit", "ApiEndpoints.0.RateLimit");
+                AddPath("rateLimitHeaders", "ApiEndpoints.0.RateLimit.Headers");
+                AddPath("rateLimitStatusCode", "ApiEndpoints.0.RateLimit.StatusCode");
+                AddPath("operationId", "ApiEndpoints.0.OperationId");
+                AddPath("resource", "ApiEndpoints.0.Resource");
+                AddPath("tags", "ApiEndpoints.0.Tags");
+                AddPath("requestExamples", "ApiEndpoints.0.RequestExamples");
+                AddPath("requestExampleCount", "ApiEndpoints.0.RequestExamples.Count");
+                AddPath("requestHeaders", "ApiEndpoints.0.RequestHeaders");
+                AddPath("responseHeaders", "ApiEndpoints.0.ResponseHeaders");
+                AddPath("errorResponses", "ApiEndpoints.0.ErrorResponses");
+                AddPath("errorResponseCount", "ApiEndpoints.0.ErrorResponses.Count");
+                AddPath("errorCatalog", "ApiEndpoints.0.ErrorCatalog");
+                AddPath("errorCatalogCount", "ApiEndpoints.0.ErrorCatalog.Count");
+                AddPath("successResponseSchema", "ApiEndpoints.0.SuccessResponseSchema");
+                AddPath("errorResponseSchema", "ApiEndpoints.0.ErrorResponseSchema");
+                AddPath("requestBodyFields", "ApiEndpoints.0.RequestBodyFields");
+                AddPath("successResponseFields", "ApiEndpoints.0.SuccessResponseFields");
+                AddPath("errorResponseFields", "ApiEndpoints.0.ErrorResponseFields");
+                AddPath("faqItems", "FaqItems");
+                AddPath("callouts", "Callouts");
+                AddPath("primaryActions", "PrimaryActions");
+                AddSelector("mainHeading", "h1, h2");
+                AddSelector("sectionHeadings", "h2, h3", all: true);
+                AddSelector("navigationLinks", "header nav a, nav a, [role='navigation'] a", source: "page", all: true);
+                AddSelector("navigationHrefs", "header nav a, nav a, [role='navigation'] a", source: "page", mode: "Attribute", attribute: "href", all: true);
+                AddPath("breadcrumbs", "Breadcrumbs.0.Labels");
+                AddPath("codeBlockCount", "CodeBlocks.Count");
+                AddPath("codeSampleCount", "CodeSamples.Count");
+                AddPath("apiEndpointCount", "ApiEndpoints.Count");
+                AddSelector("faqCount", "details, [itemscope][itemtype*='Question' i], [itemprop='mainEntity'][itemscope]", mode: "Count");
+                AddPath("calloutCount", "Callouts.Count");
+                AddPath("primaryActionLabels", "PrimaryActions");
+                AddSelector("tableCount", "table", mode: "Count");
+                break;
+
+            case HtmlCrawlStructuredJsonPreset.Article:
+                AddPath("title", "Metadata.Title");
+                AddPath("description", "Metadata.Description");
+                AddPath("canonicalUrl", "Metadata.CanonicalUrl");
+                AddPath("language", "Metadata.Language");
+                AddPath("author", "Metadata.Author");
+                AddPath("publishedTime", "Metadata.PublishedTime");
+                AddPath("modifiedTime", "Metadata.ModifiedTime");
+                AddPath("imageUrl", "Metadata.ImageUrl");
+                AddPath("summary", "Document.Summary");
+                AddPath("content", "Document.Text");
+                AddPath("markdown", "Document.Markdown");
+                AddPath("headings", "Document.Headings");
+                AddPath("keywords", "Document.Keywords");
+                AddPath("links", "Document.Links");
+                AddPath("faqItems", "FaqItems");
+                AddPath("callouts", "Callouts");
+                AddPath("primaryActions", "PrimaryActions");
+                AddSelector("mainHeading", "h1");
+                AddSelector("lead", "p");
+                AddSelector("sectionHeadings", "h2, h3", all: true);
+                AddSelector("imageUrls", "article img[src], main img[src], img[src]", source: "page", mode: "Attribute", attribute: "src", all: true);
+                break;
+
+            case HtmlCrawlStructuredJsonPreset.Product:
+                AddPath("title", "Metadata.Title");
+                AddPath("description", "Metadata.Description");
+                AddPath("canonicalUrl", "Metadata.CanonicalUrl");
+                AddPath("language", "Metadata.Language");
+                AddPath("siteName", "Metadata.SiteName");
+                AddPath("imageUrl", "Metadata.ImageUrl");
+                AddPath("summary", "Document.Summary");
+                AddPath("content", "Document.Text");
+                AddPath("markdown", "Document.Markdown");
+                AddPath("headings", "Document.Headings");
+                AddPath("breadcrumbs", "Breadcrumbs.0.Labels");
+                AddPath("faqItems", "FaqItems");
+                AddPath("specTables", "SpecTables");
+                AddPath("primaryActions", "PrimaryActions");
+                AddSelector("name", "[itemprop='name'], h1", source: "page");
+                AddSelector("price", "[itemprop='price'], .price, .product-price, [data-price], [class*='price']", source: "page");
+                AddSelector("priceMeta", "meta[property='product:price:amount'], meta[itemprop='price']", source: "page", mode: "Attribute", attribute: "content");
+                AddSelector("currency", "meta[property='product:price:currency'], meta[itemprop='priceCurrency']", source: "page", mode: "Attribute", attribute: "content");
+                AddSelector("sku", "[itemprop='sku'], [data-sku], .sku, [class*='sku']", source: "page");
+                AddSelector("availability", "[itemprop='availability'], .availability, [data-stock-status], [class*='stock']", source: "page");
+                AddSelector("imageUrls", "img[src]", source: "page", mode: "Attribute", attribute: "src", all: true);
+                AddSelector("specTableCount", "table", mode: "Count");
+                break;
+        }
+
+        return schema;
+    }
+
+    private static HtmlCrawlStructuredJsonPreset ResolveStructuredJsonPreset(
+        HtmlCrawlStructuredJson structuredJson,
+        IDocument document,
+        IDocument selectedDocument,
+        HtmlCrawlStructuredJsonPreset structuredPreset) {
+        if (structuredPreset == HtmlCrawlStructuredJsonPreset.None) {
+            return HtmlCrawlStructuredJsonPreset.None;
+        }
+
+        if (structuredPreset != HtmlCrawlStructuredJsonPreset.Auto) {
+            return structuredPreset;
+        }
+
+        if (LooksLikeProductPage(document, structuredJson)) {
+            return HtmlCrawlStructuredJsonPreset.Product;
+        }
+
+        if (LooksLikeDocsPage(document, selectedDocument, structuredJson)) {
+            return HtmlCrawlStructuredJsonPreset.Docs;
+        }
+
+        return HtmlCrawlStructuredJsonPreset.Article;
+    }
+
+    private static bool LooksLikeDocsPage(IDocument document, IDocument selectedDocument, HtmlCrawlStructuredJson structuredJson) {
+        string url = structuredJson.Document.Url ?? string.Empty;
+        string title = structuredJson.Metadata.Title ?? structuredJson.Document.Title ?? string.Empty;
+        bool docsUrl = url.IndexOf("/docs", StringComparison.OrdinalIgnoreCase) >= 0
+            || url.IndexOf("/documentation", StringComparison.OrdinalIgnoreCase) >= 0
+            || url.IndexOf("/reference", StringComparison.OrdinalIgnoreCase) >= 0
+            || url.IndexOf("/api", StringComparison.OrdinalIgnoreCase) >= 0
+            || url.IndexOf("/manual", StringComparison.OrdinalIgnoreCase) >= 0
+            || url.IndexOf("/guide", StringComparison.OrdinalIgnoreCase) >= 0;
+        bool docsTitle = title.IndexOf("docs", StringComparison.OrdinalIgnoreCase) >= 0
+            || title.IndexOf("documentation", StringComparison.OrdinalIgnoreCase) >= 0
+            || title.IndexOf("reference", StringComparison.OrdinalIgnoreCase) >= 0
+            || title.IndexOf("api", StringComparison.OrdinalIgnoreCase) >= 0;
+        int codeBlockCount = selectedDocument.QuerySelectorAll("pre, code, samp, kbd").Length;
+        int tocCount = document.QuerySelectorAll("[aria-label*='table of contents' i], nav.toc, .toc, .table-of-contents, [data-toc]").Length;
+        bool strongNavigation = structuredJson.Layout.Regions.Any(region =>
+            string.Equals(region.Kind, "Navigation", StringComparison.OrdinalIgnoreCase) &&
+            region.LinkCount >= 4);
+        return docsUrl || docsTitle || codeBlockCount > 0 || tocCount > 0 || (strongNavigation && structuredJson.Document.Headings.Count >= 2);
+    }
+
+    private static bool LooksLikeProductPage(IDocument document, HtmlCrawlStructuredJson structuredJson) {
+        bool hasProductMicrodata = structuredJson.MicrodataItems.Any(item =>
+            !string.IsNullOrWhiteSpace(item.Type) &&
+            item.Type.IndexOf("Product", StringComparison.OrdinalIgnoreCase) >= 0);
+        bool hasPrice = document.QuerySelectorAll("[itemprop='price'], meta[property='product:price:amount'], .price, .product-price, [data-price], [class*='price']").Length > 0;
+        bool hasSku = document.QuerySelectorAll("[itemprop='sku'], [data-sku], .sku, [class*='sku']").Length > 0;
+        bool hasAvailability = document.QuerySelectorAll("[itemprop='availability'], .availability, [data-stock-status], [class*='stock']").Length > 0;
+        bool hasCommerceAction = document.QuerySelectorAll("button, a")
+            .Select(element => NormalizeWhitespace(element.TextContent))
+            .Any(text =>
+                text.IndexOf("add to cart", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                text.IndexOf("buy now", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                text.IndexOf("checkout", StringComparison.OrdinalIgnoreCase) >= 0);
+        return hasProductMicrodata || (hasPrice && (hasSku || hasAvailability || hasCommerceAction));
+    }
+
     private static PageSearchMetadata BuildPageSearchMetadata(HtmlCrawlPage page) {
-        string sourceText = GetSearchText(page);
-        string[] headings = ExtractHeadings(page.Html);
-        List<string> chunkTexts = BuildPageChunkTexts(page);
+        return BuildPageSearchMetadata(page.Html, page.Text, page.Markdown);
+    }
+
+    private static PageSearchMetadata BuildPageSearchMetadata(string html, string text, string markdown) {
+        string sourceText = GetSearchText(text, markdown, html);
+        string[] headings = ExtractHeadings(html);
+        List<string> chunkTexts = BuildPageChunkTexts(sourceText);
         return new PageSearchMetadata {
             WordCount = CountWords(sourceText),
             CharacterCount = sourceText.Length,
@@ -1374,6 +2101,24 @@ public static class HtmlCrawler {
 
     internal static int GetChunkCountForSummary(IEnumerable<HtmlCrawlPage> pages) =>
         BuildChunkRecords(pages).Count;
+
+    internal static int GetStructuredAuthenticatedApiEndpointCount(HtmlCrawlStructuredJson? structuredJson) =>
+        structuredJson?.ApiEndpoints.Count(endpoint =>
+            endpoint.Authentication.Required.HasValue
+            || endpoint.Authentication.Schemes.Count > 0
+            || endpoint.Authentication.Headers.Count > 0
+            || !string.IsNullOrWhiteSpace(endpoint.Authentication.Summary)) ?? 0;
+
+    internal static int GetStructuredRateLimitedApiEndpointCount(HtmlCrawlStructuredJson? structuredJson) =>
+        structuredJson?.ApiEndpoints.Count(endpoint =>
+            endpoint.RateLimit.Mentioned
+            || endpoint.RateLimit.StatusCode.HasValue
+            || endpoint.RateLimit.Headers.Count > 0
+            || !string.IsNullOrWhiteSpace(endpoint.RateLimit.Limit)
+            || !string.IsNullOrWhiteSpace(endpoint.RateLimit.Summary)) ?? 0;
+
+    internal static int GetStructuredApiErrorResponseCount(HtmlCrawlStructuredJson? structuredJson) =>
+        structuredJson?.ApiEndpoints.Sum(endpoint => endpoint.ErrorResponses.Count) ?? 0;
 
     private static (object GraphDocument, int NodeCount, int EdgeCount, int FetchedNodeCount, int SkippedNodeCount, int ExternalNodeCount, Dictionary<string, int> NodeCategories, Dictionary<string, int> EdgeRelations, Dictionary<string, int> SkippedNodeReasons) BuildGraphDocument(
         IEnumerable<HtmlCrawlPage> pages,
@@ -1541,7 +2286,7 @@ public static class HtmlCrawler {
 
         foreach (HtmlCrawlPage page in pages.Where(page => page.Status == HtmlCrawlPageStatus.Success)) {
             PageSearchMetadata searchMetadata = BuildPageSearchMetadata(page);
-            List<string> pageChunks = BuildPageChunkTexts(page);
+            List<string> pageChunks = BuildPageChunkTexts(page.Text, page.Markdown, page.Html);
             int chunkIndex = 1;
             foreach (string chunkText in pageChunks) {
                 string fingerprint = ComputeContentFingerprint(chunkText);
@@ -1573,8 +2318,15 @@ public static class HtmlCrawler {
         return chunks;
     }
 
-    private static List<string> BuildPageChunkTexts(HtmlCrawlPage page) {
-        string sourceText = GetSearchText(page);
+    private static List<string> BuildPageChunkTexts(HtmlCrawlPage page) =>
+        BuildPageChunkTexts(page.Text, page.Markdown, page.Html);
+
+    private static List<string> BuildPageChunkTexts(string text, string markdown, string html) {
+        string sourceText = GetSearchText(text, markdown, html);
+        return BuildPageChunkTexts(sourceText);
+    }
+
+    private static List<string> BuildPageChunkTexts(string sourceText) {
         if (string.IsNullOrWhiteSpace(sourceText)) {
             return new List<string>();
         }
@@ -1609,16 +2361,4353 @@ public static class HtmlCrawler {
         return chunks;
     }
 
-    private static string GetSearchText(HtmlCrawlPage page) {
-        if (!string.IsNullOrWhiteSpace(page.Text)) {
-            return NormalizeWhitespace(page.Text);
+    private static string GetSearchText(HtmlCrawlPage page) =>
+        GetSearchText(page.Text, page.Markdown, page.Html);
+
+    private static string GetSearchText(string text, string markdown, string html) {
+        if (!string.IsNullOrWhiteSpace(text)) {
+            return NormalizeWhitespace(text);
         }
 
-        if (!string.IsNullOrWhiteSpace(page.Html)) {
-            return NormalizeWhitespace(HtmlParserToText.ConvertToText(page.Html));
+        if (!string.IsNullOrWhiteSpace(markdown)) {
+            return NormalizeWhitespace(markdown);
+        }
+
+        if (!string.IsNullOrWhiteSpace(html)) {
+            return NormalizeWhitespace(HtmlParserToText.ConvertToText(html));
         }
 
         return string.Empty;
+    }
+
+    private static HtmlCrawlStructuredDocument BuildStructuredDocument(
+        HtmlCrawlPage page,
+        PageSearchMetadata searchMetadata,
+        string text,
+        string markdown) {
+        return new HtmlCrawlStructuredDocument {
+            Url = page.Url,
+            RequestedUrl = page.RequestedUrl,
+            ParentUrl = page.ParentUrl,
+            CanonicalUrl = page.CanonicalUrl,
+            Depth = page.Depth,
+            Title = page.Title,
+            ContentType = page.ContentType,
+            Rendered = page.Rendered,
+            RenderMode = page.RenderMode,
+            RenderReasonCode = page.RenderReasonCode,
+            ContentModeUsed = page.ContentModeUsed,
+            ContentSelectionReasonCode = page.ContentSelectionReasonCode,
+            ContentSelectionReason = page.ContentSelectionReason,
+            ContentElementSelectorHint = page.ContentElementSelectorHint,
+            WordCount = searchMetadata.WordCount,
+            CharacterCount = searchMetadata.CharacterCount,
+            ChunkCount = searchMetadata.ChunkCount,
+            LinkCount = page.Links.Count,
+            AssetCount = page.AssetUrls.Count,
+            InteractionCount = page.AppliedInteractions.Count,
+            Summary = searchMetadata.Summary,
+            Headings = new List<string>(searchMetadata.Headings),
+            Keywords = new List<string>(searchMetadata.Keywords),
+            Links = page.Links
+                .Where(link => !string.IsNullOrWhiteSpace(link))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(link => link, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            AppliedInteractions = new List<string>(page.AppliedInteractions),
+            Text = text,
+            Markdown = markdown
+        };
+    }
+
+    private static HtmlCrawlStructuredMetadata BuildStructuredMetadata(
+        HtmlCrawlPage page,
+        IDocument document,
+        IReadOnlyCollection<HtmlMetaTag> metaTags,
+        HtmlOpenGraph openGraph) {
+        return new HtmlCrawlStructuredMetadata {
+            Title = page.Title ?? FindOpenGraphValue(openGraph, "title"),
+            Description = FindMetaContent(metaTags, "description")
+                ?? FindOpenGraphValue(openGraph, "description"),
+            CanonicalUrl = page.CanonicalUrl,
+            Language = document.DocumentElement?.GetAttribute("lang"),
+            SiteName = FindOpenGraphValue(openGraph, "site_name")
+                ?? FindMetaContent(metaTags, "application-name"),
+            Type = FindOpenGraphValue(openGraph, "type"),
+            Author = FindMetaContent(metaTags, "author", "article:author"),
+            PublishedTime = FindMetaContent(metaTags, "article:published_time", "published_time", "pubdate"),
+            ModifiedTime = FindMetaContent(metaTags, "article:modified_time", "last-modified", "modified_time"),
+            Robots = FindMetaContent(metaTags, "robots"),
+            Generator = FindMetaContent(metaTags, "generator"),
+            ImageUrl = FindOpenGraphValue(openGraph, "image"),
+            Keywords = SplitMetadataKeywords(FindMetaContent(metaTags, "keywords")),
+            MetaTagCount = metaTags.Count,
+            OpenGraphPropertyCount = openGraph.Properties.Count
+        };
+    }
+
+    private static HtmlCrawlStructuredLayout BuildStructuredLayout(IDocument document) {
+        List<HtmlCrawlStructuredRegion> regions = new();
+        HashSet<IElement> seenElements = new();
+
+        foreach ((string kind, string selector) in StructuredRegionSelectors) {
+            IEnumerable<IElement> matches = document.QuerySelectorAll(selector)
+                .Where(element => element != null && seenElements.Add(element))
+                .Where(element => !string.Equals(kind, "Navigation", StringComparison.OrdinalIgnoreCase) || !LooksLikeBreadcrumbElement(element))
+                .Where(ShouldIncludeStructuredRegion)
+                .OrderByDescending(element => CountWords(element.TextContent))
+                .ThenBy(element => BuildElementSelectorHint(element), StringComparer.OrdinalIgnoreCase)
+                .Take(4);
+
+            foreach (IElement element in matches) {
+                regions.Add(BuildStructuredRegion(kind, element));
+            }
+        }
+
+        return new HtmlCrawlStructuredLayout {
+            Regions = regions
+                .OrderBy(region => GetStructuredRegionKindOrder(region.Kind))
+                .ThenByDescending(region => region.WordCount)
+                .ThenBy(region => region.SelectorHint, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            HeaderCount = regions.Count(region => string.Equals(region.Kind, "Header", StringComparison.OrdinalIgnoreCase)),
+            NavigationCount = regions.Count(region => string.Equals(region.Kind, "Navigation", StringComparison.OrdinalIgnoreCase)),
+            MainCount = regions.Count(region => string.Equals(region.Kind, "Main", StringComparison.OrdinalIgnoreCase)),
+            ArticleCount = regions.Count(region => string.Equals(region.Kind, "Article", StringComparison.OrdinalIgnoreCase)),
+            AsideCount = regions.Count(region => string.Equals(region.Kind, "Aside", StringComparison.OrdinalIgnoreCase)),
+            FooterCount = regions.Count(region => string.Equals(region.Kind, "Footer", StringComparison.OrdinalIgnoreCase))
+        };
+    }
+
+    private static HtmlCrawlStructuredRegion BuildStructuredRegion(string kind, IElement element) {
+        string text = NormalizeWhitespace(element.TextContent);
+        return new HtmlCrawlStructuredRegion {
+            Kind = kind,
+            Tag = element.LocalName,
+            Id = string.IsNullOrWhiteSpace(element.Id) ? null : element.Id,
+            Classes = GetElementClassNames(element),
+            SelectorHint = BuildElementSelectorHint(element),
+            Role = element.GetAttribute("role"),
+            AriaLabel = element.GetAttribute("aria-label"),
+            Summary = BuildSummary(text),
+            WordCount = CountWords(text),
+            LinkCount = element.QuerySelectorAll("a[href]").Length,
+            HeadingCount = element.QuerySelectorAll("h1, h2, h3, h4, h5, h6").Length,
+            LinkLabels = element.QuerySelectorAll("a[href]")
+                .Select(anchor => NormalizeWhitespace(anchor.TextContent))
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.Ordinal)
+                .Take(12)
+                .ToList(),
+            IsLikelyBoilerplate = ContainsBoilerplateSignals(element) || IsLinkDenseBoilerplateBlock(element)
+        };
+    }
+
+    private static bool ShouldIncludeStructuredRegion(IElement element) {
+        if (element == null) {
+            return false;
+        }
+
+        string text = NormalizeWhitespace(element.TextContent);
+        int wordCount = CountWords(text);
+        int linkCount = element.QuerySelectorAll("a[href]").Length;
+        int headingCount = element.QuerySelectorAll("h1, h2, h3, h4, h5, h6").Length;
+        return wordCount > 0 || linkCount > 0 || headingCount > 0;
+    }
+
+    private static bool LooksLikeBreadcrumbElement(IElement element) {
+        if (element == null) {
+            return false;
+        }
+
+        string selectorHint = BuildElementSelectorHint(element) ?? string.Empty;
+        string ariaLabel = element.GetAttribute("aria-label") ?? string.Empty;
+        string itemType = element.GetAttribute("itemtype") ?? string.Empty;
+        return selectorHint.IndexOf("breadcrumb", StringComparison.OrdinalIgnoreCase) >= 0
+            || ariaLabel.IndexOf("breadcrumb", StringComparison.OrdinalIgnoreCase) >= 0
+            || itemType.IndexOf("BreadcrumbList", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static int GetStructuredRegionKindOrder(string? kind) {
+        return kind?.ToLowerInvariant() switch {
+            "header" => 0,
+            "navigation" => 1,
+            "main" => 2,
+            "article" => 3,
+            "aside" => 4,
+            "footer" => 5,
+            _ => 6
+        };
+    }
+
+    private static List<HtmlCrawlStructuredCodeBlock> BuildStructuredCodeBlocks(IDocument selectedDocument) {
+        List<HtmlCrawlStructuredCodeBlock> blocks = new();
+        HashSet<IElement> seen = new();
+        IEnumerable<IElement> elements = selectedDocument.QuerySelectorAll("pre")
+            .Concat(selectedDocument.QuerySelectorAll("code[class*='language'], code[class*='lang-'], code[data-language], code[lang], code[type], samp, kbd")
+                .Where(element => element.Closest("pre") == null));
+
+        foreach (IElement element in elements) {
+            if (element == null || !seen.Add(element)) {
+                continue;
+            }
+
+            IElement sourceElement = string.Equals(element.LocalName, "pre", StringComparison.OrdinalIgnoreCase)
+                ? element.QuerySelector("code") ?? element
+                : element;
+            string code = NormalizeCodeBlockText(sourceElement.TextContent);
+            if (string.IsNullOrWhiteSpace(code)) {
+                continue;
+            }
+
+            string[] lines = code.Split(new[] { '\n' }, StringSplitOptions.None);
+            blocks.Add(new HtmlCrawlStructuredCodeBlock {
+                Language = DetectCodeBlockLanguage(sourceElement),
+                Code = code,
+                LineCount = lines.Length,
+                CharacterCount = code.Length,
+                SelectorHint = BuildElementSelectorHint(element)
+            });
+        }
+
+        return blocks;
+    }
+
+    private static List<HtmlCrawlStructuredCodeSample> BuildStructuredCodeSamples(IDocument selectedDocument) {
+        List<HtmlCrawlStructuredCodeSample> samples = new();
+        HashSet<IElement> seen = new();
+        foreach (IElement element in selectedDocument.QuerySelectorAll("pre")
+                     .Concat(selectedDocument.QuerySelectorAll("code[class*='language'], code[class*='lang-'], code[data-language], code[lang], code[type], samp, kbd")
+                         .Where(item => item.Closest("pre") == null))) {
+            if (element == null || !seen.Add(element)) {
+                continue;
+            }
+
+            IElement sourceElement = string.Equals(element.LocalName, "pre", StringComparison.OrdinalIgnoreCase)
+                ? element.QuerySelector("code") ?? element
+                : element;
+            string code = NormalizeCodeBlockText(sourceElement.TextContent);
+            if (string.IsNullOrWhiteSpace(code)) {
+                continue;
+            }
+
+            string? heading = FindNearbyHeadingText(element);
+            string? language = DetectCodeBlockLanguage(sourceElement);
+            string kind = DetectStructuredCodeSampleKind(code, language);
+            string? method = null;
+            string? path = null;
+            if (!TryParseApiMethodAndPath(code, out method, out path) && !string.IsNullOrWhiteSpace(heading)) {
+                TryParseApiMethodAndPath(heading!, out method, out path);
+            }
+
+            samples.Add(new HtmlCrawlStructuredCodeSample {
+                Title = BuildStructuredCodeSampleTitle(heading, kind, method, path, language),
+                Heading = heading,
+                Language = language,
+                Kind = kind,
+                Code = code,
+                Method = method,
+                Path = path,
+                SelectorHint = BuildElementSelectorHint(element)
+            });
+        }
+
+        return samples;
+    }
+
+    private static List<HtmlCrawlStructuredBreadcrumbTrail> BuildStructuredBreadcrumbs(IDocument document, string? pageUrl) {
+        List<HtmlCrawlStructuredBreadcrumbTrail> trails = new();
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        Uri? baseUri = Uri.TryCreate(pageUrl, UriKind.Absolute, out Uri? resolvedBaseUri) ? resolvedBaseUri : null;
+
+        foreach (IElement container in document.QuerySelectorAll("[aria-label*='breadcrumb' i], nav.breadcrumb, .breadcrumb, .breadcrumbs, [data-breadcrumb], [data-breadcrumbs], ol[itemtype*='BreadcrumbList' i], ul[itemtype*='BreadcrumbList' i]")) {
+            HtmlCrawlStructuredBreadcrumbTrail? trail = BuildStructuredBreadcrumbTrail(container, baseUri);
+            if (trail == null || trail.Items.Count == 0) {
+                continue;
+            }
+
+            string key = string.Join(">", trail.Labels);
+            if (!seen.Add(key)) {
+                continue;
+            }
+
+            trails.Add(trail);
+        }
+
+        return trails;
+    }
+
+    private static HtmlCrawlStructuredBreadcrumbTrail? BuildStructuredBreadcrumbTrail(IElement container, Uri? baseUri) {
+        IEnumerable<IElement> candidates = container.QuerySelectorAll("li").Length > 0
+            ? container.QuerySelectorAll("li")
+            : container.QuerySelectorAll("a[href], [aria-current='page'], span[itemprop='name'], strong, span");
+
+        List<HtmlCrawlStructuredBreadcrumbItem> items = new();
+        foreach (IElement candidate in candidates) {
+            IElement? anchor = string.Equals(candidate.LocalName, "a", StringComparison.OrdinalIgnoreCase)
+                ? candidate
+                : candidate.QuerySelector("a[href]");
+            string label = NormalizeWhitespace(anchor?.TextContent ?? candidate.TextContent);
+            if (string.IsNullOrWhiteSpace(label)) {
+                continue;
+            }
+
+            if (items.Count > 0 && string.Equals(items[^1].Label, label, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            string? url = TryResolveStructuredHref(baseUri, anchor?.GetAttribute("href"));
+            bool isCurrent = string.Equals(candidate.GetAttribute("aria-current"), "page", StringComparison.OrdinalIgnoreCase)
+                || (anchor == null && candidates.Count() > 1)
+                || (string.IsNullOrWhiteSpace(url) && items.Count > 0);
+            items.Add(new HtmlCrawlStructuredBreadcrumbItem {
+                Label = label,
+                Url = url,
+                IsCurrent = isCurrent
+            });
+        }
+
+        if (items.Count < 2) {
+            return null;
+        }
+
+        return new HtmlCrawlStructuredBreadcrumbTrail {
+            Items = items,
+            Labels = items.Select(item => item.Label).ToList(),
+            Urls = items.Where(item => !string.IsNullOrWhiteSpace(item.Url))
+                .Select(item => item.Url!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            CurrentLabel = items.LastOrDefault(item => item.IsCurrent)?.Label ?? items[^1].Label,
+            SelectorHint = BuildElementSelectorHint(container)
+        };
+    }
+
+    private static List<HtmlCrawlStructuredFaqItem> BuildStructuredFaqItems(IDocument selectedDocument) {
+        List<HtmlCrawlStructuredFaqItem> items = new();
+        HashSet<string> seenQuestions = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (IElement questionElement in selectedDocument.QuerySelectorAll("[itemscope][itemtype*='Question' i], [itemprop='mainEntity'][itemscope]")) {
+            string question = NormalizeWhitespace(questionElement.QuerySelector("[itemprop='name']")?.TextContent);
+            IElement? answerElement = questionElement.QuerySelector("[itemprop='acceptedAnswer'] [itemprop='text'], [itemprop='acceptedAnswer']");
+            string answer = NormalizeWhitespace(answerElement?.TextContent);
+            string answerMarkdown = answerElement == null ? string.Empty : ConvertSelectedHtmlToMarkdown(answerElement.InnerHtml, null);
+            AddStructuredFaqItem(items, seenQuestions, question, answer, answerMarkdown, "Microdata", questionElement);
+        }
+
+        foreach (IElement details in selectedDocument.QuerySelectorAll("details")) {
+            string question = NormalizeWhitespace(details.QuerySelector("summary")?.TextContent);
+            IElement clone = (IElement)details.Clone(true);
+            foreach (IElement summary in clone.QuerySelectorAll("summary").ToArray()) {
+                summary.Remove();
+            }
+
+            string answer = NormalizeWhitespace(clone.TextContent);
+            string answerMarkdown = string.IsNullOrWhiteSpace(clone.InnerHtml) ? string.Empty : ConvertSelectedHtmlToMarkdown(clone.InnerHtml, null);
+            AddStructuredFaqItem(items, seenQuestions, question, answer, answerMarkdown, "Details", details);
+        }
+
+        return items;
+    }
+
+    private static void AddStructuredFaqItem(
+        IList<HtmlCrawlStructuredFaqItem> items,
+        ISet<string> seenQuestions,
+        string question,
+        string answer,
+        string answerMarkdown,
+        string source,
+        IElement element) {
+        if (string.IsNullOrWhiteSpace(question) || string.IsNullOrWhiteSpace(answer) || !seenQuestions.Add(question)) {
+            return;
+        }
+
+        items.Add(new HtmlCrawlStructuredFaqItem {
+            Question = question,
+            Answer = answer,
+            AnswerMarkdown = answerMarkdown,
+            Source = source,
+            SelectorHint = BuildElementSelectorHint(element)
+        });
+    }
+
+    private static List<HtmlCrawlStructuredSpecTable> BuildStructuredSpecTables(IDocument selectedDocument, IReadOnlyList<HtmlTableResult> tables) {
+        List<HtmlCrawlStructuredSpecTable> specTables = new();
+        IHtmlCollection<IElement> tableElements = selectedDocument.QuerySelectorAll("table");
+        for (int index = 0; index < Math.Min(tableElements.Length, tables.Count); index++) {
+            IElement tableElement = tableElements[index];
+            HtmlTableResult table = tables[index];
+            if (!LooksLikeStructuredSpecTable(tableElement, table)) {
+                continue;
+            }
+
+            string? title = NormalizeWhitespace(tableElement.QuerySelector("caption")?.TextContent);
+            if (string.IsNullOrWhiteSpace(title)) {
+                title = FindNearbyHeadingText(tableElement);
+            }
+
+            List<HtmlCrawlStructuredSpecItem> entries = BuildStructuredSpecEntries(table);
+            if (entries.Count == 0) {
+                continue;
+            }
+
+            HtmlCrawlStructuredSpecTable specTable = new() {
+                TableIndex = index,
+                Title = title,
+                Headers = new List<string>(table.Metadata.Headers),
+                Entries = entries,
+                SelectorHint = BuildElementSelectorHint(tableElement)
+            };
+            foreach (HtmlCrawlStructuredSpecItem entry in entries) {
+                if (!specTable.Properties.ContainsKey(entry.Name)) {
+                    specTable.Properties[entry.Name] = entry.Value;
+                }
+            }
+
+            specTables.Add(specTable);
+        }
+
+        return specTables;
+    }
+
+    private static List<HtmlCrawlStructuredSpecItem> BuildStructuredSpecEntries(HtmlTableResult table) {
+        List<HtmlCrawlStructuredSpecItem> entries = new();
+        foreach (Dictionary<string, string?> row in table.Data) {
+            List<KeyValuePair<string, string?>> populated = row
+                .Where(item => !string.IsNullOrWhiteSpace(item.Key) && !string.IsNullOrWhiteSpace(item.Value))
+                .ToList();
+            if (populated.Count < 2) {
+                continue;
+            }
+
+            HtmlCrawlStructuredSpecItem item = new() {
+                Name = NormalizeWhitespace(populated[0].Value ?? populated[0].Key),
+                Value = NormalizeWhitespace(populated[1].Value)
+            };
+            if (string.IsNullOrWhiteSpace(item.Name) || string.IsNullOrWhiteSpace(item.Value)) {
+                continue;
+            }
+
+            entries.Add(item);
+        }
+
+        return entries;
+    }
+
+    private static bool LooksLikeStructuredSpecTable(IElement tableElement, HtmlTableResult table) {
+        string selectorHint = BuildElementSelectorHint(tableElement) ?? string.Empty;
+        string classes = table.Metadata.Classes ?? string.Empty;
+        string headers = string.Join(" ", table.Metadata.Headers);
+        string nearbyHeading = FindNearbyHeadingText(tableElement) ?? string.Empty;
+        bool looksLikeParameterTable = ContainsAnyToken(headers, "parameter", "required", "description", "default", "location")
+            || ContainsAnyToken(nearbyHeading, "parameter", "request body", "query parameter", "path parameter", "header");
+        if (looksLikeParameterTable) {
+            return false;
+        }
+
+        bool classSignal = ContainsAnyToken(selectorHint, "spec", "feature", "attribute", "property", "parameter", "option", "config")
+            || ContainsAnyToken(classes, "spec", "feature", "attribute", "property", "parameter", "option", "config");
+        bool headerSignal = ContainsAnyToken(headers, "name", "property", "attribute", "setting", "option", "parameter", "value", "description", "details");
+        bool twoColumn = table.Metadata.ColumnCount > 0 && table.Metadata.ColumnCount <= 2;
+        bool rowShapeLooksLikePairs = table.Data.Count > 0 && table.Data.All(row => row.Count(item => !string.IsNullOrWhiteSpace(item.Value)) <= 2);
+        return classSignal || (twoColumn && (headerSignal || rowShapeLooksLikePairs));
+    }
+
+    private static List<HtmlCrawlStructuredCallout> BuildStructuredCallouts(IDocument selectedDocument) {
+        List<HtmlCrawlStructuredCallout> callouts = new();
+        HashSet<IElement> seen = new();
+        foreach (IElement element in selectedDocument.QuerySelectorAll("aside, blockquote, div, section").Where(LooksLikeStructuredCalloutElement)) {
+            if (element == null || !seen.Add(element) || element.Closest("details") != null) {
+                continue;
+            }
+
+            string text = NormalizeWhitespace(element.TextContent);
+            if (string.IsNullOrWhiteSpace(text)) {
+                continue;
+            }
+
+            string? title = NormalizeWhitespace(element.QuerySelector("strong, b, h1, h2, h3, h4, h5, h6, .title, .heading")?.TextContent);
+            callouts.Add(new HtmlCrawlStructuredCallout {
+                Kind = DetectStructuredCalloutKind(element),
+                Title = title,
+                Text = text,
+                Markdown = string.IsNullOrWhiteSpace(element.InnerHtml) ? string.Empty : ConvertSelectedHtmlToMarkdown(element.InnerHtml, null),
+                SelectorHint = BuildElementSelectorHint(element)
+            });
+        }
+
+        return callouts;
+    }
+
+    private static bool LooksLikeStructuredCalloutElement(IElement element) {
+        if (element == null) {
+            return false;
+        }
+
+        string role = element.GetAttribute("role") ?? string.Empty;
+        string hint = BuildElementSelectorHint(element) ?? string.Empty;
+        return role.Equals("alert", StringComparison.OrdinalIgnoreCase)
+            || role.Equals("note", StringComparison.OrdinalIgnoreCase)
+            || role.Equals("status", StringComparison.OrdinalIgnoreCase)
+            || ContainsAnyToken(hint, "note", "warning", "warn", "tip", "info", "danger", "error", "success", "important", "callout", "admonition", "caution");
+    }
+
+    private static string DetectStructuredCalloutKind(IElement element) {
+        string hint = BuildElementSelectorHint(element) ?? string.Empty;
+        string role = element.GetAttribute("role") ?? string.Empty;
+        if (ContainsAnyToken(hint, "warning", "warn", "caution")) {
+            return "warning";
+        }
+        if (ContainsAnyToken(hint, "danger", "error")) {
+            return "danger";
+        }
+        if (ContainsAnyToken(hint, "tip", "success")) {
+            return "tip";
+        }
+        if (ContainsAnyToken(hint, "important")) {
+            return "important";
+        }
+        if (role.Equals("alert", StringComparison.OrdinalIgnoreCase)) {
+            return "warning";
+        }
+        return "note";
+    }
+
+    private static List<HtmlCrawlStructuredPrimaryAction> BuildStructuredPrimaryActions(IDocument selectedDocument, string? pageUrl) {
+        List<(int Score, HtmlCrawlStructuredPrimaryAction Action)> scored = new();
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+        Uri? baseUri = Uri.TryCreate(pageUrl, UriKind.Absolute, out Uri? baseUriResolved) ? baseUriResolved : null;
+
+        foreach (IElement element in selectedDocument.QuerySelectorAll("a[href], button, input[type='submit'], input[type='button'], [role='button']")) {
+            string label = GetStructuredActionLabel(element);
+            if (string.IsNullOrWhiteSpace(label)) {
+                continue;
+            }
+
+            int score = ScoreStructuredPrimaryAction(element, label);
+            if (score <= 0) {
+                continue;
+            }
+
+            string? url = string.Equals(element.LocalName, "a", StringComparison.OrdinalIgnoreCase)
+                ? TryResolveStructuredHref(baseUri, element.GetAttribute("href"))
+                : null;
+            string key = $"{label}|{url}|{element.LocalName}";
+            if (!seen.Add(key)) {
+                continue;
+            }
+
+            scored.Add((score, new HtmlCrawlStructuredPrimaryAction {
+                Label = label,
+                Url = url,
+                Type = DetectStructuredActionType(element),
+                Intent = DetectStructuredActionIntent(label, element),
+                SelectorHint = BuildElementSelectorHint(element)
+            }));
+        }
+
+        return scored
+            .OrderByDescending(item => item.Score)
+            .ThenBy(item => item.Action.Label, StringComparer.OrdinalIgnoreCase)
+            .Select(item => item.Action)
+            .Take(8)
+            .ToList();
+    }
+
+    private static string GetStructuredActionLabel(IElement element) {
+        string? inputValue = element.GetAttribute("value");
+        return NormalizeWhitespace(inputValue ?? element.TextContent);
+    }
+
+    private static int ScoreStructuredPrimaryAction(IElement element, string label) {
+        string hint = BuildElementSelectorHint(element) ?? string.Empty;
+        int score = 0;
+        if (ContainsAnyToken(hint, "primary", "cta", "button", "btn", "action")) {
+            score += 3;
+        }
+        if (element.GetAttribute("role")?.Equals("button", StringComparison.OrdinalIgnoreCase) == true
+            || string.Equals(element.LocalName, "button", StringComparison.OrdinalIgnoreCase)) {
+            score += 2;
+        }
+        if (ContainsAnyToken(label, "install", "download", "start", "get started", "try", "buy", "add to cart", "checkout", "contact sales", "sign up", "create account")) {
+            score += 4;
+        }
+        if (label.Length <= 40) {
+            score += 1;
+        }
+        if (ContainsAnyToken(label, "learn more", "read more", "home", "docs", "privacy")) {
+            score -= 2;
+        }
+        if (element.Closest("nav, header, footer") != null) {
+            score -= 2;
+        }
+        return score;
+    }
+
+    private static string DetectStructuredActionType(IElement element) {
+        if (string.Equals(element.LocalName, "a", StringComparison.OrdinalIgnoreCase)) {
+            return "link";
+        }
+        if (string.Equals(element.LocalName, "button", StringComparison.OrdinalIgnoreCase)) {
+            return "button";
+        }
+
+        return string.Equals(element.GetAttribute("type"), "submit", StringComparison.OrdinalIgnoreCase)
+            ? "submit"
+            : "button";
+    }
+
+    private static string DetectStructuredActionIntent(string label, IElement element) {
+        if (ContainsAnyToken(label, "install")) {
+            return "install";
+        }
+        if (ContainsAnyToken(label, "download")) {
+            return "download";
+        }
+        if (ContainsAnyToken(label, "buy", "add to cart", "checkout")) {
+            return "buy";
+        }
+        if (ContainsAnyToken(label, "start", "get started", "try")) {
+            return "start";
+        }
+        if (ContainsAnyToken(label, "contact sales")) {
+            return "contact-sales";
+        }
+        return string.Equals(element.LocalName, "a", StringComparison.OrdinalIgnoreCase) ? "navigate" : "action";
+    }
+
+    private static List<HtmlCrawlStructuredApiEndpoint> BuildStructuredApiEndpoints(
+        IDocument selectedDocument,
+        IReadOnlyList<HtmlCrawlStructuredCodeSample> codeSamples,
+        string pageUrl) {
+        Dictionary<string, HtmlCrawlStructuredApiEndpoint> endpoints = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (IElement heading in selectedDocument.QuerySelectorAll("h1, h2, h3, h4, h5, h6")) {
+            string text = NormalizeWhitespace(heading.TextContent);
+            if (!TryParseApiMethodAndPath(text, out string? method, out string? path)) {
+                continue;
+            }
+
+            HtmlCrawlStructuredApiEndpoint endpoint = GetOrCreateStructuredApiEndpoint(endpoints, method!, path!);
+            endpoint.Title ??= text;
+            endpoint.Description ??= FindFollowingParagraphText(heading);
+            endpoint.SelectorHint ??= BuildElementSelectorHint(heading);
+            AppendDistinct(endpoint.Sources, "Heading");
+
+            IDocument sectionDocument = BuildStructuredSectionDocument(heading);
+            List<HtmlCrawlStructuredCodeSample> sectionCodeSamples = BuildStructuredCodeSamples(sectionDocument);
+            foreach (HtmlCrawlStructuredApiParameter parameter in BuildStructuredApiParameters(sectionDocument)) {
+                if (!endpoint.Parameters.Any(existing =>
+                        string.Equals(existing.Name, parameter.Name, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(existing.Location, parameter.Location, StringComparison.OrdinalIgnoreCase))) {
+                    endpoint.Parameters.Add(parameter);
+                }
+            }
+
+            foreach (HtmlCrawlStructuredRequestExample requestExample in BuildStructuredRequestExamples(sectionCodeSamples)) {
+                if (!endpoint.RequestExamples.Any(existing =>
+                        string.Equals(existing.Method, requestExample.Method, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(existing.Path, requestExample.Path, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(existing.Body, requestExample.Body, StringComparison.Ordinal)
+                        && string.Equals(existing.Title, requestExample.Title, StringComparison.OrdinalIgnoreCase))) {
+                    endpoint.RequestExamples.Add(requestExample);
+                }
+            }
+
+            foreach (HtmlCrawlStructuredResponseExample responseExample in BuildStructuredResponseExamples(sectionDocument, sectionCodeSamples, pageUrl)) {
+                if (!endpoint.ResponseExamples.Any(existing =>
+                        string.Equals(existing.Body, responseExample.Body, StringComparison.Ordinal)
+                        && string.Equals(existing.Title, responseExample.Title, StringComparison.OrdinalIgnoreCase)
+                        && existing.StatusCode == responseExample.StatusCode)) {
+                    endpoint.ResponseExamples.Add(responseExample);
+                }
+            }
+
+            MergeStructuredApiAuthentication(endpoint.Authentication, BuildStructuredApiAuthentication(sectionDocument, sectionCodeSamples, endpoint.Parameters));
+            MergeStructuredApiRateLimit(endpoint.RateLimit, BuildStructuredApiRateLimit(sectionDocument, sectionCodeSamples, endpoint.ResponseExamples));
+        }
+
+        foreach (HtmlCrawlStructuredCodeSample sample in codeSamples.Where(sample => !string.IsNullOrWhiteSpace(sample.Method) && !string.IsNullOrWhiteSpace(sample.Path))) {
+            HtmlCrawlStructuredApiEndpoint endpoint = GetOrCreateStructuredApiEndpoint(endpoints, sample.Method!, sample.Path!);
+            endpoint.Title ??= sample.Title;
+            endpoint.SelectorHint ??= sample.SelectorHint;
+            if (!string.IsNullOrWhiteSpace(sample.Language)) {
+                AppendDistinct(endpoint.ExampleLanguages, sample.Language!);
+            }
+            AppendDistinct(endpoint.Sources, "CodeSample");
+
+            HtmlCrawlStructuredRequestExample? requestExample = BuildStructuredRequestExample(sample);
+            if (requestExample != null
+                && !endpoint.RequestExamples.Any(existing =>
+                    string.Equals(existing.Method, requestExample.Method, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Path, requestExample.Path, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Body, requestExample.Body, StringComparison.Ordinal)
+                    && string.Equals(existing.Title, requestExample.Title, StringComparison.OrdinalIgnoreCase))) {
+                endpoint.RequestExamples.Add(requestExample);
+            }
+        }
+
+        foreach (HtmlCrawlStructuredApiEndpoint endpoint in endpoints.Values) {
+            endpoint.Resource ??= BuildStructuredApiPrimaryResource(endpoint.Path);
+            foreach (string tag in BuildStructuredApiTags(endpoint.Path, endpoint.Title, endpoint.Description)) {
+                AppendDistinct(endpoint.Tags, tag);
+            }
+            endpoint.OperationId ??= BuildStructuredApiOperationId(endpoint.Method, endpoint.Path, endpoint.Title);
+            ApplyStructuredApiParameterGrouping(endpoint, pageUrl);
+            if (!endpoint.Authentication.Required.HasValue
+                && (endpoint.Authentication.Schemes.Count > 0 || endpoint.Authentication.Headers.Count > 0)) {
+                endpoint.Authentication.Required = true;
+            }
+            endpoint.RequestHeaders = BuildStructuredEndpointRequestHeaders(endpoint);
+            endpoint.ResponseHeaders = BuildStructuredEndpointResponseHeaders(endpoint);
+            endpoint.ErrorResponses = endpoint.ResponseExamples
+                .Where(response => response.IsError)
+                .OrderBy(response => response.StatusCode ?? int.MaxValue)
+                .ThenBy(response => response.Title, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            endpoint.ErrorCatalog = BuildStructuredEndpointErrorCatalog(endpoint.ErrorResponses);
+            endpoint.SuccessResponseSchema = BuildStructuredEndpointResponseSchema(endpoint.ResponseExamples.Where(response => !response.IsError));
+            endpoint.ErrorResponseSchema = BuildStructuredEndpointResponseSchema(endpoint.ErrorResponses);
+            endpoint.SuccessResponseFields = BuildStructuredEndpointResponseFields(endpoint.ResponseExamples.Where(response => !response.IsError));
+            endpoint.ErrorResponseFields = BuildStructuredEndpointResponseFields(endpoint.ErrorResponses);
+        }
+
+        return endpoints.Values
+            .OrderBy(endpoint => endpoint.Path, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(endpoint => endpoint.Method, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static HtmlCrawlStructuredApiCatalog BuildStructuredApiCatalog(
+        HtmlCrawlStructuredMetadata metadata,
+        IReadOnlyList<HtmlCrawlStructuredApiEndpoint> endpoints) {
+        List<HtmlCrawlStructuredApiEndpoint> endpointList = endpoints
+            .Where(endpoint => !string.IsNullOrWhiteSpace(endpoint.Method) && !string.IsNullOrWhiteSpace(endpoint.Path))
+            .ToList();
+        return new HtmlCrawlStructuredApiCatalog {
+            Title = metadata.Title,
+            Description = metadata.Description,
+            OperationCount = endpointList.Count,
+            PathCount = endpointList.Select(endpoint => endpoint.Path).Distinct(StringComparer.OrdinalIgnoreCase).Count(),
+            AuthenticatedOperationCount = endpointList.Count(endpoint =>
+                endpoint.Authentication.Required == true
+                || endpoint.Authentication.Schemes.Count > 0
+                || endpoint.Authentication.Headers.Count > 0),
+            RateLimitedOperationCount = endpointList.Count(endpoint =>
+                endpoint.RateLimit.Mentioned
+                || endpoint.RateLimit.StatusCode.HasValue
+                || endpoint.RateLimit.Headers.Count > 0
+                || !string.IsNullOrWhiteSpace(endpoint.RateLimit.Limit)),
+            ErrorCatalogCount = endpointList.Sum(endpoint => endpoint.ErrorCatalog.Count),
+            Resources = endpointList.Select(endpoint => endpoint.Resource)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .Cast<string>()
+                .ToList(),
+            Tags = endpointList.SelectMany(endpoint => endpoint.Tags)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            OperationIds = endpointList.Select(endpoint => endpoint.OperationId)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .Cast<string>()
+                .ToList(),
+            Paths = endpointList.Select(endpoint => endpoint.Path)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+        };
+    }
+
+    private static HtmlCrawlStructuredOpenApiLike BuildStructuredOpenApiLike(
+        HtmlCrawlPage page,
+        HtmlCrawlStructuredMetadata metadata,
+        IReadOnlyList<HtmlCrawlStructuredApiEndpoint> endpoints) {
+        Dictionary<string, HtmlCrawlStructuredOpenApiPathItem> paths = new(StringComparer.OrdinalIgnoreCase);
+        foreach (HtmlCrawlStructuredApiEndpoint endpoint in endpoints
+                     .Where(endpoint => !string.IsNullOrWhiteSpace(endpoint.Method) && !string.IsNullOrWhiteSpace(endpoint.Path))
+                     .OrderBy(endpoint => endpoint.Path, StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(endpoint => endpoint.Method, StringComparer.OrdinalIgnoreCase)) {
+            if (!paths.TryGetValue(endpoint.Path, out HtmlCrawlStructuredOpenApiPathItem? pathItem)) {
+                pathItem = new HtmlCrawlStructuredOpenApiPathItem {
+                    Path = endpoint.Path
+                };
+                paths[endpoint.Path] = pathItem;
+            }
+
+            if (!string.IsNullOrWhiteSpace(endpoint.Resource)) {
+                AppendDistinct(pathItem.Resources, endpoint.Resource!);
+            }
+
+            pathItem.Operations[endpoint.Method.ToLowerInvariant()] = BuildStructuredOpenApiOperation(endpoint, page.Url);
+        }
+
+        HtmlCrawlStructuredOpenApiLike openApiLike = new() {
+            Title = metadata.Title,
+            Description = metadata.Description,
+            Servers = BuildStructuredOpenApiServers(page, metadata),
+            Tags = endpoints.SelectMany(endpoint => endpoint.Tags)
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            Resources = endpoints.Select(endpoint => endpoint.Resource)
+                .Where(resource => !string.IsNullOrWhiteSpace(resource))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(resource => resource, StringComparer.OrdinalIgnoreCase)
+                .Cast<string>()
+                .ToList(),
+            Paths = paths
+        };
+        ApplyStructuredOpenApiComponents(openApiLike);
+        AnnotateStructuredOpenApiPromotion(openApiLike);
+        return openApiLike;
+    }
+
+    private static HtmlCrawlStructuredOpenApiLike BuildResultOpenApiLike(HtmlCrawlResult result) {
+        List<(HtmlCrawlPage Page, HtmlCrawlStructuredApiEndpoint Endpoint)> endpointEntries = result.Pages
+            .Where(page => page.StructuredJson != null)
+            .SelectMany(page => (page.StructuredJson?.ApiEndpoints ?? Array.Empty<HtmlCrawlStructuredApiEndpoint>())
+                .Where(endpoint => !string.IsNullOrWhiteSpace(endpoint.Method) && !string.IsNullOrWhiteSpace(endpoint.Path))
+                .Select(endpoint => (Page: page, Endpoint: endpoint)))
+            .ToList();
+
+        Dictionary<string, HtmlCrawlStructuredOpenApiPathItem> paths = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((HtmlCrawlPage Page, HtmlCrawlStructuredApiEndpoint Endpoint) entry in endpointEntries
+                     .OrderBy(item => item.Endpoint.Path, StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(item => item.Endpoint.Method, StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(item => item.Page.Url, StringComparer.OrdinalIgnoreCase)) {
+            if (!paths.TryGetValue(entry.Endpoint.Path, out HtmlCrawlStructuredOpenApiPathItem? pathItem)) {
+                pathItem = new HtmlCrawlStructuredOpenApiPathItem {
+                    Path = entry.Endpoint.Path
+                };
+                paths[entry.Endpoint.Path] = pathItem;
+            }
+
+            if (!string.IsNullOrWhiteSpace(entry.Endpoint.Resource)) {
+                AppendDistinct(pathItem.Resources, entry.Endpoint.Resource!);
+            }
+
+            string methodKey = entry.Endpoint.Method.ToLowerInvariant();
+            if (!pathItem.Operations.TryGetValue(methodKey, out HtmlCrawlStructuredOpenApiOperation? operation)) {
+                operation = BuildStructuredOpenApiOperation(entry.Endpoint, entry.Page.Url);
+                pathItem.Operations[methodKey] = operation;
+                continue;
+            }
+
+            MergeStructuredOpenApiOperation(operation, entry.Endpoint, entry.Page.Url);
+        }
+
+        HtmlCrawlStructuredMetadata? primaryMetadata = result.Pages
+            .Select(page => page.StructuredJson?.Metadata)
+            .FirstOrDefault(metadata => metadata != null && (!string.IsNullOrWhiteSpace(metadata.Title) || !string.IsNullOrWhiteSpace(metadata.Description)));
+
+        HtmlCrawlStructuredOpenApiLike openApiLike = new() {
+            Title = primaryMetadata?.Title,
+            Description = primaryMetadata?.Description,
+            Servers = BuildStructuredOpenApiServers(result.Pages.Select(page => page.Url)),
+            Tags = endpointEntries.SelectMany(item => item.Endpoint.Tags)
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            Resources = endpointEntries.Select(item => item.Endpoint.Resource)
+                .Where(resource => !string.IsNullOrWhiteSpace(resource))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(resource => resource, StringComparer.OrdinalIgnoreCase)
+                .Cast<string>()
+                .ToList(),
+            Paths = paths
+        };
+        ApplyStructuredOpenApiComponents(openApiLike);
+        AnnotateStructuredOpenApiPromotion(openApiLike);
+        return openApiLike;
+    }
+
+    private static HtmlCrawlStructuredOpenApiOperation BuildStructuredOpenApiOperation(HtmlCrawlStructuredApiEndpoint endpoint, string pageUrl) {
+        return new HtmlCrawlStructuredOpenApiOperation {
+            OperationId = endpoint.OperationId,
+            Method = endpoint.Method.ToLowerInvariant(),
+            Path = endpoint.Path,
+            Summary = endpoint.Title,
+            Description = endpoint.Description,
+            Resource = endpoint.Resource,
+            Tags = new List<string>(endpoint.Tags),
+            Authentication = CloneStructuredApiAuthentication(endpoint.Authentication),
+            RateLimit = CloneStructuredApiRateLimit(endpoint.RateLimit),
+            Parameters = endpoint.Parameters.Select(CloneStructuredApiParameter).ToList(),
+            RequestHeaders = endpoint.RequestHeaders.Select(CloneStructuredHttpHeader).ToList(),
+            ResponseHeaders = endpoint.ResponseHeaders.Select(CloneStructuredHttpHeader).ToList(),
+            RequestExamples = endpoint.RequestExamples.Select(CloneStructuredRequestExample).ToList(),
+            ResponseExamples = endpoint.ResponseExamples.Select(CloneStructuredResponseExample).ToList(),
+            ErrorCatalog = endpoint.ErrorCatalog.Select(CloneStructuredApiError).ToList(),
+            RequestBodySchema = new Dictionary<string, string?>(endpoint.RequestBodySchema, StringComparer.OrdinalIgnoreCase),
+            RequestBodyFields = endpoint.RequestBodyFields.Select(CloneStructuredField).ToList(),
+            SuccessResponseSchema = new Dictionary<string, string?>(endpoint.SuccessResponseSchema, StringComparer.OrdinalIgnoreCase),
+            SuccessResponseFields = endpoint.SuccessResponseFields.Select(CloneStructuredField).ToList(),
+            ErrorResponseSchema = new Dictionary<string, string?>(endpoint.ErrorResponseSchema, StringComparer.OrdinalIgnoreCase),
+            ErrorResponseFields = endpoint.ErrorResponseFields.Select(CloneStructuredField).ToList(),
+            Provenance = BuildStructuredOpenApiProvenance(endpoint, pageUrl)
+        };
+    }
+
+    private static void AnnotateStructuredOpenApiPromotion(HtmlCrawlStructuredOpenApiLike openApiLike) {
+        List<HtmlCrawlStructuredOpenApiOperation> operations = openApiLike.Paths.Values
+            .SelectMany(path => path.Operations.Values)
+            .ToList();
+
+        foreach (HtmlCrawlStructuredOpenApiOperation operation in operations) {
+            AnnotateStructuredOpenApiPromotion(operation);
+        }
+
+        openApiLike.StrictOpenApiPromotionThreshold = StrictOpenApiPromotionThreshold;
+        openApiLike.StrictOpenApiEligibleOperationCount = operations.Count(operation => operation.StrictOpenApiEligible);
+        openApiLike.StrictOpenApiSkippedOperationCount = operations.Count - openApiLike.StrictOpenApiEligibleOperationCount;
+        openApiLike.StrictOpenApiAverageScore = operations.Count == 0
+            ? 0
+            : Math.Round(operations.Average(operation => operation.StrictOpenApiScore), 2, MidpointRounding.AwayFromZero);
+    }
+
+    private static void AnnotateStructuredOpenApiPromotion(HtmlCrawlStructuredOpenApiOperation operation) {
+        List<string> warnings = new();
+        int score = 0;
+
+        bool hasMethod = !string.IsNullOrWhiteSpace(operation.Method);
+        bool hasPath = !string.IsNullOrWhiteSpace(operation.Path);
+        bool hasOperationId = !string.IsNullOrWhiteSpace(operation.OperationId);
+        bool hasSummary = !string.IsNullOrWhiteSpace(operation.Summary);
+        bool hasDescription = !string.IsNullOrWhiteSpace(operation.Description);
+        bool hasGrouping = !string.IsNullOrWhiteSpace(operation.Resource) || operation.Tags.Count > 0;
+        bool hasRequestContract = operation.Parameters.Count > 0
+            || operation.RequestBodyFields.Count > 0
+            || operation.RequestBodySchema.Count > 0
+            || operation.RequestExamples.Count > 0;
+        bool hasResponseContract = operation.ResponseExamples.Count > 0
+            || operation.SuccessResponseFields.Count > 0
+            || operation.SuccessResponseSchema.Count > 0
+            || operation.ErrorResponseFields.Count > 0
+            || operation.ErrorResponseSchema.Count > 0;
+        bool hasSuccessfulResponse = operation.ResponseExamples.Any(example => !example.IsError && example.StatusCode.GetValueOrDefault() < 400)
+            || operation.SuccessResponseFields.Count > 0
+            || operation.SuccessResponseSchema.Count > 0;
+        bool hasErrorCoverage = operation.ResponseExamples.Any(example => example.IsError)
+            || operation.ErrorCatalog.Count > 0
+            || operation.ErrorResponseFields.Count > 0
+            || operation.ErrorResponseSchema.Count > 0;
+        bool hasAuthentication = operation.Authentication.Required != false
+            || operation.Authentication.Headers.Count > 0
+            || operation.Authentication.Schemes.Count > 0;
+        bool hasRateLimit = operation.RateLimit.Mentioned
+            || operation.RateLimit.StatusCode != null
+            || operation.RateLimit.Headers.Count > 0;
+        bool hasHeaders = operation.RequestHeaders.Count > 0 || operation.ResponseHeaders.Count > 0;
+
+        if (hasMethod) {
+            score += 10;
+        } else {
+            warnings.Add("missing method");
+        }
+
+        if (hasPath) {
+            score += 10;
+        } else {
+            warnings.Add("missing path");
+        }
+
+        if (hasOperationId) {
+            score += 10;
+        } else {
+            warnings.Add("missing operationId");
+        }
+
+        if (hasSummary) {
+            score += 10;
+        } else {
+            warnings.Add("missing summary");
+        }
+
+        if (hasDescription) {
+            score += 5;
+        } else {
+            warnings.Add("missing description");
+        }
+
+        if (hasGrouping) {
+            score += 5;
+        }
+
+        if (operation.Parameters.Count > 0) {
+            score += 8;
+        }
+        if (operation.RequestBodyFields.Count > 0 || operation.RequestBodySchema.Count > 0) {
+            score += 8;
+        }
+        if (operation.RequestExamples.Count > 0) {
+            score += 8;
+        }
+        if (!hasRequestContract) {
+            warnings.Add("missing request contract");
+        }
+
+        if (hasSuccessfulResponse) {
+            score += 20;
+        } else {
+            warnings.Add("missing success response contract");
+        }
+
+        if (hasResponseContract) {
+            score += 8;
+        } else {
+            warnings.Add("missing response contract");
+        }
+
+        if (hasErrorCoverage) {
+            score += 4;
+        }
+        if (hasAuthentication) {
+            score += 4;
+        }
+        if (hasRateLimit) {
+            score += 2;
+        }
+        if (hasHeaders) {
+            score += 2;
+        }
+
+        operation.StrictOpenApiScore = Math.Min(score, 100);
+        operation.StrictOpenApiEligible = hasMethod
+            && hasPath
+            && hasSummary
+            && hasSuccessfulResponse
+            && operation.StrictOpenApiScore >= StrictOpenApiPromotionThreshold;
+
+        if (!operation.StrictOpenApiEligible && operation.StrictOpenApiScore < StrictOpenApiPromotionThreshold) {
+            warnings.Add("promotion score below threshold");
+        }
+
+        operation.StrictOpenApiWarnings = warnings
+            .Where(warning => !string.IsNullOrWhiteSpace(warning))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(warning => warning, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static HtmlCrawlStructuredOpenApiProvenance BuildStructuredOpenApiProvenance(HtmlCrawlStructuredApiEndpoint endpoint, string pageUrl) {
+        HtmlCrawlStructuredOpenApiProvenance provenance = new();
+        AppendStructuredOpenApiProvenanceEntry(provenance, pageUrl, "Endpoint", endpoint.SelectorHint, endpoint.Title);
+
+        foreach (string sourceKind in endpoint.Sources) {
+            AppendDistinct(provenance.SourceKinds, sourceKind);
+            AppendStructuredOpenApiProvenanceEntry(provenance, pageUrl, sourceKind, endpoint.SelectorHint, endpoint.Title);
+        }
+
+        foreach (HtmlCrawlStructuredRequestExample example in endpoint.RequestExamples) {
+            AppendStructuredOpenApiProvenanceEntry(provenance, pageUrl, "RequestExample", example.SelectorHint, example.Title ?? example.Method ?? example.Path);
+        }
+
+        foreach (HtmlCrawlStructuredResponseExample example in endpoint.ResponseExamples) {
+            string? label = example.Title
+                ?? (example.StatusCode.HasValue ? $"Response {example.StatusCode.Value}" : null)
+                ?? example.Description;
+            AppendStructuredOpenApiProvenanceEntry(provenance, pageUrl, "ResponseExample", example.SelectorHint, label);
+        }
+
+        foreach (HtmlCrawlStructuredApiError error in endpoint.ErrorCatalog) {
+            string? label = error.Summary
+                ?? (error.StatusCode.HasValue ? $"Error {error.StatusCode.Value}" : null)
+                ?? error.StatusText;
+            AppendStructuredOpenApiProvenanceEntry(provenance, pageUrl, "ErrorCatalog", error.SelectorHint, label);
+        }
+
+        if (endpoint.Parameters.Count > 0) {
+            string? parameterSource = endpoint.Parameters
+                .Select(parameter => parameter.Location)
+                .FirstOrDefault(location => !string.IsNullOrWhiteSpace(location));
+            AppendStructuredOpenApiProvenanceEntry(provenance, pageUrl, "ParameterTable", endpoint.SelectorHint, parameterSource);
+        }
+
+        return provenance;
+    }
+
+    private static void MergeStructuredOpenApiProvenance(HtmlCrawlStructuredOpenApiProvenance target, HtmlCrawlStructuredOpenApiProvenance source) {
+        foreach (string pageUrl in source.PageUrls) {
+            AppendDistinct(target.PageUrls, pageUrl);
+        }
+
+        foreach (string kind in source.SourceKinds) {
+            AppendDistinct(target.SourceKinds, kind);
+        }
+
+        foreach (HtmlCrawlStructuredOpenApiProvenanceEntry entry in source.Entries) {
+            if (target.Entries.Any(existing =>
+                    string.Equals(existing.PageUrl, entry.PageUrl, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Kind, entry.Kind, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.SelectorHint, entry.SelectorHint, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Label, entry.Label, StringComparison.OrdinalIgnoreCase))) {
+                continue;
+            }
+
+            target.Entries.Add(CloneStructuredOpenApiProvenanceEntry(entry));
+        }
+    }
+
+    private static void AppendStructuredOpenApiProvenanceEntry(
+        HtmlCrawlStructuredOpenApiProvenance provenance,
+        string pageUrl,
+        string kind,
+        string? selectorHint,
+        string? label) {
+        if (string.IsNullOrWhiteSpace(pageUrl) || string.IsNullOrWhiteSpace(kind)) {
+            return;
+        }
+
+        AppendDistinct(provenance.PageUrls, pageUrl);
+        AppendDistinct(provenance.SourceKinds, kind);
+
+        if (provenance.Entries.Any(existing =>
+                string.Equals(existing.PageUrl, pageUrl, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Kind, kind, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.SelectorHint, selectorHint, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Label, label, StringComparison.OrdinalIgnoreCase))) {
+            return;
+        }
+
+        provenance.Entries.Add(new HtmlCrawlStructuredOpenApiProvenanceEntry {
+            PageUrl = pageUrl,
+            Kind = kind,
+            SelectorHint = selectorHint,
+            Label = label
+        });
+    }
+
+    private static void MergeStructuredOpenApiOperation(HtmlCrawlStructuredOpenApiOperation target, HtmlCrawlStructuredApiEndpoint source, string pageUrl) {
+        target.OperationId ??= source.OperationId;
+        target.Summary ??= source.Title;
+        target.Description ??= source.Description;
+        target.Resource ??= source.Resource;
+        foreach (string tag in source.Tags) {
+            AppendDistinct(target.Tags, tag);
+        }
+
+        MergeStructuredApiAuthentication(target.Authentication, source.Authentication);
+        MergeStructuredApiRateLimit(target.RateLimit, source.RateLimit);
+
+        foreach (HtmlCrawlStructuredApiParameter parameter in source.Parameters) {
+            if (!target.Parameters.Any(existing =>
+                    string.Equals(existing.Name, parameter.Name, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Location, parameter.Location, StringComparison.OrdinalIgnoreCase))) {
+                target.Parameters.Add(CloneStructuredApiParameter(parameter));
+            }
+        }
+
+        foreach (HtmlCrawlStructuredHttpHeader header in source.RequestHeaders) {
+            AppendStructuredHeader(target.RequestHeaders, header.Name, header.Value);
+        }
+        foreach (HtmlCrawlStructuredHttpHeader header in source.ResponseHeaders) {
+            AppendStructuredHeader(target.ResponseHeaders, header.Name, header.Value);
+        }
+
+        foreach (HtmlCrawlStructuredRequestExample example in source.RequestExamples) {
+            if (!target.RequestExamples.Any(existing =>
+                    string.Equals(existing.Method, example.Method, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Path, example.Path, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(existing.Body, example.Body, StringComparison.Ordinal)
+                    && string.Equals(existing.Title, example.Title, StringComparison.OrdinalIgnoreCase))) {
+                target.RequestExamples.Add(CloneStructuredRequestExample(example));
+            }
+        }
+
+        foreach (HtmlCrawlStructuredResponseExample example in source.ResponseExamples) {
+            if (!target.ResponseExamples.Any(existing =>
+                    existing.StatusCode == example.StatusCode
+                    && string.Equals(existing.Body, example.Body, StringComparison.Ordinal)
+                    && string.Equals(existing.Title, example.Title, StringComparison.OrdinalIgnoreCase))) {
+                target.ResponseExamples.Add(CloneStructuredResponseExample(example));
+            }
+        }
+
+        foreach (HtmlCrawlStructuredApiError error in source.ErrorCatalog) {
+            HtmlCrawlStructuredApiError? existing = target.ErrorCatalog.FirstOrDefault(item =>
+                item.StatusCode == error.StatusCode
+                && string.Equals(item.StatusText, error.StatusText, StringComparison.OrdinalIgnoreCase));
+            if (existing == null) {
+                target.ErrorCatalog.Add(CloneStructuredApiError(error));
+                continue;
+            }
+
+            existing.Summary ??= error.Summary;
+            existing.ContentType ??= error.ContentType;
+            existing.SelectorHint ??= error.SelectorHint;
+            existing.SampleCount += error.SampleCount;
+            foreach (HtmlCrawlStructuredHttpHeader header in error.Headers) {
+                AppendStructuredHeader(existing.Headers, header.Name, header.Value);
+            }
+            MergeStructuredSchemaMaps(existing.Schema, error.Schema);
+            existing.Fields = MergeStructuredFieldCollections(existing.Fields, error.Fields);
+        }
+
+        MergeStructuredSchemaMaps(target.RequestBodySchema, source.RequestBodySchema);
+        MergeStructuredSchemaMaps(target.SuccessResponseSchema, source.SuccessResponseSchema);
+        MergeStructuredSchemaMaps(target.ErrorResponseSchema, source.ErrorResponseSchema);
+        target.RequestBodyFields = MergeStructuredFieldCollections(target.RequestBodyFields, source.RequestBodyFields);
+        target.SuccessResponseFields = MergeStructuredFieldCollections(target.SuccessResponseFields, source.SuccessResponseFields);
+        target.ErrorResponseFields = MergeStructuredFieldCollections(target.ErrorResponseFields, source.ErrorResponseFields);
+        MergeStructuredOpenApiProvenance(target.Provenance, BuildStructuredOpenApiProvenance(source, pageUrl));
+    }
+
+    private static IList<HtmlCrawlStructuredField> MergeStructuredFieldCollections(
+        IEnumerable<HtmlCrawlStructuredField> first,
+        IEnumerable<HtmlCrawlStructuredField> second) {
+        Dictionary<string, HtmlCrawlStructuredField> fields = new(StringComparer.OrdinalIgnoreCase);
+        foreach (HtmlCrawlStructuredField field in first.Concat(second)) {
+            if (!fields.TryGetValue(field.Path, out HtmlCrawlStructuredField? existing)) {
+                fields[field.Path] = CloneStructuredField(field);
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(existing.Name) && !string.IsNullOrWhiteSpace(field.Name)) {
+                existing.Name = field.Name;
+            }
+            existing.ParentPath ??= field.ParentPath;
+            existing.Kind = MergeStructuredFieldKinds(existing.Kind, field.Kind);
+            existing.Depth = Math.Min(existing.Depth, field.Depth);
+            existing.Type = MergeStructuredTypeValues(existing.Type, field.Type);
+            existing.Format ??= field.Format;
+            existing.Required = existing.Required == true && field.Required == true
+                ? true
+                : existing.Required ?? field.Required;
+            existing.Nullable = existing.Nullable == true || field.Nullable == true
+                ? true
+                : existing.Nullable ?? field.Nullable;
+            existing.ExampleValue ??= field.ExampleValue;
+            existing.Source ??= field.Source;
+            MergeStructuredFieldProvenance(existing, field);
+            existing.EvidenceCount = Math.Max(existing.EvidenceCount, field.EvidenceCount);
+            existing.ConfidenceScore = Math.Max(existing.ConfidenceScore, field.ConfidenceScore);
+            foreach (string enumValue in field.EnumValues) {
+                AppendDistinct(existing.EnumValues, enumValue);
+            }
+            foreach (string childPath in field.ChildPaths) {
+                AppendDistinct(existing.ChildPaths, childPath);
+            }
+        }
+
+        return FinalizeStructuredFieldConfidence(FinalizeStructuredFieldRelationships(fields.Values))
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static void AppendStructuredFieldProvenance(
+        HtmlCrawlStructuredField field,
+        string pageUrl,
+        string kind,
+        string? selectorHint,
+        string? label) {
+        if (field == null || string.IsNullOrWhiteSpace(pageUrl) || string.IsNullOrWhiteSpace(kind)) {
+            return;
+        }
+
+        if (field.Provenance.Any(existing =>
+                string.Equals(existing.PageUrl, pageUrl, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Kind, kind, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.SelectorHint, selectorHint, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Label, label, StringComparison.OrdinalIgnoreCase))) {
+            return;
+        }
+
+        field.Provenance.Add(new HtmlCrawlStructuredFieldProvenanceEntry {
+            PageUrl = pageUrl,
+            Kind = kind,
+            SelectorHint = selectorHint,
+            Label = label
+        });
+    }
+
+    private static void MergeStructuredFieldProvenance(HtmlCrawlStructuredField target, HtmlCrawlStructuredField source) {
+        foreach (HtmlCrawlStructuredFieldProvenanceEntry provenance in source.Provenance) {
+            AppendStructuredFieldProvenance(target, provenance.PageUrl, provenance.Kind, provenance.SelectorHint, provenance.Label);
+        }
+    }
+
+    private static IList<HtmlCrawlStructuredField> FinalizeStructuredFieldConfidence(IEnumerable<HtmlCrawlStructuredField> fields) {
+        List<HtmlCrawlStructuredField> fieldList = fields.ToList();
+        foreach (HtmlCrawlStructuredField field in fieldList) {
+            field.EvidenceCount = field.Provenance
+                .Select(entry => string.Join("|",
+                    entry.PageUrl ?? string.Empty,
+                    entry.Kind ?? string.Empty,
+                    entry.SelectorHint ?? string.Empty,
+                    entry.Label ?? string.Empty))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count();
+            field.ConfidenceScore = ComputeStructuredFieldConfidence(field);
+        }
+
+        return fieldList;
+    }
+
+    private static int ComputeStructuredFieldConfidence(HtmlCrawlStructuredField field) {
+        int score = 20;
+        int evidenceCount = field.EvidenceCount > 0 ? field.EvidenceCount : field.Provenance.Count;
+        int sourceKindCount = field.Provenance
+            .Select(entry => entry.Kind)
+            .Where(kind => !string.IsNullOrWhiteSpace(kind))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+
+        if (field.Provenance.Any(entry => string.Equals(entry.Kind, "ParameterTable", StringComparison.OrdinalIgnoreCase))) {
+            score += 40;
+        }
+        if (field.Provenance.Any(entry => string.Equals(entry.Kind, "JsonResponse", StringComparison.OrdinalIgnoreCase))) {
+            score += 25;
+        }
+        if (field.Provenance.Any(entry => string.Equals(entry.Kind, "JsonSchemaMap", StringComparison.OrdinalIgnoreCase))) {
+            score += 10;
+        }
+        if (field.Required == true) {
+            score += 10;
+        }
+        if (!string.IsNullOrWhiteSpace(field.Type)) {
+            score += 5;
+        }
+        if (!string.IsNullOrWhiteSpace(field.Format)) {
+            score += 5;
+        }
+        if (!string.IsNullOrWhiteSpace(field.ExampleValue)) {
+            score += 5;
+        }
+        if (field.EnumValues.Count > 0) {
+            score += 5;
+        }
+        if (field.ChildPaths.Count > 0) {
+            score += 5;
+        }
+
+        score += Math.Min(evidenceCount * 5, 15);
+        score += Math.Min(sourceKindCount * 5, 10);
+
+        return Math.Min(score, 100);
+    }
+
+    private static void ApplyStructuredOpenApiComponents(HtmlCrawlStructuredOpenApiLike openApiLike) {
+        HtmlCrawlStructuredOpenApiComponents components = new();
+        Dictionary<string, string> schemaRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> fieldSetRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> authRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> rateLimitRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> parameterSetRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> requestHeaderSetRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> responseHeaderSetRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> requestExampleSetRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> responseExampleSetRefs = new(StringComparer.Ordinal);
+        Dictionary<string, string> errorCatalogRefs = new(StringComparer.Ordinal);
+
+        foreach (HtmlCrawlStructuredOpenApiOperation operation in openApiLike.Paths.Values
+                     .SelectMany(path => path.Operations.Values)
+                     .OrderBy(operation => operation.Path, StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(operation => operation.Method, StringComparer.OrdinalIgnoreCase)) {
+            if (HasStructuredAuthProfile(operation.Authentication)) {
+                operation.AuthenticationRef = GetOrAddStructuredAuthProfileComponent(components, authRefs, operation.Authentication);
+            }
+            if (HasStructuredRateLimitProfile(operation.RateLimit)) {
+                operation.RateLimitRef = GetOrAddStructuredRateLimitProfileComponent(components, rateLimitRefs, operation.RateLimit);
+            }
+            if (operation.Parameters.Count > 0) {
+                operation.ParametersRef = GetOrAddStructuredParameterSetComponent(components, parameterSetRefs, operation.Parameters);
+            }
+            if (operation.RequestHeaders.Count > 0) {
+                operation.RequestHeadersRef = GetOrAddStructuredHeaderSetComponent(components, requestHeaderSetRefs, "requestHeaderSet", operation.RequestHeaders);
+            }
+            if (operation.ResponseHeaders.Count > 0) {
+                operation.ResponseHeadersRef = GetOrAddStructuredHeaderSetComponent(components, responseHeaderSetRefs, "responseHeaderSet", operation.ResponseHeaders);
+            }
+            if (operation.RequestExamples.Count > 0) {
+                operation.RequestExamplesRef = GetOrAddStructuredRequestExampleSetComponent(components, requestExampleSetRefs, operation.RequestExamples);
+            }
+            if (operation.ResponseExamples.Count > 0) {
+                operation.ResponseExamplesRef = GetOrAddStructuredResponseExampleSetComponent(components, responseExampleSetRefs, operation.ResponseExamples);
+            }
+            if (operation.ErrorCatalog.Count > 0) {
+                operation.ErrorCatalogRef = GetOrAddStructuredErrorCatalogComponent(components, errorCatalogRefs, operation.ErrorCatalog);
+            }
+            if (operation.RequestBodySchema.Count > 0) {
+                operation.RequestBodySchemaRef = GetOrAddStructuredSchemaComponent(components, schemaRefs, "requestBodySchema", operation.RequestBodySchema);
+            }
+            if (operation.SuccessResponseSchema.Count > 0) {
+                operation.SuccessResponseSchemaRef = GetOrAddStructuredSchemaComponent(components, schemaRefs, "successResponseSchema", operation.SuccessResponseSchema);
+            }
+            if (operation.ErrorResponseSchema.Count > 0) {
+                operation.ErrorResponseSchemaRef = GetOrAddStructuredSchemaComponent(components, schemaRefs, "errorResponseSchema", operation.ErrorResponseSchema);
+            }
+            if (operation.RequestBodyFields.Count > 0) {
+                operation.RequestBodyFieldsRef = GetOrAddStructuredFieldSetComponent(components, fieldSetRefs, "requestBodyFields", operation.RequestBodyFields);
+            }
+            if (operation.SuccessResponseFields.Count > 0) {
+                operation.SuccessResponseFieldsRef = GetOrAddStructuredFieldSetComponent(components, fieldSetRefs, "successResponseFields", operation.SuccessResponseFields);
+            }
+            if (operation.ErrorResponseFields.Count > 0) {
+                operation.ErrorResponseFieldsRef = GetOrAddStructuredFieldSetComponent(components, fieldSetRefs, "errorResponseFields", operation.ErrorResponseFields);
+            }
+        }
+
+        openApiLike.Components = components;
+    }
+
+    private static bool HasStructuredAuthProfile(HtmlCrawlStructuredApiAuthentication value) =>
+        value.Required.HasValue
+        || value.Schemes.Count > 0
+        || value.Headers.Count > 0
+        || !string.IsNullOrWhiteSpace(value.Summary);
+
+    private static bool HasStructuredRateLimitProfile(HtmlCrawlStructuredApiRateLimit value) =>
+        value.Mentioned
+        || value.StatusCode.HasValue
+        || value.Headers.Count > 0
+        || !string.IsNullOrWhiteSpace(value.Limit)
+        || !string.IsNullOrWhiteSpace(value.Window)
+        || !string.IsNullOrWhiteSpace(value.Summary);
+
+    private static string GetOrAddStructuredSchemaComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        string prefix,
+        IDictionary<string, string?> schema) {
+        string signature = BuildStructuredSchemaSignature(schema);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey(prefix, components.Schemas.Keys);
+        components.Schemas[key] = new Dictionary<string, string?>(schema, StringComparer.OrdinalIgnoreCase);
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredFieldSetComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        string prefix,
+        IEnumerable<HtmlCrawlStructuredField> fields) {
+        List<HtmlCrawlStructuredField> clonedFields = fields.Select(CloneStructuredField).ToList();
+        string signature = BuildStructuredFieldSetSignature(clonedFields);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey(prefix, components.FieldSets.Keys);
+        components.FieldSets[key] = clonedFields;
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredAuthProfileComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        HtmlCrawlStructuredApiAuthentication auth) {
+        string signature = BuildStructuredAuthProfileSignature(auth);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey("authProfile", components.AuthProfiles.Keys);
+        components.AuthProfiles[key] = CloneStructuredApiAuthentication(auth);
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredRateLimitProfileComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        HtmlCrawlStructuredApiRateLimit rateLimit) {
+        string signature = BuildStructuredRateLimitProfileSignature(rateLimit);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey("rateLimitProfile", components.RateLimitProfiles.Keys);
+        components.RateLimitProfiles[key] = CloneStructuredApiRateLimit(rateLimit);
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredParameterSetComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        IEnumerable<HtmlCrawlStructuredApiParameter> parameters) {
+        List<HtmlCrawlStructuredApiParameter> clonedParameters = parameters.Select(CloneStructuredApiParameter).ToList();
+        string signature = BuildStructuredParameterSetSignature(clonedParameters);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey("parameterSet", components.ParameterSets.Keys);
+        components.ParameterSets[key] = clonedParameters;
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredHeaderSetComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        string prefix,
+        IEnumerable<HtmlCrawlStructuredHttpHeader> headers) {
+        List<HtmlCrawlStructuredHttpHeader> clonedHeaders = headers.Select(CloneStructuredHttpHeader).ToList();
+        string signature = BuildStructuredHeaderSetSignature(clonedHeaders);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey(prefix, prefix.StartsWith("request", StringComparison.OrdinalIgnoreCase)
+            ? components.RequestHeaderSets.Keys
+            : components.ResponseHeaderSets.Keys);
+        if (prefix.StartsWith("request", StringComparison.OrdinalIgnoreCase)) {
+            components.RequestHeaderSets[key] = clonedHeaders;
+        } else {
+            components.ResponseHeaderSets[key] = clonedHeaders;
+        }
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredRequestExampleSetComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        IEnumerable<HtmlCrawlStructuredRequestExample> examples) {
+        List<HtmlCrawlStructuredRequestExample> clonedExamples = examples.Select(CloneStructuredRequestExample).ToList();
+        string signature = BuildStructuredRequestExampleSetSignature(clonedExamples);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey("requestExampleSet", components.RequestExampleSets.Keys);
+        components.RequestExampleSets[key] = clonedExamples;
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredResponseExampleSetComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        IEnumerable<HtmlCrawlStructuredResponseExample> examples) {
+        List<HtmlCrawlStructuredResponseExample> clonedExamples = examples.Select(CloneStructuredResponseExample).ToList();
+        string signature = BuildStructuredResponseExampleSetSignature(clonedExamples);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey("responseExampleSet", components.ResponseExampleSets.Keys);
+        components.ResponseExampleSets[key] = clonedExamples;
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string GetOrAddStructuredErrorCatalogComponent(
+        HtmlCrawlStructuredOpenApiComponents components,
+        IDictionary<string, string> refs,
+        IEnumerable<HtmlCrawlStructuredApiError> errors) {
+        List<HtmlCrawlStructuredApiError> clonedErrors = errors.Select(CloneStructuredApiError).ToList();
+        string signature = BuildStructuredErrorCatalogSignature(clonedErrors);
+        if (refs.TryGetValue(signature, out string? existingRef)) {
+            return existingRef;
+        }
+
+        string key = BuildStructuredComponentKey("errorCatalog", components.ErrorCatalogs.Keys);
+        components.ErrorCatalogs[key] = clonedErrors;
+        refs[signature] = key;
+        return key;
+    }
+
+    private static string BuildStructuredComponentKey(string prefix, IEnumerable<string> existingKeys) {
+        HashSet<string> keys = new(existingKeys, StringComparer.OrdinalIgnoreCase);
+        int index = 1;
+        string candidate;
+        do {
+            candidate = prefix + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            index++;
+        } while (keys.Contains(candidate));
+
+        return candidate;
+    }
+
+    private static string BuildStructuredSchemaSignature(IEnumerable<KeyValuePair<string, string?>> schema) {
+        return string.Join("|", schema
+            .OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(item => $"{item.Key}={item.Value ?? string.Empty}"));
+    }
+
+    private static string BuildStructuredFieldSetSignature(IEnumerable<HtmlCrawlStructuredField> fields) {
+        return string.Join("|", fields
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .Select(field => string.Join("~", new[] {
+                field.Path,
+                field.ParentPath ?? string.Empty,
+                field.Kind ?? string.Empty,
+                field.Type ?? string.Empty,
+                field.Format ?? string.Empty,
+                field.Required?.ToString() ?? string.Empty,
+                field.Nullable?.ToString() ?? string.Empty,
+                string.Join(",", field.ChildPaths.OrderBy(item => item, StringComparer.OrdinalIgnoreCase)),
+                string.Join(",", field.EnumValues.OrderBy(item => item, StringComparer.OrdinalIgnoreCase))
+            })));
+    }
+
+    private static string BuildStructuredAuthProfileSignature(HtmlCrawlStructuredApiAuthentication auth) {
+        return string.Join("|", new[] {
+            auth.Required?.ToString() ?? string.Empty,
+            string.Join(",", auth.Schemes.OrderBy(item => item, StringComparer.OrdinalIgnoreCase)),
+            string.Join(",", auth.Headers.OrderBy(item => item, StringComparer.OrdinalIgnoreCase))
+        });
+    }
+
+    private static string BuildStructuredRateLimitProfileSignature(HtmlCrawlStructuredApiRateLimit rateLimit) {
+        return string.Join("|", new[] {
+            rateLimit.Mentioned.ToString(),
+            rateLimit.StatusCode?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+            rateLimit.Limit ?? string.Empty,
+            rateLimit.Window ?? string.Empty,
+            string.Join(",", rateLimit.Headers.OrderBy(item => item, StringComparer.OrdinalIgnoreCase))
+        });
+    }
+
+    private static string BuildStructuredParameterSetSignature(IEnumerable<HtmlCrawlStructuredApiParameter> parameters) {
+        return string.Join("|", parameters
+            .OrderBy(parameter => parameter.Location, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(parameter => string.Join("~", new[] {
+                parameter.Name,
+                parameter.Type ?? string.Empty,
+                parameter.Format ?? string.Empty,
+                parameter.Location ?? string.Empty,
+                parameter.Required?.ToString() ?? string.Empty,
+                parameter.Nullable?.ToString() ?? string.Empty,
+                parameter.Pattern ?? string.Empty,
+                parameter.DefaultValue ?? string.Empty,
+                parameter.ExampleValue ?? string.Empty,
+                string.Join(",", parameter.EnumValues.OrderBy(item => item, StringComparer.OrdinalIgnoreCase))
+            })));
+    }
+
+    private static string BuildStructuredHeaderSetSignature(IEnumerable<HtmlCrawlStructuredHttpHeader> headers) {
+        return string.Join("|", headers
+            .OrderBy(header => header.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(header => $"{header.Name}={header.Value ?? string.Empty}"));
+    }
+
+    private static string BuildStructuredRequestExampleSetSignature(IEnumerable<HtmlCrawlStructuredRequestExample> examples) {
+        return string.Join("|", examples
+            .OrderBy(example => example.Method, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(example => example.Path, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(example => example.Title, StringComparer.OrdinalIgnoreCase)
+            .Select(example => string.Join("~", new[] {
+                example.Method ?? string.Empty,
+                example.Path ?? string.Empty,
+                example.ContentType ?? string.Empty,
+                example.Kind,
+                BuildStructuredHeaderSetSignature(example.Headers),
+                example.Body
+            })));
+    }
+
+    private static string BuildStructuredResponseExampleSetSignature(IEnumerable<HtmlCrawlStructuredResponseExample> examples) {
+        return string.Join("|", examples
+            .OrderBy(example => example.StatusCode ?? int.MaxValue)
+            .ThenBy(example => example.Title, StringComparer.OrdinalIgnoreCase)
+            .Select(example => string.Join("~", new[] {
+                example.StatusCode?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                example.StatusText ?? string.Empty,
+                example.ContentType ?? string.Empty,
+                example.Kind,
+                BuildStructuredHeaderSetSignature(example.Headers),
+                example.Body
+            })));
+    }
+
+    private static string BuildStructuredErrorCatalogSignature(IEnumerable<HtmlCrawlStructuredApiError> errors) {
+        return string.Join("|", errors
+            .OrderBy(error => error.StatusCode ?? int.MaxValue)
+            .ThenBy(error => error.StatusText, StringComparer.OrdinalIgnoreCase)
+            .Select(error => string.Join("~", new[] {
+                error.StatusCode?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                error.StatusText ?? string.Empty,
+                error.ContentType ?? string.Empty,
+                BuildStructuredHeaderSetSignature(error.Headers),
+                BuildStructuredSchemaSignature(error.Schema),
+                BuildStructuredFieldSetSignature(error.Fields)
+            })));
+    }
+
+    private static string NormalizeStrictOpenApiParameterLocation(string? location) {
+        string normalized = NormalizeWhitespace(location)?.ToLowerInvariant() ?? string.Empty;
+        return normalized is "path" or "query" or "header" or "cookie" ? normalized : "query";
+    }
+
+    private static object? BuildStrictOpenApiSchemaReference(string? fieldSetRef, string? schemaRef) {
+        string? reference = !string.IsNullOrWhiteSpace(fieldSetRef) ? fieldSetRef : schemaRef;
+        if (string.IsNullOrWhiteSpace(reference)) {
+            return null;
+        }
+
+        return new Dictionary<string, object?> {
+            ["$ref"] = $"#/components/schemas/{reference}"
+        };
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiRequestExamples(IEnumerable<HtmlCrawlStructuredRequestExample> examples) {
+        Dictionary<string, object?> values = new(StringComparer.OrdinalIgnoreCase);
+        int index = 1;
+        foreach (HtmlCrawlStructuredRequestExample example in examples) {
+            values["example" + index.ToString(System.Globalization.CultureInfo.InvariantCulture)] = new Dictionary<string, object?> {
+                ["summary"] = example.Title ?? example.Description,
+                ["value"] = ParseStrictOpenApiExampleValue(example.Body)
+            };
+            index++;
+        }
+
+        return values;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiResponseExamples(IEnumerable<HtmlCrawlStructuredResponseExample> examples) {
+        Dictionary<string, object?> values = new(StringComparer.OrdinalIgnoreCase);
+        int index = 1;
+        foreach (HtmlCrawlStructuredResponseExample example in examples) {
+            values["example" + index.ToString(System.Globalization.CultureInfo.InvariantCulture)] = new Dictionary<string, object?> {
+                ["summary"] = example.Title ?? example.Description ?? example.StatusText,
+                ["value"] = ParseStrictOpenApiExampleValue(example.Body)
+            };
+            index++;
+        }
+
+        return values;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiHeaderDefinitions(IEnumerable<HtmlCrawlStructuredHttpHeader> headers) {
+        Dictionary<string, object?> values = new(StringComparer.OrdinalIgnoreCase);
+        foreach (HtmlCrawlStructuredHttpHeader header in headers.Where(header => !string.IsNullOrWhiteSpace(header.Name)).GroupBy(header => header.Name, StringComparer.OrdinalIgnoreCase).Select(group => group.First())) {
+            Dictionary<string, object?> headerDefinition = new(StringComparer.OrdinalIgnoreCase) {
+                ["schema"] = new Dictionary<string, object?> {
+                    ["type"] = "string"
+                }
+            };
+            if (!string.IsNullOrWhiteSpace(header.Value)) {
+                headerDefinition["example"] = header.Value;
+            }
+            values[header.Name] = headerDefinition;
+        }
+
+        return values;
+    }
+
+    private static object? ParseStrictOpenApiExampleValue(string? body) {
+        if (string.IsNullOrWhiteSpace(body)) {
+            return null;
+        }
+
+        if (TryParseStructuredJsonPayload(body, out object? jsonBody, out _, out _)) {
+            return jsonBody;
+        }
+
+        return body;
+    }
+
+    private static object BuildStrictOpenApiSchemaFromFields(IList<HtmlCrawlStructuredField> fields) {
+        Dictionary<string, HtmlCrawlStructuredField> byPath = fields
+            .Where(field => !string.IsNullOrWhiteSpace(field.Path))
+            .GroupBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        bool rootArray = byPath.Keys.Any(path => path.StartsWith("$[]", StringComparison.Ordinal));
+        Dictionary<string, object?> schema = rootArray
+            ? BuildStrictOpenApiArraySchema(byPath, "$[]", null)
+            : BuildStrictOpenApiObjectSchema(byPath, null);
+        AddStrictOpenApiSchemaProvenance(schema, fields);
+        AddStrictOpenApiSchemaConfidenceSummary(schema, fields);
+        return schema;
+    }
+
+    private static object BuildStrictOpenApiSchemaFromFlatMap(IDictionary<string, string?> schemaMap) {
+        IList<HtmlCrawlStructuredField> fields = BuildStructuredFieldsFromSchemaMap(schemaMap);
+        return fields.Count > 0 ? BuildStrictOpenApiSchemaFromFields(fields) : new Dictionary<string, object?> {
+            ["type"] = "object"
+        };
+    }
+
+    private static IList<HtmlCrawlStructuredField> BuildStructuredFieldsFromSchemaMap(IDictionary<string, string?> schemaMap) {
+        List<HtmlCrawlStructuredField> fields = new();
+        foreach (KeyValuePair<string, string?> item in schemaMap.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+            if (string.IsNullOrWhiteSpace(item.Key) || string.Equals(item.Key, "$", StringComparison.Ordinal)) {
+                continue;
+            }
+
+            fields.Add(new HtmlCrawlStructuredField {
+                Name = ExtractStructuredFieldName(item.Key),
+                Path = item.Key,
+                ParentPath = GetStructuredParentPath(item.Key),
+                Kind = item.Key.EndsWith("[]", StringComparison.Ordinal)
+                    ? "array-item"
+                    : string.Equals(item.Value, "object", StringComparison.OrdinalIgnoreCase)
+                        ? "object"
+                        : string.Equals(item.Value, "array", StringComparison.OrdinalIgnoreCase)
+                            ? "array"
+                            : "field",
+                Depth = GetStructuredFieldDepth(item.Key),
+                Type = item.Value,
+                Source = "JsonSchemaMap"
+            });
+        }
+
+        return FinalizeStructuredFieldConfidence(FinalizeStructuredFieldRelationships(fields))
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiObjectSchema(
+        IDictionary<string, HtmlCrawlStructuredField> byPath,
+        string? path) {
+        Dictionary<string, object?> schema = new(StringComparer.OrdinalIgnoreCase) {
+            ["type"] = "object"
+        };
+
+        IEnumerable<HtmlCrawlStructuredField> children = byPath.Values
+            .Where(field => string.Equals(field.ParentPath, path, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        Dictionary<string, object?> properties = new(StringComparer.OrdinalIgnoreCase);
+        List<string> required = new();
+
+        foreach (HtmlCrawlStructuredField child in children) {
+            string propertyName = child.Name;
+            if (string.IsNullOrWhiteSpace(propertyName) || string.Equals(propertyName, "$[]", StringComparison.Ordinal)) {
+                propertyName = ExtractStructuredFieldName(child.Path);
+            }
+
+            properties[propertyName] = BuildStrictOpenApiSchemaNode(byPath, child.Path, child);
+            if (child.Required == true) {
+                required.Add(propertyName);
+            }
+        }
+
+        schema["properties"] = properties;
+        if (required.Count > 0) {
+            schema["required"] = required;
+        }
+
+        if (!string.IsNullOrWhiteSpace(path) && byPath.TryGetValue(path, out HtmlCrawlStructuredField? field)) {
+            AddStrictOpenApiFieldProvenance(schema, field);
+            AddStrictOpenApiFieldConfidence(schema, field);
+        }
+
+        return schema;
+    }
+
+    private static Dictionary<string, object?> BuildStrictOpenApiArraySchema(
+        IDictionary<string, HtmlCrawlStructuredField> byPath,
+        string path,
+        HtmlCrawlStructuredField? ownerField) {
+        Dictionary<string, object?> schema = new(StringComparer.OrdinalIgnoreCase) {
+            ["type"] = "array"
+        };
+
+        if (ownerField != null) {
+            AddStrictOpenApiFieldProvenance(schema, ownerField);
+            AddStrictOpenApiFieldConfidence(schema, ownerField);
+        }
+
+        if (byPath.TryGetValue(path, out HtmlCrawlStructuredField? itemField)) {
+            schema["items"] = BuildStrictOpenApiSchemaNode(byPath, path, itemField);
+        } else {
+            IEnumerable<HtmlCrawlStructuredField> children = byPath.Values
+                .Where(field => string.Equals(field.ParentPath, path, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (children.Any()) {
+                schema["items"] = BuildStrictOpenApiObjectSchema(byPath, path);
+            } else {
+                schema["items"] = new Dictionary<string, object?> {
+                    ["type"] = "string"
+                };
+            }
+        }
+
+        return schema;
+    }
+
+    private static object BuildStrictOpenApiSchemaNode(
+        IDictionary<string, HtmlCrawlStructuredField> byPath,
+        string path,
+        HtmlCrawlStructuredField field) {
+        if (string.Equals(field.Kind, "array", StringComparison.OrdinalIgnoreCase)) {
+            return BuildStrictOpenApiArraySchema(byPath, path + "[]", field);
+        }
+        if (string.Equals(field.Kind, "object", StringComparison.OrdinalIgnoreCase)) {
+            return BuildStrictOpenApiObjectSchema(byPath, path);
+        }
+        if (string.Equals(field.Kind, "array-item", StringComparison.OrdinalIgnoreCase)
+            && byPath.Values.Any(candidate => string.Equals(candidate.ParentPath, path, StringComparison.OrdinalIgnoreCase))) {
+            return BuildStrictOpenApiObjectSchema(byPath, path);
+        }
+
+        Dictionary<string, object?> schema = new(StringComparer.OrdinalIgnoreCase);
+        ApplyStrictOpenApiType(schema, field.Type, field.Format);
+        if (field.Nullable == true) {
+            schema["nullable"] = true;
+        }
+        if (field.EnumValues.Count > 0) {
+            schema["enum"] = field.EnumValues.Cast<object>().ToList();
+        }
+        if (!string.IsNullOrWhiteSpace(field.ExampleValue)) {
+            schema["example"] = ParseStrictOpenApiExampleValue(field.ExampleValue);
+        }
+        AddStrictOpenApiFieldProvenance(schema, field);
+        AddStrictOpenApiFieldConfidence(schema, field);
+
+        return schema;
+    }
+
+    private static void AddStrictOpenApiSchemaProvenance(IDictionary<string, object?> schema, IEnumerable<HtmlCrawlStructuredField> fields) {
+        List<Dictionary<string, object?>> provenance = BuildStrictOpenApiFieldProvenance(fields.SelectMany(field => field.Provenance));
+        if (provenance.Count > 0) {
+            schema["x-htmltinkerx-schemaProvenance"] = provenance;
+        }
+    }
+
+    private static void AddStrictOpenApiFieldProvenance(IDictionary<string, object?> schema, HtmlCrawlStructuredField field) {
+        List<Dictionary<string, object?>> provenance = BuildStrictOpenApiFieldProvenance(field.Provenance);
+        if (provenance.Count > 0) {
+            schema["x-htmltinkerx-fieldProvenance"] = provenance;
+        }
+    }
+
+    private static void AddStrictOpenApiFieldConfidence(IDictionary<string, object?> schema, HtmlCrawlStructuredField field) {
+        if (field.ConfidenceScore > 0) {
+            schema["x-htmltinkerx-confidence"] = field.ConfidenceScore;
+        }
+        if (field.EvidenceCount > 0) {
+            schema["x-htmltinkerx-evidenceCount"] = field.EvidenceCount;
+        }
+    }
+
+    private static void AddStrictOpenApiSchemaConfidenceSummary(IDictionary<string, object?> schema, IEnumerable<HtmlCrawlStructuredField> fields) {
+        List<HtmlCrawlStructuredField> scoredFields = fields
+            .Where(field => field.ConfidenceScore > 0)
+            .ToList();
+        if (scoredFields.Count == 0) {
+            return;
+        }
+
+        schema["x-htmltinkerx-confidenceSummary"] = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+            ["average"] = Math.Round(scoredFields.Average(field => field.ConfidenceScore), 2, MidpointRounding.AwayFromZero),
+            ["min"] = scoredFields.Min(field => field.ConfidenceScore),
+            ["max"] = scoredFields.Max(field => field.ConfidenceScore),
+            ["fieldCount"] = scoredFields.Count,
+            ["evidenceCount"] = scoredFields.Sum(field => field.EvidenceCount)
+        };
+    }
+
+    private static List<Dictionary<string, object?>> BuildStrictOpenApiFieldProvenance(IEnumerable<HtmlCrawlStructuredFieldProvenanceEntry> entries) {
+        return entries
+            .GroupBy(entry => string.Join("|",
+                entry.PageUrl ?? string.Empty,
+                entry.Kind ?? string.Empty,
+                entry.SelectorHint ?? string.Empty,
+                entry.Label ?? string.Empty), StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .OrderBy(entry => entry.PageUrl, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(entry => entry.Kind, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(entry => entry.Label, StringComparer.OrdinalIgnoreCase)
+            .Select(entry => new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                ["pageUrl"] = entry.PageUrl,
+                ["kind"] = entry.Kind,
+                ["selectorHint"] = entry.SelectorHint,
+                ["label"] = entry.Label
+            })
+            .ToList();
+    }
+
+    private static void ApplyStrictOpenApiType(Dictionary<string, object?> schema, string? type, string? format) {
+        string normalizedType = NormalizeWhitespace(type)?.ToLowerInvariant() ?? string.Empty;
+        switch (normalizedType) {
+            case "integer":
+                schema["type"] = "integer";
+                break;
+            case "number":
+                schema["type"] = "number";
+                break;
+            case "boolean":
+                schema["type"] = "boolean";
+                break;
+            case "array":
+                schema["type"] = "array";
+                schema["items"] = new Dictionary<string, object?> {
+                    ["type"] = "string"
+                };
+                break;
+            case "object":
+                schema["type"] = "object";
+                break;
+            default:
+                schema["type"] = "string";
+                break;
+        }
+
+        if (!string.IsNullOrWhiteSpace(format)) {
+            schema["format"] = format;
+        }
+    }
+
+    private static string GetStrictOpenApiResponseCode(int? statusCode) =>
+        statusCode.HasValue
+            ? statusCode.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : "default";
+
+    private static void AddStrictOpenApiExtension(IDictionary<string, object?> value, string key, object? extensionValue) {
+        if (extensionValue == null) {
+            return;
+        }
+
+        if (extensionValue is string stringValue && string.IsNullOrWhiteSpace(stringValue)) {
+            return;
+        }
+
+        value[key] = extensionValue;
+    }
+
+    private static void AddStrictOpenApiComponentExtension(IDictionary<string, object?> components, string key, object? extensionValue) {
+        if (extensionValue == null) {
+            return;
+        }
+
+        switch (extensionValue) {
+            case IDictionary<string, object?> objectDictionary when objectDictionary.Count == 0:
+                return;
+            case System.Collections.IDictionary dictionary when dictionary.Count == 0:
+                return;
+            case System.Collections.ICollection collection when collection.Count == 0:
+                return;
+        }
+
+        components[key] = extensionValue;
+    }
+
+    private static IList<string> BuildStructuredOpenApiServers(HtmlCrawlPage page, HtmlCrawlStructuredMetadata metadata) =>
+        BuildStructuredOpenApiServers(new[] { page.Url, metadata.CanonicalUrl, metadata.ImageUrl });
+
+    private static IList<string> BuildStructuredOpenApiServers(IEnumerable<string?> values) {
+        List<string> servers = new();
+
+        foreach (string? value in values) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                continue;
+            }
+
+            if (Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)) {
+                string origin = uri.GetLeftPart(UriPartial.Authority);
+                if (!string.IsNullOrWhiteSpace(origin)) {
+                    AppendDistinct(servers, origin);
+                }
+            }
+        }
+
+        return servers;
+    }
+
+    private static IDocument BuildStructuredSectionDocument(IElement heading) {
+        int headingLevel = GetHeadingLevel(heading);
+        StringBuilder builder = new();
+        builder.Append("<div>")
+            .Append(heading.OuterHtml);
+        IElement? sibling = heading.NextElementSibling;
+        while (sibling != null) {
+            if (GetHeadingLevel(sibling) is int siblingLevel && siblingLevel <= headingLevel) {
+                break;
+            }
+
+            builder.Append(sibling.OuterHtml);
+            sibling = sibling.NextElementSibling;
+        }
+
+        builder.Append("</div>");
+        return HtmlParser.ParseWithAngleSharp(builder.ToString());
+    }
+
+    private static int GetHeadingLevel(IElement element) {
+        if (element == null || element.LocalName.Length != 2 || element.LocalName[0] != 'h' || !char.IsDigit(element.LocalName[1])) {
+            return int.MaxValue;
+        }
+
+        return element.LocalName[1] - '0';
+    }
+
+    private static List<HtmlCrawlStructuredApiParameter> BuildStructuredApiParameters(IDocument sectionDocument) {
+        List<HtmlCrawlStructuredApiParameter> parameters = new();
+        foreach (IElement table in sectionDocument.QuerySelectorAll("table")) {
+            List<HtmlTableResult> parsedTables = HtmlParser.ParseTablesWithAngleSharpDetailed(table.OuterHtml);
+            HtmlTableResult? parsed = parsedTables.FirstOrDefault();
+            if (parsed == null || !LooksLikeApiParameterTable(parsed, table)) {
+                continue;
+            }
+
+            string? location = DetectApiParameterLocation(table, parsed);
+            foreach (Dictionary<string, string?> row in parsed.Data) {
+                HtmlCrawlStructuredApiParameter? parameter = BuildStructuredApiParameter(row, location, BuildElementSelectorHint(table));
+                if (parameter != null) {
+                    parameters.Add(parameter);
+                }
+            }
+        }
+
+        return parameters;
+    }
+
+    private static bool LooksLikeApiParameterTable(HtmlTableResult table, IElement tableElement) {
+        string headers = string.Join(" ", table.Metadata.Headers);
+        string nearbyHeading = FindNearbyHeadingText(tableElement) ?? string.Empty;
+        bool hasNameColumn = ContainsAnyToken(headers, "parameter", "name", "field");
+        bool hasDetailColumn = ContainsAnyToken(headers, "type", "required", "description", "default", "location");
+        bool headingSignal = ContainsAnyToken(nearbyHeading, "parameter", "request body", "query parameter", "path parameter", "header");
+        return hasNameColumn && (hasDetailColumn || headingSignal);
+    }
+
+    private static List<HtmlCrawlStructuredRequestExample> BuildStructuredRequestExamples(
+        IReadOnlyList<HtmlCrawlStructuredCodeSample> codeSamples) {
+        List<HtmlCrawlStructuredRequestExample> requestExamples = new();
+        foreach (HtmlCrawlStructuredCodeSample sample in codeSamples) {
+            HtmlCrawlStructuredRequestExample? requestExample = BuildStructuredRequestExample(sample);
+            if (requestExample == null) {
+                continue;
+            }
+
+            requestExamples.Add(requestExample);
+        }
+
+        return requestExamples;
+    }
+
+    private static HtmlCrawlStructuredApiParameter? BuildStructuredApiParameter(Dictionary<string, string?> row, string? fallbackLocation, string? selectorHint) {
+        string? name = GetStructuredRowValue(row, "parameter", "name", "field");
+        if (string.IsNullOrWhiteSpace(name)) {
+            return null;
+        }
+
+        string? type = GetStructuredRowValue(row, "type", "data type");
+        string? description = GetStructuredRowValue(row, "description", "details", "summary");
+        string? format = NormalizeStructuredApiParameterFormat(
+            GetStructuredRowValue(row, "format", "data format"),
+            type,
+            name,
+            description,
+            GetStructuredRowValue(row, "example", "example value", "sample", "sample value"));
+        string? exampleValue = GetStructuredRowValue(row, "example", "example value", "sample", "sample value");
+        string? pattern = GetStructuredRowValue(row, "pattern", "regex", "regexp");
+        IList<string> enumValues = ParseStructuredApiEnumValues(
+            GetStructuredRowValue(row, "enum", "allowed values", "allowed", "values"),
+            description);
+        string? defaultValue = GetStructuredRowValue(row, "default", "default value");
+        string? location = GetStructuredRowValue(row, "location", "in") ?? fallbackLocation;
+        bool? required = ParseNullableBoolean(GetStructuredRowValue(row, "required", "mandatory"));
+        bool? nullable = ParseNullableBoolean(GetStructuredRowValue(row, "nullable", "allow null", "allows null", "null"));
+        nullable ??= InferStructuredApiNullable(description);
+
+        return new HtmlCrawlStructuredApiParameter {
+            Name = NormalizeWhitespace(name),
+            Type = NormalizeWhitespace(type),
+            Format = NormalizeWhitespace(format),
+            Location = NormalizeWhitespace(location),
+            Required = required,
+            Nullable = nullable,
+            Description = NormalizeWhitespace(description),
+            DefaultValue = NormalizeWhitespace(defaultValue),
+            ExampleValue = NormalizeWhitespace(exampleValue),
+            Pattern = NormalizeWhitespace(pattern),
+            EnumValues = enumValues,
+            SelectorHint = selectorHint
+        };
+    }
+
+    private static HtmlCrawlStructuredApiAuthentication BuildStructuredApiAuthentication(
+        IDocument sectionDocument,
+        IReadOnlyList<HtmlCrawlStructuredCodeSample> codeSamples,
+        IEnumerable<HtmlCrawlStructuredApiParameter> parameters) {
+        HtmlCrawlStructuredApiAuthentication authentication = new();
+        string sectionText = NormalizeWhitespace(sectionDocument.DocumentElement?.TextContent);
+
+        foreach (HtmlCrawlStructuredApiParameter parameter in parameters) {
+            AppendStructuredApiAuthenticationSignals(authentication, parameter.Name);
+            AppendStructuredApiAuthenticationSignals(authentication, parameter.Description);
+            AppendStructuredApiAuthenticationSignals(authentication, parameter.DefaultValue);
+
+            string? headerName = NormalizeStructuredAuthenticationHeader(parameter.Name);
+            if (string.Equals(parameter.Location, "header", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(headerName)) {
+                AppendDistinct(authentication.Headers, headerName);
+                authentication.Required ??= parameter.Required;
+            }
+        }
+
+        foreach (HtmlCrawlStructuredCodeSample sample in codeSamples) {
+            AppendStructuredApiAuthenticationSignals(authentication, sample.Heading);
+            AppendStructuredApiAuthenticationSignals(authentication, sample.Title);
+            AppendStructuredApiAuthenticationSignals(authentication, sample.Code);
+        }
+
+        AppendStructuredApiAuthenticationSignals(authentication, sectionText);
+
+        if (!authentication.Required.HasValue
+            && (authentication.Schemes.Count > 0 || authentication.Headers.Count > 0)) {
+            authentication.Required = true;
+        }
+
+        authentication.Summary = FindFirstStructuredSignalText(sectionDocument,
+            "authentication",
+            "authorization",
+            "bearer",
+            "api key",
+            "x-api-key",
+            "oauth",
+            "jwt",
+            "basic auth",
+            "token");
+
+        if (string.IsNullOrWhiteSpace(authentication.Summary)
+            && (authentication.Required.HasValue || authentication.Schemes.Count > 0 || authentication.Headers.Count > 0)) {
+            List<string> parts = new();
+            if (authentication.Required == true) {
+                parts.Add("Authentication required");
+            } else if (authentication.Required == false) {
+                parts.Add("No authentication required");
+            }
+
+            if (authentication.Schemes.Count > 0) {
+                parts.Add("schemes: " + string.Join(", ", authentication.Schemes));
+            }
+            if (authentication.Headers.Count > 0) {
+                parts.Add("headers: " + string.Join(", ", authentication.Headers));
+            }
+
+            authentication.Summary = string.Join("; ", parts);
+        }
+
+        return authentication;
+    }
+
+    private static void MergeStructuredApiAuthentication(
+        HtmlCrawlStructuredApiAuthentication target,
+        HtmlCrawlStructuredApiAuthentication source) {
+        if (!target.Required.HasValue && source.Required.HasValue) {
+            target.Required = source.Required;
+        }
+
+        foreach (string scheme in source.Schemes) {
+            AppendDistinct(target.Schemes, scheme);
+        }
+        foreach (string header in source.Headers) {
+            AppendDistinct(target.Headers, header);
+        }
+
+        target.Summary ??= source.Summary;
+    }
+
+    private static void ApplyStructuredApiParameterGrouping(HtmlCrawlStructuredApiEndpoint endpoint, string pageUrl) {
+        endpoint.PathParameters = endpoint.Parameters
+            .Where(parameter => string.Equals(ResolveStructuredApiParameterLocation(endpoint.Path, parameter), "path", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        endpoint.QueryParameters = endpoint.Parameters
+            .Where(parameter => string.Equals(ResolveStructuredApiParameterLocation(endpoint.Path, parameter), "query", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        endpoint.HeaderParameters = endpoint.Parameters
+            .Where(parameter => string.Equals(ResolveStructuredApiParameterLocation(endpoint.Path, parameter), "header", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        endpoint.BodyParameters = endpoint.Parameters
+            .Where(parameter => string.Equals(ResolveStructuredApiParameterLocation(endpoint.Path, parameter), "body", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        endpoint.RequestBodySchema = endpoint.BodyParameters
+            .Where(parameter => !string.IsNullOrWhiteSpace(parameter.Name))
+            .GroupBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(parameter => parameter.Type).FirstOrDefault(type => !string.IsNullOrWhiteSpace(type)),
+                StringComparer.OrdinalIgnoreCase);
+        endpoint.RequestBodyFields = FinalizeStructuredFieldConfidence(FinalizeStructuredFieldRelationships(endpoint.BodyParameters
+            .Select(parameter => BuildStructuredRequestBodyField(parameter, pageUrl)))
+            )
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (HtmlCrawlStructuredApiParameter parameter in endpoint.HeaderParameters) {
+            string? headerName = NormalizeStructuredAuthenticationHeader(parameter.Name);
+            if (!string.IsNullOrWhiteSpace(headerName)) {
+                AppendDistinct(endpoint.Authentication.Headers, headerName);
+                endpoint.Authentication.Required ??= parameter.Required;
+            }
+
+            AppendStructuredApiAuthenticationSignals(endpoint.Authentication, parameter.Name);
+            AppendStructuredApiAuthenticationSignals(endpoint.Authentication, parameter.Description);
+        }
+
+        if (!endpoint.Authentication.Required.HasValue
+            && (endpoint.Authentication.Schemes.Count > 0 || endpoint.Authentication.Headers.Count > 0)) {
+            endpoint.Authentication.Required = true;
+        }
+    }
+
+    private static string ResolveStructuredApiParameterLocation(string endpointPath, HtmlCrawlStructuredApiParameter parameter) {
+        if (!string.IsNullOrWhiteSpace(parameter.Location)) {
+            string explicitLocation = parameter.Location!.Trim().ToLowerInvariant();
+            if (explicitLocation is "path" or "query" or "header" or "body") {
+                return explicitLocation;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameter.Name)
+            && endpointPath.IndexOf("{" + parameter.Name + "}", StringComparison.OrdinalIgnoreCase) >= 0) {
+            return "path";
+        }
+
+        return "body";
+    }
+
+    private static string? DetectApiParameterLocation(IElement tableElement, HtmlTableResult table) {
+        string heading = FindNearbyHeadingText(tableElement) ?? string.Empty;
+        string headers = string.Join(" ", table.Metadata.Headers);
+        string combined = heading + " " + headers;
+        if (ContainsAnyToken(combined, "path")) {
+            return "path";
+        }
+        if (ContainsAnyToken(combined, "query")) {
+            return "query";
+        }
+        if (ContainsAnyToken(combined, "header")) {
+            return "header";
+        }
+        if (ContainsAnyToken(combined, "body", "request")) {
+            return "body";
+        }
+
+        return null;
+    }
+
+    private static string? GetStructuredRowValue(Dictionary<string, string?> row, params string[] names) {
+        foreach (string name in names) {
+            foreach (KeyValuePair<string, string?> item in row) {
+                if (string.Equals(item.Key, name, StringComparison.OrdinalIgnoreCase)) {
+                    return item.Value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool? ParseNullableBoolean(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        string normalized = value.Trim();
+        if (normalized.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("required", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+        if (normalized.Equals("false", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("no", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("optional", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return null;
+    }
+
+    private static bool? InferStructuredApiNullable(string? description) {
+        if (string.IsNullOrWhiteSpace(description)) {
+            return null;
+        }
+
+        string normalized = NormalizeWhitespace(description);
+        if (Regex.IsMatch(normalized, @"\b(nullable|may be null|can be null|or null)\b", RegexOptions.IgnoreCase)) {
+            return true;
+        }
+        if (Regex.IsMatch(normalized, @"\b(not null|non-null|must not be null|cannot be null)\b", RegexOptions.IgnoreCase)) {
+            return false;
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeStructuredApiParameterFormat(
+        string? explicitFormat,
+        string? type,
+        string? name,
+        string? description,
+        string? exampleValue) {
+        foreach (string? candidate in new[] { explicitFormat, type, name, description, exampleValue }) {
+            string? normalized = MapStructuredApiParameterFormat(candidate);
+            if (!string.IsNullOrWhiteSpace(normalized)) {
+                return normalized;
+            }
+        }
+
+        return NormalizeWhitespace(explicitFormat);
+    }
+
+    private static string? MapStructuredApiParameterFormat(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        string normalized = NormalizeWhitespace(value).ToLowerInvariant();
+        if (normalized.Contains("uuid") || normalized.Contains("guid")) {
+            return "uuid";
+        }
+        if (normalized.Contains("date-time") || normalized.Contains("datetime") || normalized.Contains("timestamp")) {
+            return "date-time";
+        }
+        if (Regex.IsMatch(normalized, @"\bdate\b", RegexOptions.IgnoreCase)) {
+            return "date";
+        }
+        if (normalized.Contains("email") || Regex.IsMatch(normalized, @"^[^@\s]+@[^@\s]+\.[^@\s]+$")) {
+            return "email";
+        }
+        if (normalized.Contains("uri") || normalized.Contains("url") || Uri.TryCreate(value.Trim(), UriKind.Absolute, out _)) {
+            return "uri";
+        }
+        if (normalized.Contains("hostname")) {
+            return "hostname";
+        }
+        if (normalized.Contains("ipv4")) {
+            return "ipv4";
+        }
+        if (normalized.Contains("ipv6")) {
+            return "ipv6";
+        }
+        if (normalized.Contains("slug")) {
+            return "slug";
+        }
+        if (normalized.Contains("base64")) {
+            return "base64";
+        }
+
+        return null;
+    }
+
+    private static IList<string> ParseStructuredApiEnumValues(string? rawValues, string? description) {
+        List<string> values = new();
+
+        void AppendCandidates(string? input, bool prose) {
+            if (string.IsNullOrWhiteSpace(input)) {
+                return;
+            }
+
+            string normalized = NormalizeWhitespace(input);
+            if (string.IsNullOrWhiteSpace(normalized)) {
+                return;
+            }
+
+            if (prose) {
+                Match match = Regex.Match(normalized, @"\b(?:one of|allowed values?|valid values?)\s*[:\-]\s*(.+)$", RegexOptions.IgnoreCase);
+                if (match.Success) {
+                    normalized = match.Groups[1].Value;
+                } else {
+                    return;
+                }
+            }
+
+            normalized = normalized.Trim('[', ']', '(', ')');
+            foreach (string part in Regex.Split(normalized, @"\s*(?:,|\||/|;)\s*")) {
+                string candidate = NormalizeWhitespace(part.Trim('\"', '\'', '`'));
+                if (!string.IsNullOrWhiteSpace(candidate) && !candidate.Contains(' ')) {
+                    AppendDistinct(values, candidate);
+                }
+            }
+        }
+
+        AppendCandidates(rawValues, prose: false);
+        if (values.Count == 0) {
+            AppendCandidates(description, prose: true);
+        }
+
+        return values;
+    }
+
+    private static HtmlCrawlStructuredApiRateLimit BuildStructuredApiRateLimit(
+        IDocument sectionDocument,
+        IReadOnlyList<HtmlCrawlStructuredCodeSample> codeSamples,
+        IEnumerable<HtmlCrawlStructuredResponseExample> responseExamples) {
+        HtmlCrawlStructuredApiRateLimit rateLimit = new();
+        string sectionText = NormalizeWhitespace(sectionDocument.DocumentElement?.TextContent);
+
+        foreach (HtmlCrawlStructuredCodeSample sample in codeSamples) {
+            AppendStructuredApiRateLimitSignals(rateLimit, sample.Heading);
+            AppendStructuredApiRateLimitSignals(rateLimit, sample.Title);
+            AppendStructuredApiRateLimitSignals(rateLimit, sample.Code);
+        }
+
+        foreach (HtmlCrawlStructuredResponseExample responseExample in responseExamples) {
+            if (responseExample.StatusCode == 429) {
+                rateLimit.Mentioned = true;
+                rateLimit.StatusCode ??= 429;
+            }
+
+            AppendStructuredApiRateLimitSignals(rateLimit, responseExample.Title);
+            AppendStructuredApiRateLimitSignals(rateLimit, responseExample.Body);
+        }
+
+        AppendStructuredApiRateLimitSignals(rateLimit, sectionText);
+        rateLimit.Summary = FindFirstStructuredSignalText(sectionDocument,
+            "rate limit",
+            "rate-limit",
+            "quota",
+            "throttle",
+            "throttling",
+            "retry-after",
+            "too many requests",
+            "x-ratelimit",
+            "ratelimit");
+
+        if (string.IsNullOrWhiteSpace(rateLimit.Summary)
+            && (rateLimit.Mentioned || rateLimit.StatusCode.HasValue || rateLimit.Headers.Count > 0 || !string.IsNullOrWhiteSpace(rateLimit.Limit))) {
+            List<string> parts = new();
+            if (!string.IsNullOrWhiteSpace(rateLimit.Limit)) {
+                parts.Add(rateLimit.Limit!);
+            }
+            if (rateLimit.StatusCode.HasValue) {
+                parts.Add("status " + rateLimit.StatusCode.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            if (rateLimit.Headers.Count > 0) {
+                parts.Add("headers: " + string.Join(", ", rateLimit.Headers));
+            }
+
+            rateLimit.Summary = string.Join("; ", parts);
+        }
+
+        return rateLimit;
+    }
+
+    private static void MergeStructuredApiRateLimit(
+        HtmlCrawlStructuredApiRateLimit target,
+        HtmlCrawlStructuredApiRateLimit source) {
+        target.Mentioned |= source.Mentioned;
+        target.StatusCode ??= source.StatusCode;
+        target.Limit ??= source.Limit;
+        target.Window ??= source.Window;
+        foreach (string header in source.Headers) {
+            AppendDistinct(target.Headers, header);
+        }
+
+        target.Summary ??= source.Summary;
+    }
+
+    private static List<HtmlCrawlStructuredResponseExample> BuildStructuredResponseExamples(
+        IDocument sectionDocument,
+        IReadOnlyList<HtmlCrawlStructuredCodeSample> codeSamples,
+        string pageUrl) {
+        List<HtmlCrawlStructuredResponseExample> responseExamples = new();
+        foreach (HtmlCrawlStructuredCodeSample sample in codeSamples) {
+            if (!LooksLikeResponseExample(sample)) {
+                continue;
+            }
+
+            List<HtmlCrawlStructuredHttpHeader> headers = new();
+            string body = sample.Code;
+            int? parsedStatusCode = null;
+            string? parsedStatusText = null;
+            string? contentType = null;
+            if (TryParseStructuredHttpResponseSample(sample.Code, out int? sampleStatusCode, out string? sampleStatusText, out List<HtmlCrawlStructuredHttpHeader> sampleHeaders, out string sampleBody)) {
+                parsedStatusCode = sampleStatusCode;
+                parsedStatusText = sampleStatusText;
+                headers = sampleHeaders;
+                body = sampleBody;
+                contentType = sampleHeaders
+                    .FirstOrDefault(header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                    ?.Value;
+            }
+
+            int? statusCode = parsedStatusCode ?? ExtractStatusCode(sample.Heading) ?? ExtractStatusCode(sample.Title);
+            string? statusText = parsedStatusText
+                ?? ExtractStatusText(sample.Heading)
+                ?? ExtractStatusText(sample.Title)
+                ?? (statusCode.HasValue ? GetDefaultHttpStatusText(statusCode.Value) : null);
+            object? jsonBody = null;
+            Dictionary<string, string?> bodySchema = new(StringComparer.OrdinalIgnoreCase);
+            List<string> topLevelKeys = new();
+            List<HtmlCrawlStructuredField> bodyFields = new();
+            if (TryParseStructuredJsonPayload(body, out object? parsedJsonBody, out Dictionary<string, string?> parsedBodySchema, out List<string> parsedTopLevelKeys)) {
+                jsonBody = parsedJsonBody;
+                bodySchema = parsedBodySchema;
+                topLevelKeys = parsedTopLevelKeys;
+                bodyFields = BuildStructuredFieldsFromJsonPayload(
+                    parsedJsonBody,
+                    "JsonResponse",
+                    pageUrl,
+                    sample.SelectorHint,
+                    sample.Title ?? sample.Heading ?? (statusCode.HasValue ? "Response " + statusCode.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : null));
+            }
+
+            responseExamples.Add(new HtmlCrawlStructuredResponseExample {
+                Title = sample.Title,
+                Description = sample.Heading,
+                Language = sample.Language,
+                Kind = sample.Kind,
+                StatusCode = statusCode,
+                StatusText = statusText,
+                Headers = headers,
+                ContentType = contentType ?? InferStructuredResponseContentType(sample.Language, sample.Kind, body),
+                IsError = statusCode is >= 400,
+                Body = body,
+                BodySchema = bodySchema,
+                TopLevelKeys = topLevelKeys,
+                JsonBody = jsonBody,
+                BodyFields = bodyFields,
+                SelectorHint = sample.SelectorHint
+            });
+        }
+
+        foreach (HtmlCrawlStructuredResponseExample response in BuildStructuredDocumentedErrorResponses(sectionDocument, responseExamples)) {
+            if (!responseExamples.Any(existing =>
+                    existing.StatusCode == response.StatusCode
+                    && string.Equals(existing.Description, response.Description, StringComparison.OrdinalIgnoreCase))) {
+                responseExamples.Add(response);
+            }
+        }
+
+        return responseExamples;
+    }
+
+    private static List<HtmlCrawlStructuredHttpHeader> BuildStructuredEndpointRequestHeaders(HtmlCrawlStructuredApiEndpoint endpoint) {
+        List<HtmlCrawlStructuredHttpHeader> headers = new();
+        foreach (HtmlCrawlStructuredRequestExample requestExample in endpoint.RequestExamples) {
+            foreach (HtmlCrawlStructuredHttpHeader header in requestExample.Headers) {
+                AppendStructuredHeader(headers, header.Name, header.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(requestExample.ContentType)) {
+                AppendStructuredHeader(headers, "Content-Type", requestExample.ContentType);
+            }
+        }
+
+        foreach (HtmlCrawlStructuredApiParameter parameter in endpoint.HeaderParameters) {
+            AppendStructuredHeader(headers, parameter.Name, parameter.ExampleValue ?? parameter.DefaultValue);
+        }
+
+        foreach (string headerName in endpoint.Authentication.Headers) {
+            HtmlCrawlStructuredApiParameter? parameter = endpoint.HeaderParameters
+                .FirstOrDefault(item => string.Equals(item.Name, headerName, StringComparison.OrdinalIgnoreCase));
+            AppendStructuredHeader(headers, headerName, parameter?.ExampleValue ?? parameter?.DefaultValue);
+        }
+
+        if (endpoint.RequestBodySchema.Count > 0
+            && !headers.Any(header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase))) {
+            AppendStructuredHeader(headers, "Content-Type", "application/json");
+        }
+
+        return headers;
+    }
+
+    private static List<HtmlCrawlStructuredHttpHeader> BuildStructuredEndpointResponseHeaders(HtmlCrawlStructuredApiEndpoint endpoint) {
+        List<HtmlCrawlStructuredHttpHeader> headers = new();
+        foreach (HtmlCrawlStructuredResponseExample response in endpoint.ResponseExamples) {
+            foreach (HtmlCrawlStructuredHttpHeader header in response.Headers) {
+                AppendStructuredHeader(headers, header.Name, header.Value);
+            }
+        }
+
+        foreach (string headerName in endpoint.RateLimit.Headers) {
+            AppendStructuredHeader(headers, headerName, null);
+        }
+
+        return headers;
+    }
+
+    private static IDictionary<string, string?> BuildStructuredEndpointResponseSchema(IEnumerable<HtmlCrawlStructuredResponseExample> responses) {
+        Dictionary<string, string?> schema = new(StringComparer.OrdinalIgnoreCase);
+        foreach (HtmlCrawlStructuredResponseExample response in responses) {
+            MergeStructuredSchemaMaps(schema, response.BodySchema);
+        }
+
+        return schema;
+    }
+
+    private static IList<HtmlCrawlStructuredField> BuildStructuredEndpointResponseFields(IEnumerable<HtmlCrawlStructuredResponseExample> responses) {
+        List<HtmlCrawlStructuredResponseExample> responseList = responses.ToList();
+        Dictionary<string, HtmlCrawlStructuredField> fields = new(StringComparer.OrdinalIgnoreCase);
+        foreach (HtmlCrawlStructuredResponseExample response in responseList) {
+            foreach (HtmlCrawlStructuredField field in response.BodyFields) {
+                if (!fields.TryGetValue(field.Path, out HtmlCrawlStructuredField? existing)) {
+                    existing = new HtmlCrawlStructuredField {
+                        Name = field.Name,
+                        Path = field.Path,
+                        ParentPath = field.ParentPath,
+                        ChildPaths = new List<string>(field.ChildPaths),
+                        Kind = field.Kind,
+                        Depth = field.Depth,
+                        Type = field.Type,
+                        Format = field.Format,
+                        Required = true,
+                        Nullable = field.Nullable,
+                        ExampleValue = field.ExampleValue,
+                        EnumValues = new List<string>(field.EnumValues),
+                        Source = field.Source,
+                        Provenance = field.Provenance.Select(CloneStructuredFieldProvenanceEntry).ToList(),
+                        EvidenceCount = field.EvidenceCount,
+                        ConfidenceScore = field.ConfidenceScore
+                    };
+                    fields[field.Path] = existing;
+                    continue;
+                }
+
+                existing.Type = MergeStructuredTypeValues(existing.Type, field.Type);
+                existing.Format ??= field.Format;
+                existing.ParentPath ??= field.ParentPath;
+                existing.Kind = MergeStructuredFieldKinds(existing.Kind, field.Kind);
+                existing.Depth = Math.Min(existing.Depth, field.Depth);
+                existing.Nullable = existing.Nullable == true || field.Nullable == true
+                    ? true
+                    : existing.Nullable ?? field.Nullable;
+                existing.ExampleValue ??= field.ExampleValue;
+                existing.Source ??= field.Source;
+                MergeStructuredFieldProvenance(existing, field);
+                existing.EvidenceCount = Math.Max(existing.EvidenceCount, field.EvidenceCount);
+                existing.ConfidenceScore = Math.Max(existing.ConfidenceScore, field.ConfidenceScore);
+                foreach (string enumValue in field.EnumValues) {
+                    AppendDistinct(existing.EnumValues, enumValue);
+                }
+                foreach (string childPath in field.ChildPaths) {
+                    AppendDistinct(existing.ChildPaths, childPath);
+                }
+            }
+        }
+
+        foreach (HtmlCrawlStructuredField field in fields.Values) {
+            field.Required = responseList.Count > 0 && responseList.All(response =>
+                response.BodyFields.Any(candidate => string.Equals(candidate.Path, field.Path, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        return FinalizeStructuredFieldConfidence(FinalizeStructuredFieldRelationships(fields.Values))
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static IList<HtmlCrawlStructuredApiError> BuildStructuredEndpointErrorCatalog(IEnumerable<HtmlCrawlStructuredResponseExample> errorResponses) {
+        return errorResponses
+            .GroupBy(response => $"{response.StatusCode?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "unknown"}|{NormalizeWhitespace(response.StatusText) ?? string.Empty}", StringComparer.OrdinalIgnoreCase)
+            .Select(group => {
+                List<HtmlCrawlStructuredResponseExample> groupedResponses = group.ToList();
+                HtmlCrawlStructuredResponseExample primary = groupedResponses[0];
+                List<HtmlCrawlStructuredHttpHeader> headers = new();
+                foreach (HtmlCrawlStructuredResponseExample response in groupedResponses) {
+                    foreach (HtmlCrawlStructuredHttpHeader header in response.Headers) {
+                        AppendStructuredHeader(headers, header.Name, header.Value);
+                    }
+                }
+
+                return new HtmlCrawlStructuredApiError {
+                    StatusCode = primary.StatusCode,
+                    StatusText = primary.StatusText,
+                    Summary = groupedResponses
+                        .Select(response => NormalizeWhitespace(response.Description) ?? NormalizeWhitespace(response.Title))
+                        .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
+                        ?? primary.StatusText
+                        ?? "Error response",
+                    Headers = headers,
+                    ContentType = groupedResponses
+                        .Select(response => response.ContentType)
+                        .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)),
+                    Schema = new Dictionary<string, string?>(BuildStructuredEndpointResponseSchema(groupedResponses), StringComparer.OrdinalIgnoreCase),
+                    Fields = BuildStructuredEndpointResponseFields(groupedResponses),
+                    SampleCount = groupedResponses.Count,
+                    SelectorHint = groupedResponses
+                        .Select(response => response.SelectorHint)
+                        .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
+                };
+            })
+            .OrderBy(error => error.StatusCode ?? int.MaxValue)
+            .ThenBy(error => error.StatusText, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static HtmlCrawlStructuredField BuildStructuredRequestBodyField(HtmlCrawlStructuredApiParameter parameter, string pageUrl) {
+        HtmlCrawlStructuredField field = new() {
+            Name = parameter.Name,
+            Path = parameter.Name,
+            ParentPath = GetStructuredParentPath(parameter.Name),
+            Kind = "field",
+            Depth = GetStructuredFieldDepth(parameter.Name),
+            Type = parameter.Type,
+            Format = parameter.Format,
+            Required = parameter.Required,
+            Nullable = parameter.Nullable,
+            ExampleValue = parameter.ExampleValue ?? parameter.DefaultValue,
+            EnumValues = new List<string>(parameter.EnumValues),
+            Source = "ParameterTable"
+        };
+        AppendStructuredFieldProvenance(field, pageUrl, "ParameterTable", parameter.SelectorHint, parameter.Name);
+        return field;
+    }
+
+    private static List<HtmlCrawlStructuredField> FinalizeStructuredFieldRelationships(IEnumerable<HtmlCrawlStructuredField> fields) {
+        Dictionary<string, HtmlCrawlStructuredField> byPath = fields
+            .GroupBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (HtmlCrawlStructuredField field in byPath.Values) {
+            field.ParentPath ??= GetStructuredParentPath(field.Path);
+            field.Depth = field.Depth > 0 ? field.Depth : GetStructuredFieldDepth(field.Path);
+        }
+
+        foreach (HtmlCrawlStructuredField field in byPath.Values) {
+            if (string.IsNullOrWhiteSpace(field.ParentPath)) {
+                continue;
+            }
+
+            if (byPath.TryGetValue(field.ParentPath, out HtmlCrawlStructuredField? parent)) {
+                AppendDistinct(parent.ChildPaths, field.Path);
+            }
+        }
+
+        return byPath.Values.ToList();
+    }
+
+    private static string? GetStructuredParentPath(string? path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return null;
+        }
+
+        string normalized = path!;
+        if (normalized.EndsWith("[]", StringComparison.Ordinal)) {
+            return normalized.Substring(0, normalized.Length - 2);
+        }
+
+        int separatorIndex = normalized.LastIndexOf('.');
+        if (separatorIndex < 0) {
+            return null;
+        }
+
+        return normalized.Substring(0, separatorIndex);
+    }
+
+    private static int GetStructuredFieldDepth(string? path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return 0;
+        }
+
+        int depth = 0;
+        foreach (string segment in path!.Split('.')) {
+            if (string.IsNullOrWhiteSpace(segment)) {
+                continue;
+            }
+
+            depth++;
+        }
+
+        return depth;
+    }
+
+    private static string MergeStructuredFieldKinds(string current, string incoming) {
+        if (string.IsNullOrWhiteSpace(current)) {
+            return string.IsNullOrWhiteSpace(incoming) ? "field" : incoming;
+        }
+        if (string.IsNullOrWhiteSpace(incoming) || string.Equals(current, incoming, StringComparison.OrdinalIgnoreCase)) {
+            return current;
+        }
+
+        if (string.Equals(current, "field", StringComparison.OrdinalIgnoreCase)) {
+            return incoming;
+        }
+        if (string.Equals(incoming, "field", StringComparison.OrdinalIgnoreCase)) {
+            return current;
+        }
+
+        return current;
+    }
+
+    private static List<HtmlCrawlStructuredResponseExample> BuildStructuredDocumentedErrorResponses(
+        IDocument sectionDocument,
+        IReadOnlyList<HtmlCrawlStructuredResponseExample> existingResponses) {
+        List<HtmlCrawlStructuredResponseExample> responses = new();
+        foreach (IElement element in sectionDocument.QuerySelectorAll("p, li, td, th, dd, dt, aside, [class*='callout' i], [class*='notice' i], [class*='warning' i], [class*='alert' i]")) {
+            string text = NormalizeWhitespace(element.TextContent);
+            if (string.IsNullOrWhiteSpace(text)) {
+                continue;
+            }
+
+            int? statusCode = ExtractStatusCode(text);
+            if (statusCode is not >= 400) {
+                continue;
+            }
+
+            if (!LooksLikeDocumentedErrorText(text)) {
+                continue;
+            }
+
+            if (existingResponses.Any(response => response.StatusCode == statusCode && response.IsError)) {
+                continue;
+            }
+
+            List<HtmlCrawlStructuredHttpHeader> headers = BuildStructuredHeadersFromText(text);
+            responses.Add(new HtmlCrawlStructuredResponseExample {
+                Title = "Error " + statusCode.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Description = text,
+                Kind = "text",
+                StatusCode = statusCode,
+                StatusText = ExtractStatusText(text) ?? GetDefaultHttpStatusText(statusCode.Value),
+                Headers = headers,
+                ContentType = "text/plain",
+                IsError = true,
+                Body = string.Empty,
+                SelectorHint = BuildElementSelectorHint(element)
+            });
+        }
+
+        return responses;
+    }
+
+    private static void AppendStructuredApiAuthenticationSignals(HtmlCrawlStructuredApiAuthentication authentication, string? text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return;
+        }
+
+        string normalized = NormalizeWhitespace(text);
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            return;
+        }
+
+        if (Regex.IsMatch(normalized, @"\b(no authentication required|without authentication|public endpoint|anonymous access)\b", RegexOptions.IgnoreCase)) {
+            authentication.Required ??= false;
+        }
+
+        if (ContainsAnyToken(normalized, "authorization")) {
+            AppendDistinct(authentication.Headers, "Authorization");
+        }
+        if (ContainsAnyToken(normalized, "x-api-key", "api-key", "api key")) {
+            AppendDistinct(authentication.Headers, "X-API-Key");
+            AppendDistinct(authentication.Schemes, "api-key");
+        }
+        if (ContainsAnyToken(normalized, "x-auth-token")) {
+            AppendDistinct(authentication.Headers, "X-Auth-Token");
+            AppendDistinct(authentication.Schemes, "token");
+        }
+        if (Regex.IsMatch(normalized, @"\bbearer\b|\bjwt\b", RegexOptions.IgnoreCase)) {
+            AppendDistinct(authentication.Schemes, "bearer");
+        }
+        if (Regex.IsMatch(normalized, @"\boauth\s*2(?:\.0)?\b|\boauth2\b", RegexOptions.IgnoreCase)) {
+            AppendDistinct(authentication.Schemes, "oauth2");
+        }
+        if (Regex.IsMatch(normalized, @"\bbasic auth\b|\bauthorization\s*:\s*basic\b", RegexOptions.IgnoreCase)) {
+            AppendDistinct(authentication.Schemes, "basic");
+            AppendDistinct(authentication.Headers, "Authorization");
+        }
+
+        foreach (Match match in Regex.Matches(normalized, @"(?im)^\s*(Authorization|X-API-Key|Api-Key|X-Auth-Token|X-Access-Token)\s*:", RegexOptions.IgnoreCase)) {
+            string? header = NormalizeStructuredAuthenticationHeader(match.Groups[1].Value);
+            if (!string.IsNullOrWhiteSpace(header)) {
+                AppendDistinct(authentication.Headers, header);
+            }
+        }
+
+        if (!authentication.Required.HasValue
+            && (Regex.IsMatch(normalized, @"\b(auth(?:entication)? required|requires authentication|authenticated requests?|authorization required|include (?:your|an?) api key|provide (?:your|an?) api key|send (?:your|an?) api key|set the authorization header|bearer token required)\b", RegexOptions.IgnoreCase)
+                || authentication.Schemes.Count > 0
+                || authentication.Headers.Count > 0)) {
+            authentication.Required = true;
+        }
+    }
+
+    private static string? NormalizeStructuredAuthenticationHeader(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        string normalized = NormalizeWhitespace(value);
+        if (normalized.Equals("authorization", StringComparison.OrdinalIgnoreCase)) {
+            return "Authorization";
+        }
+        if (normalized.Equals("x-api-key", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("api-key", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("api key", StringComparison.OrdinalIgnoreCase)) {
+            return "X-API-Key";
+        }
+        if (normalized.Equals("x-auth-token", StringComparison.OrdinalIgnoreCase)) {
+            return "X-Auth-Token";
+        }
+        if (normalized.Equals("x-access-token", StringComparison.OrdinalIgnoreCase)) {
+            return "X-Access-Token";
+        }
+
+        return null;
+    }
+
+    private static void AppendStructuredApiRateLimitSignals(HtmlCrawlStructuredApiRateLimit rateLimit, string? text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return;
+        }
+
+        string normalized = NormalizeWhitespace(text);
+        if (string.IsNullOrWhiteSpace(normalized)) {
+            return;
+        }
+
+        if (ContainsAnyToken(normalized, "rate limit", "rate-limit", "quota", "throttle", "throttling", "retry-after", "too many requests", "x-ratelimit", "ratelimit")) {
+            rateLimit.Mentioned = true;
+        }
+
+        if (!rateLimit.StatusCode.HasValue
+            && (ContainsAnyToken(normalized, "too many requests")
+                || Regex.IsMatch(normalized, @"\b429\b", RegexOptions.IgnoreCase))) {
+            rateLimit.StatusCode = 429;
+        }
+
+        foreach (string header in new[] { "Retry-After", "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "RateLimit-Limit", "RateLimit-Remaining", "RateLimit-Reset" }) {
+            if (normalized.IndexOf(header, StringComparison.OrdinalIgnoreCase) >= 0) {
+                AppendDistinct(rateLimit.Headers, header);
+                rateLimit.Mentioned = true;
+            }
+        }
+
+        Match requestsPerWindow = Regex.Match(normalized, @"\b(\d[\d,]*)\s+requests?\s+per\s+(second|minute|hour|day|month)\b", RegexOptions.IgnoreCase);
+        if (!requestsPerWindow.Success) {
+            requestsPerWindow = Regex.Match(normalized, @"\b(\d[\d,]*)\s*/\s*(second|minute|hour|day|month)\b", RegexOptions.IgnoreCase);
+        }
+
+        if (requestsPerWindow.Success) {
+            string amount = requestsPerWindow.Groups[1].Value;
+            string window = requestsPerWindow.Groups[2].Value.ToLowerInvariant();
+            rateLimit.Mentioned = true;
+            rateLimit.Window ??= window;
+            rateLimit.Limit ??= amount + " requests per " + window;
+        }
+    }
+
+    private static string? FindFirstStructuredSignalText(IDocument sectionDocument, params string[] tokens) {
+        foreach (IElement element in sectionDocument.QuerySelectorAll("p, li, td, th, dd, dt, aside, [class*='callout' i], [class*='notice' i], [class*='warning' i], [class*='alert' i], pre, code")) {
+            string text = NormalizeWhitespace(element.TextContent);
+            if (!string.IsNullOrWhiteSpace(text) && ContainsAnyToken(text, tokens)) {
+                return text;
+            }
+        }
+
+        string fallback = NormalizeWhitespace(sectionDocument.DocumentElement?.TextContent);
+        return ContainsAnyToken(fallback, tokens) ? fallback : null;
+    }
+
+    private static bool LooksLikeResponseExample(HtmlCrawlStructuredCodeSample sample) {
+        string heading = sample.Heading ?? sample.Title ?? string.Empty;
+        if (ContainsAnyToken(heading, "response", "example response", "success response", "error response")) {
+            return true;
+        }
+        if (ExtractStatusCode(heading).HasValue) {
+            return true;
+        }
+
+        return sample.Method == null && (string.Equals(sample.Kind, "json", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(sample.Kind, "http", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool LooksLikeRequestExample(HtmlCrawlStructuredCodeSample sample) {
+        if (LooksLikeResponseExample(sample)) {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(sample.Method) && !string.IsNullOrWhiteSpace(sample.Path)) {
+            return true;
+        }
+
+        return string.Equals(sample.Kind, "curl", StringComparison.OrdinalIgnoreCase)
+            || (string.Equals(sample.Kind, "http", StringComparison.OrdinalIgnoreCase)
+                && Regex.IsMatch(sample.Code, @"(?im)^\s*(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/[^\s'""]+)(?:\s+HTTP/\d(?:\.\d)?)?\s*$"));
+    }
+
+    private static HtmlCrawlStructuredRequestExample? BuildStructuredRequestExample(HtmlCrawlStructuredCodeSample sample) {
+        if (!LooksLikeRequestExample(sample)) {
+            return null;
+        }
+
+        List<HtmlCrawlStructuredHttpHeader> headers = new();
+        string body = string.Empty;
+        string? method = sample.Method;
+        string? path = sample.Path;
+        string? contentType = null;
+
+        if (TryParseStructuredHttpRequestSample(sample.Code, out string? parsedMethod, out string? parsedPath, out List<HtmlCrawlStructuredHttpHeader> parsedHeaders, out string parsedBody)) {
+            method = parsedMethod ?? method;
+            path = parsedPath ?? path;
+            headers = parsedHeaders;
+            body = parsedBody;
+            contentType = parsedHeaders
+                .FirstOrDefault(header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+        } else if (TryParseStructuredCurlRequestSample(sample.Code, out parsedMethod, out parsedPath, out parsedHeaders, out parsedBody)) {
+            method = parsedMethod ?? method;
+            path = parsedPath ?? path;
+            headers = parsedHeaders;
+            body = parsedBody;
+            contentType = parsedHeaders
+                .FirstOrDefault(header => string.Equals(header.Name, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+        } else {
+            body = sample.Code;
+        }
+
+        if (string.IsNullOrWhiteSpace(method) || string.IsNullOrWhiteSpace(path)) {
+            return null;
+        }
+
+        return new HtmlCrawlStructuredRequestExample {
+            Title = sample.Title,
+            Description = sample.Heading,
+            Language = sample.Language,
+            Kind = sample.Kind,
+            Method = method,
+            Path = path,
+            Headers = headers,
+            ContentType = contentType ?? InferStructuredRequestContentType(sample.Language, sample.Kind, body),
+            Body = body,
+            SelectorHint = sample.SelectorHint
+        };
+    }
+
+    private static bool LooksLikeDocumentedErrorText(string text) =>
+        ContainsAnyToken(text,
+            "error",
+            "returns",
+            "response",
+            "too many requests",
+            "unauthorized",
+            "forbidden",
+            "not found",
+            "invalid",
+            "failed");
+
+    private static List<HtmlCrawlStructuredHttpHeader> BuildStructuredHeadersFromText(string text) {
+        List<HtmlCrawlStructuredHttpHeader> headers = new();
+        foreach (string headerName in BuildStructuredDocumentedResponseHeaderNames(text)) {
+            AppendStructuredHeader(headers, headerName, null);
+        }
+
+        return headers;
+    }
+
+    private static bool TryParseStructuredJsonPayload(
+        string body,
+        out object? jsonBody,
+        out Dictionary<string, string?> bodySchema,
+        out List<string> topLevelKeys) {
+        jsonBody = null;
+        bodySchema = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        topLevelKeys = new List<string>();
+
+        if (!LooksLikeJson(body)) {
+            return false;
+        }
+
+        try {
+            using JsonDocument document = JsonDocument.Parse(body);
+            jsonBody = ConvertStructuredJsonElement(document.RootElement);
+            if (document.RootElement.ValueKind == JsonValueKind.Object) {
+                foreach (JsonProperty property in document.RootElement.EnumerateObject()) {
+                    topLevelKeys.Add(property.Name);
+                }
+            }
+
+            BuildStructuredJsonSchema(bodySchema, jsonBody, null);
+            return true;
+        } catch (JsonException) {
+            return false;
+        }
+    }
+
+    private static List<HtmlCrawlStructuredField> BuildStructuredFieldsFromJsonPayload(
+        object? jsonBody,
+        string source,
+        string pageUrl,
+        string? selectorHint,
+        string? label) {
+        List<HtmlCrawlStructuredField> fields = new();
+        AppendStructuredFieldsFromJsonValue(fields, jsonBody, null, source, pageUrl, selectorHint, label);
+        return FinalizeStructuredFieldConfidence(FinalizeStructuredFieldRelationships(fields))
+            .OrderBy(field => field.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static void AppendStructuredFieldsFromJsonValue(
+        IList<HtmlCrawlStructuredField> fields,
+        object? value,
+        string? path,
+        string source,
+        string pageUrl,
+        string? selectorHint,
+        string? label) {
+        if (value is IDictionary<string, object?> dictionary) {
+            if (!string.IsNullOrWhiteSpace(path)) {
+                HtmlCrawlStructuredField field = new() {
+                    Name = ExtractStructuredFieldName(path),
+                    Path = path,
+                    ParentPath = GetStructuredParentPath(path),
+                    Kind = "object",
+                    Depth = GetStructuredFieldDepth(path),
+                    Type = "object",
+                    Nullable = false,
+                    Source = source
+                };
+                AppendStructuredFieldProvenance(field, pageUrl, source, selectorHint, label);
+                fields.Add(field);
+            }
+
+            foreach (KeyValuePair<string, object?> item in dictionary) {
+                string childPath = string.IsNullOrWhiteSpace(path) ? item.Key : path + "." + item.Key;
+                AppendStructuredFieldsFromJsonValue(fields, item.Value, childPath, source, pageUrl, selectorHint, label);
+            }
+            return;
+        }
+
+        if (value is IList list) {
+            string arrayPath = string.IsNullOrWhiteSpace(path) ? "$" : path!;
+            if (!string.IsNullOrWhiteSpace(path)) {
+                HtmlCrawlStructuredField field = new() {
+                    Name = ExtractStructuredFieldName(arrayPath),
+                    Path = arrayPath,
+                    ParentPath = GetStructuredParentPath(arrayPath),
+                    Kind = "array",
+                    Depth = GetStructuredFieldDepth(arrayPath),
+                    Type = "array",
+                    Nullable = false,
+                    Source = source
+                };
+                AppendStructuredFieldProvenance(field, pageUrl, source, selectorHint, label);
+                fields.Add(field);
+            }
+
+            foreach (object? item in list) {
+                AppendStructuredFieldsFromJsonValue(fields, item, arrayPath + "[]", source, pageUrl, selectorHint, label);
+            }
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        string? exampleValue = value switch {
+            null => null,
+            string text => text,
+            bool boolean => boolean ? "true" : "false",
+            _ => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+        HtmlCrawlStructuredField valueField = new() {
+            Name = ExtractStructuredFieldName(path),
+            Path = path,
+            ParentPath = GetStructuredParentPath(path),
+            Kind = path.EndsWith("[]", StringComparison.Ordinal) ? "array-item" : "field",
+            Depth = GetStructuredFieldDepth(path),
+            Type = GetStructuredSchemaTypeName(value),
+            Format = NormalizeStructuredApiParameterFormat(null, null, path, null, exampleValue),
+            Required = true,
+            Nullable = value == null,
+            ExampleValue = exampleValue,
+            Source = source
+        };
+        AppendStructuredFieldProvenance(valueField, pageUrl, source, selectorHint, label);
+        fields.Add(valueField);
+    }
+
+    private static string ExtractStructuredFieldName(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return string.Empty;
+        }
+
+        string normalized = path.EndsWith("[]", StringComparison.Ordinal) ? path.Substring(0, path.Length - 2) : path;
+        int separatorIndex = normalized.LastIndexOf('.');
+        return separatorIndex >= 0 ? normalized.Substring(separatorIndex + 1) : normalized;
+    }
+
+    private static object? ConvertStructuredJsonElement(JsonElement element) {
+        switch (element.ValueKind) {
+            case JsonValueKind.Object:
+                Dictionary<string, object?> obj = new(StringComparer.OrdinalIgnoreCase);
+                foreach (JsonProperty property in element.EnumerateObject()) {
+                    obj[property.Name] = ConvertStructuredJsonElement(property.Value);
+                }
+                return obj;
+            case JsonValueKind.Array:
+                return element.EnumerateArray()
+                    .Select(ConvertStructuredJsonElement)
+                    .ToList();
+            case JsonValueKind.String:
+                return element.GetString();
+            case JsonValueKind.Number:
+                if (element.TryGetInt64(out long longValue)) {
+                    return longValue;
+                }
+                if (element.TryGetDecimal(out decimal decimalValue)) {
+                    return decimalValue;
+                }
+                return element.GetDouble();
+            case JsonValueKind.True:
+                return true;
+            case JsonValueKind.False:
+                return false;
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+            default:
+                return element.GetRawText();
+        }
+    }
+
+    private static void BuildStructuredJsonSchema(
+        IDictionary<string, string?> schema,
+        object? value,
+        string? path) {
+        if (value is IDictionary<string, object?> dictionary) {
+            if (!string.IsNullOrWhiteSpace(path)) {
+                MergeStructuredSchemaValue(schema, path!, "object");
+            }
+
+            foreach (KeyValuePair<string, object?> item in dictionary) {
+                string childPath = string.IsNullOrWhiteSpace(path) ? item.Key : path + "." + item.Key;
+                BuildStructuredJsonSchema(schema, item.Value, childPath);
+            }
+            return;
+        }
+
+        if (value is IList list) {
+            string arrayPath = string.IsNullOrWhiteSpace(path) ? "$" : path!;
+            MergeStructuredSchemaValue(schema, arrayPath, "array");
+            if (list.Count == 0) {
+                return;
+            }
+
+            foreach (object? item in list) {
+                BuildStructuredJsonSchema(schema, item, arrayPath + "[]");
+            }
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        MergeStructuredSchemaValue(schema, path!, GetStructuredSchemaTypeName(value));
+    }
+
+    private static string GetStructuredSchemaTypeName(object? value) {
+        return value switch {
+            null => "null",
+            string => "string",
+            bool => "boolean",
+            byte or sbyte or short or ushort or int or uint or long or ulong => "integer",
+            float or double or decimal => "number",
+            IDictionary<string, object?> => "object",
+            IList => "array",
+            _ => "string"
+        };
+    }
+
+    private static void MergeStructuredSchemaMaps(
+        IDictionary<string, string?> target,
+        IEnumerable<KeyValuePair<string, string?>> source) {
+        foreach (KeyValuePair<string, string?> item in source) {
+            if (string.IsNullOrWhiteSpace(item.Key)) {
+                continue;
+            }
+
+            MergeStructuredSchemaValue(target, item.Key, item.Value);
+        }
+    }
+
+    private static void MergeStructuredSchemaValue(
+        IDictionary<string, string?> target,
+        string key,
+        string? value) {
+        if (!target.TryGetValue(key, out string? existing) || string.IsNullOrWhiteSpace(existing)) {
+            target[key] = value;
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(value) || string.Equals(existing, value, StringComparison.OrdinalIgnoreCase)) {
+            return;
+        }
+
+        HashSet<string> types = new(existing.Split('|'), StringComparer.OrdinalIgnoreCase);
+        types.Add(value);
+        target[key] = string.Join("|", types.OrderBy(type => type, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static string? MergeStructuredTypeValues(string? first, string? second) {
+        if (string.IsNullOrWhiteSpace(first)) {
+            return second;
+        }
+        if (string.IsNullOrWhiteSpace(second) || string.Equals(first, second, StringComparison.OrdinalIgnoreCase)) {
+            return first;
+        }
+
+        HashSet<string> types = new(first.Split('|'), StringComparer.OrdinalIgnoreCase);
+        foreach (string type in second.Split('|')) {
+            if (!string.IsNullOrWhiteSpace(type)) {
+                types.Add(type);
+            }
+        }
+
+        return string.Join("|", types.OrderBy(type => type, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static HtmlCrawlStructuredApiAuthentication CloneStructuredApiAuthentication(HtmlCrawlStructuredApiAuthentication value) {
+        return new HtmlCrawlStructuredApiAuthentication {
+            Required = value.Required,
+            Schemes = new List<string>(value.Schemes),
+            Headers = new List<string>(value.Headers),
+            Summary = value.Summary
+        };
+    }
+
+    private static HtmlCrawlStructuredApiRateLimit CloneStructuredApiRateLimit(HtmlCrawlStructuredApiRateLimit value) {
+        return new HtmlCrawlStructuredApiRateLimit {
+            Mentioned = value.Mentioned,
+            Limit = value.Limit,
+            Window = value.Window,
+            Headers = new List<string>(value.Headers),
+            StatusCode = value.StatusCode,
+            Summary = value.Summary
+        };
+    }
+
+    private static HtmlCrawlStructuredApiParameter CloneStructuredApiParameter(HtmlCrawlStructuredApiParameter value) {
+        return new HtmlCrawlStructuredApiParameter {
+            Name = value.Name,
+            Type = value.Type,
+            Format = value.Format,
+            Location = value.Location,
+            Required = value.Required,
+            Nullable = value.Nullable,
+            Description = value.Description,
+            DefaultValue = value.DefaultValue,
+            ExampleValue = value.ExampleValue,
+            Pattern = value.Pattern,
+            EnumValues = new List<string>(value.EnumValues),
+            SelectorHint = value.SelectorHint
+        };
+    }
+
+    private static HtmlCrawlStructuredHttpHeader CloneStructuredHttpHeader(HtmlCrawlStructuredHttpHeader value) {
+        return new HtmlCrawlStructuredHttpHeader {
+            Name = value.Name,
+            Value = value.Value
+        };
+    }
+
+    private static HtmlCrawlStructuredRequestExample CloneStructuredRequestExample(HtmlCrawlStructuredRequestExample value) {
+        return new HtmlCrawlStructuredRequestExample {
+            Title = value.Title,
+            Description = value.Description,
+            Language = value.Language,
+            Kind = value.Kind,
+            Method = value.Method,
+            Path = value.Path,
+            Headers = value.Headers.Select(CloneStructuredHttpHeader).ToList(),
+            ContentType = value.ContentType,
+            Body = value.Body,
+            SelectorHint = value.SelectorHint
+        };
+    }
+
+    private static HtmlCrawlStructuredResponseExample CloneStructuredResponseExample(HtmlCrawlStructuredResponseExample value) {
+        return new HtmlCrawlStructuredResponseExample {
+            Title = value.Title,
+            Description = value.Description,
+            Language = value.Language,
+            Kind = value.Kind,
+            StatusCode = value.StatusCode,
+            StatusText = value.StatusText,
+            Headers = value.Headers.Select(CloneStructuredHttpHeader).ToList(),
+            ContentType = value.ContentType,
+            IsError = value.IsError,
+            Body = value.Body,
+            BodySchema = new Dictionary<string, string?>(value.BodySchema, StringComparer.OrdinalIgnoreCase),
+            TopLevelKeys = new List<string>(value.TopLevelKeys),
+            JsonBody = value.JsonBody,
+            BodyFields = value.BodyFields.Select(CloneStructuredField).ToList(),
+            SelectorHint = value.SelectorHint
+        };
+    }
+
+    private static HtmlCrawlStructuredApiError CloneStructuredApiError(HtmlCrawlStructuredApiError value) {
+        return new HtmlCrawlStructuredApiError {
+            StatusCode = value.StatusCode,
+            StatusText = value.StatusText,
+            Summary = value.Summary,
+            Headers = value.Headers.Select(CloneStructuredHttpHeader).ToList(),
+            ContentType = value.ContentType,
+            Schema = new Dictionary<string, string?>(value.Schema, StringComparer.OrdinalIgnoreCase),
+            Fields = value.Fields.Select(CloneStructuredField).ToList(),
+            SampleCount = value.SampleCount,
+            SelectorHint = value.SelectorHint
+        };
+    }
+
+    private static HtmlCrawlStructuredOpenApiProvenance CloneStructuredOpenApiProvenance(HtmlCrawlStructuredOpenApiProvenance value) {
+        return new HtmlCrawlStructuredOpenApiProvenance {
+            PageUrls = new List<string>(value.PageUrls),
+            SourceKinds = new List<string>(value.SourceKinds),
+            Entries = value.Entries.Select(CloneStructuredOpenApiProvenanceEntry).ToList()
+        };
+    }
+
+    private static HtmlCrawlStructuredOpenApiProvenanceEntry CloneStructuredOpenApiProvenanceEntry(HtmlCrawlStructuredOpenApiProvenanceEntry value) {
+        return new HtmlCrawlStructuredOpenApiProvenanceEntry {
+            PageUrl = value.PageUrl,
+            Kind = value.Kind,
+            SelectorHint = value.SelectorHint,
+            Label = value.Label
+        };
+    }
+
+    private static HtmlCrawlStructuredField CloneStructuredField(HtmlCrawlStructuredField value) {
+        return new HtmlCrawlStructuredField {
+            Name = value.Name,
+            Path = value.Path,
+            ParentPath = value.ParentPath,
+            ChildPaths = new List<string>(value.ChildPaths),
+            Kind = value.Kind,
+            Depth = value.Depth,
+            Type = value.Type,
+            Format = value.Format,
+            Required = value.Required,
+            Nullable = value.Nullable,
+            ExampleValue = value.ExampleValue,
+            EnumValues = new List<string>(value.EnumValues),
+            Source = value.Source,
+            Provenance = value.Provenance.Select(CloneStructuredFieldProvenanceEntry).ToList(),
+            EvidenceCount = value.EvidenceCount,
+            ConfidenceScore = value.ConfidenceScore
+        };
+    }
+
+    private static HtmlCrawlStructuredFieldProvenanceEntry CloneStructuredFieldProvenanceEntry(HtmlCrawlStructuredFieldProvenanceEntry value) {
+        return new HtmlCrawlStructuredFieldProvenanceEntry {
+            PageUrl = value.PageUrl,
+            Kind = value.Kind,
+            SelectorHint = value.SelectorHint,
+            Label = value.Label
+        };
+    }
+
+    private static IEnumerable<string> BuildStructuredDocumentedResponseHeaderNames(IDocument sectionDocument) =>
+        BuildStructuredDocumentedResponseHeaderNames(NormalizeWhitespace(sectionDocument.DocumentElement?.TextContent));
+
+    private static IEnumerable<string> BuildStructuredDocumentedResponseHeaderNames(string? text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return Array.Empty<string>();
+        }
+
+        List<string> names = new();
+        foreach (string headerName in new[] { "Retry-After", "WWW-Authenticate", "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "RateLimit-Limit", "RateLimit-Remaining", "RateLimit-Reset", "Content-Type" }) {
+            if (text.IndexOf(headerName, StringComparison.OrdinalIgnoreCase) >= 0) {
+                AppendDistinct(names, headerName);
+            }
+        }
+
+        return names;
+    }
+
+    private static void AppendStructuredHeader(IList<HtmlCrawlStructuredHttpHeader> headers, string? name, string? value) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            return;
+        }
+
+        HtmlCrawlStructuredHttpHeader? existing = headers.FirstOrDefault(header => string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (existing == null) {
+            headers.Add(new HtmlCrawlStructuredHttpHeader {
+                Name = NormalizeWhitespace(name),
+                Value = string.IsNullOrWhiteSpace(value) ? null : NormalizeWhitespace(value)
+            });
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(existing.Value) && !string.IsNullOrWhiteSpace(value)) {
+            existing.Value = NormalizeWhitespace(value);
+        }
+    }
+
+    private static string? InferStructuredRequestContentType(string? language, string kind, string body) {
+        if (LooksLikeJson(body) || string.Equals(language, "json", StringComparison.OrdinalIgnoreCase)) {
+            return "application/json";
+        }
+        if (string.Equals(kind, "http", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(kind, "curl", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(kind, "command", StringComparison.OrdinalIgnoreCase)) {
+            return LooksLikeJson(body) ? "application/json" : null;
+        }
+
+        return null;
+    }
+
+    private static string? InferStructuredResponseContentType(string? language, string kind, string body) {
+        if (LooksLikeJson(body) || string.Equals(language, "json", StringComparison.OrdinalIgnoreCase) || string.Equals(kind, "json", StringComparison.OrdinalIgnoreCase)) {
+            return "application/json";
+        }
+        if (string.Equals(language, "html", StringComparison.OrdinalIgnoreCase) || body.IndexOf("<html", StringComparison.OrdinalIgnoreCase) >= 0) {
+            return "text/html";
+        }
+        if (string.Equals(kind, "http", StringComparison.OrdinalIgnoreCase)) {
+            return "message/http";
+        }
+
+        return null;
+    }
+
+    private static bool TryParseStructuredHttpRequestSample(
+        string code,
+        out string? method,
+        out string? path,
+        out List<HtmlCrawlStructuredHttpHeader> headers,
+        out string body) {
+        method = null;
+        path = null;
+        headers = new List<HtmlCrawlStructuredHttpHeader>();
+        body = code;
+
+        if (string.IsNullOrWhiteSpace(code)) {
+            return false;
+        }
+
+        string normalizedNewlines = code.Replace("\r\n", "\n");
+        string[] lines = normalizedNewlines.Split('\n');
+        if (lines.Length == 0) {
+            return false;
+        }
+
+        Match requestLine = Regex.Match(lines[0].Trim(), @"^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/[^\s'""]+)(?:\s+HTTP/\d(?:\.\d)?)?$", RegexOptions.IgnoreCase);
+        if (!requestLine.Success) {
+            return false;
+        }
+
+        method = requestLine.Groups[1].Value.ToUpperInvariant();
+        path = NormalizeStructuredApiPath(requestLine.Groups[2].Value);
+
+        int index = 1;
+        while (index < lines.Length) {
+            string line = lines[index].Trim();
+            index++;
+            if (line.Length == 0) {
+                break;
+            }
+
+            int separatorIndex = line.IndexOf(':');
+            if (separatorIndex <= 0) {
+                continue;
+            }
+
+            string name = NormalizeWhitespace(line.Substring(0, separatorIndex));
+            string value = NormalizeWhitespace(line.Substring(separatorIndex + 1));
+            AppendStructuredHeader(headers, name, value);
+        }
+
+        body = string.Join("\n", lines.Skip(index)).Trim();
+        return true;
+    }
+
+    private static bool TryParseStructuredCurlRequestSample(
+        string code,
+        out string? method,
+        out string? path,
+        out List<HtmlCrawlStructuredHttpHeader> headers,
+        out string body) {
+        method = null;
+        path = null;
+        headers = new List<HtmlCrawlStructuredHttpHeader>();
+        body = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(code) || !Regex.IsMatch(code, @"(?im)^\s*curl\b")) {
+            return false;
+        }
+
+        Match methodMatch = Regex.Match(code, @"(?is)\b(?:-X|--request)\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\b");
+        if (methodMatch.Success) {
+            method = methodMatch.Groups[1].Value.ToUpperInvariant();
+        }
+
+        Match urlMatch = Regex.Match(code, @"(?is)\b(https?://[^\s'""]+|/[^\s'""]+)");
+        if (urlMatch.Success) {
+            path = NormalizeStructuredApiPath(urlMatch.Groups[1].Value);
+        }
+
+        foreach (Match headerMatch in Regex.Matches(code, @"(?is)\b(?:-H|--header)\s+(?:""([^""]+)""|'([^']+)'|([^\s]+))")) {
+            string rawHeader = NormalizeWhitespace(headerMatch.Groups[1].Value);
+            if (string.IsNullOrWhiteSpace(rawHeader)) {
+                rawHeader = NormalizeWhitespace(headerMatch.Groups[2].Value);
+            }
+            if (string.IsNullOrWhiteSpace(rawHeader)) {
+                rawHeader = NormalizeWhitespace(headerMatch.Groups[3].Value);
+            }
+            if (string.IsNullOrWhiteSpace(rawHeader)) {
+                continue;
+            }
+
+            int separatorIndex = rawHeader.IndexOf(':');
+            if (separatorIndex <= 0) {
+                continue;
+            }
+
+            AppendStructuredHeader(headers,
+                rawHeader.Substring(0, separatorIndex),
+                rawHeader.Substring(separatorIndex + 1));
+        }
+
+        Match bodyMatch = Regex.Match(code, @"(?is)\b(?:--data-raw|--data-binary|--data|-d)\s+(?:""([\s\S]*?)""|'([\s\S]*?)'|([^\s]+))");
+        if (bodyMatch.Success) {
+            body = NormalizeWhitespace(bodyMatch.Groups[1].Value);
+            if (string.IsNullOrWhiteSpace(body)) {
+                body = NormalizeWhitespace(bodyMatch.Groups[2].Value);
+            }
+            if (string.IsNullOrWhiteSpace(body)) {
+                body = NormalizeWhitespace(bodyMatch.Groups[3].Value);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(method)) {
+            method = string.IsNullOrWhiteSpace(body) ? "GET" : "POST";
+        }
+
+        return !string.IsNullOrWhiteSpace(method) && !string.IsNullOrWhiteSpace(path);
+    }
+
+    private static bool TryParseStructuredHttpResponseSample(
+        string code,
+        out int? statusCode,
+        out string? statusText,
+        out List<HtmlCrawlStructuredHttpHeader> headers,
+        out string body) {
+        statusCode = null;
+        statusText = null;
+        headers = new List<HtmlCrawlStructuredHttpHeader>();
+        body = code;
+
+        if (string.IsNullOrWhiteSpace(code)) {
+            return false;
+        }
+
+        string normalizedNewlines = code.Replace("\r\n", "\n");
+        string[] lines = normalizedNewlines.Split('\n');
+        if (lines.Length == 0) {
+            return false;
+        }
+
+        Match statusLine = Regex.Match(lines[0].Trim(), @"^HTTP/\d(?:\.\d)?\s+([1-5][0-9]{2})(?:\s+(.+))?$", RegexOptions.IgnoreCase);
+        if (!statusLine.Success) {
+            return false;
+        }
+
+        if (int.TryParse(statusLine.Groups[1].Value, out int parsedStatusCode)) {
+            statusCode = parsedStatusCode;
+        }
+        statusText = NormalizeWhitespace(statusLine.Groups[2].Value);
+
+        int index = 1;
+        while (index < lines.Length) {
+            string line = lines[index].Trim();
+            index++;
+            if (line.Length == 0) {
+                break;
+            }
+
+            int separatorIndex = line.IndexOf(':');
+            if (separatorIndex <= 0) {
+                continue;
+            }
+
+            string name = NormalizeWhitespace(line.Substring(0, separatorIndex));
+            string value = NormalizeWhitespace(line.Substring(separatorIndex + 1));
+            AppendStructuredHeader(headers, name, value);
+        }
+
+        body = string.Join("\n", lines.Skip(index)).Trim();
+        return true;
+    }
+
+    private static int? ExtractStatusCode(string? text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return null;
+        }
+
+        Match match = Regex.Match(text, @"\b([1-5][0-9]{2})\b");
+        if (match.Success && int.TryParse(match.Groups[1].Value, out int statusCode)) {
+            return statusCode;
+        }
+
+        return null;
+    }
+
+    private static string? ExtractStatusText(string? text) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return null;
+        }
+
+        Match httpStatusMatch = Regex.Match(text, @"\b(?:HTTP/\d(?:\.\d)?\s+)?[1-5][0-9]{2}\s+([A-Za-z][A-Za-z0-9 _-]+)", RegexOptions.IgnoreCase);
+        if (httpStatusMatch.Success) {
+            return NormalizeWhitespace(httpStatusMatch.Groups[1].Value);
+        }
+
+        return null;
+    }
+
+    private static string? GetDefaultHttpStatusText(int statusCode) {
+        return statusCode switch {
+            200 => "OK",
+            201 => "Created",
+            202 => "Accepted",
+            204 => "No Content",
+            400 => "Bad Request",
+            401 => "Unauthorized",
+            403 => "Forbidden",
+            404 => "Not Found",
+            409 => "Conflict",
+            422 => "Unprocessable Entity",
+            429 => "Too Many Requests",
+            500 => "Internal Server Error",
+            502 => "Bad Gateway",
+            503 => "Service Unavailable",
+            504 => "Gateway Timeout",
+            _ => null
+        };
+    }
+
+    private static HtmlCrawlStructuredApiEndpoint GetOrCreateStructuredApiEndpoint(
+        IDictionary<string, HtmlCrawlStructuredApiEndpoint> endpoints,
+        string method,
+        string path) {
+        string key = method.ToUpperInvariant() + " " + path;
+        if (endpoints.TryGetValue(key, out HtmlCrawlStructuredApiEndpoint? existing)) {
+            return existing;
+        }
+
+        HtmlCrawlStructuredApiEndpoint created = new() {
+            Method = method.ToUpperInvariant(),
+            Path = path
+        };
+        endpoints[key] = created;
+        return created;
+    }
+
+    private static string DetectStructuredCodeSampleKind(string code, string? language) {
+        if (TryParseApiMethodAndPath(code, out _, out _)) {
+            return "http";
+        }
+        if (string.Equals(language, "http", StringComparison.OrdinalIgnoreCase)) {
+            return "http";
+        }
+        if (Regex.IsMatch(code, @"(?im)^\s*curl\b")) {
+            return "curl";
+        }
+        if (string.Equals(language, "powershell", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(language, "ps1", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(language, "bash", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(language, "sh", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(language, "shell", StringComparison.OrdinalIgnoreCase)) {
+            return "command";
+        }
+        if (LooksLikeJson(code)) {
+            return "json";
+        }
+
+        return string.IsNullOrWhiteSpace(language) ? "text" : "code";
+    }
+
+    private static string? BuildStructuredCodeSampleTitle(string? heading, string kind, string? method, string? path, string? language) {
+        if (!string.IsNullOrWhiteSpace(heading)) {
+            return heading;
+        }
+        if (!string.IsNullOrWhiteSpace(method) && !string.IsNullOrWhiteSpace(path)) {
+            return method + " " + path;
+        }
+        if (!string.IsNullOrWhiteSpace(language)) {
+            return CultureInfoInvariantTitle(language) + " sample";
+        }
+
+        return kind switch {
+            "curl" => "cURL example",
+            "http" => "HTTP example",
+            "json" => "JSON example",
+            "command" => "Command example",
+            _ => "Code sample"
+        };
+    }
+
+    private static string? FindNearbyHeadingText(IElement element) {
+        IElement? sibling = element.PreviousElementSibling;
+        while (sibling != null) {
+            if (Regex.IsMatch(sibling.LocalName, "^h[1-6]$", RegexOptions.IgnoreCase)) {
+                return NormalizeWhitespace(sibling.TextContent);
+            }
+
+            sibling = sibling.PreviousElementSibling;
+        }
+
+        return null;
+    }
+
+    private static string? FindFollowingParagraphText(IElement element) {
+        IElement? sibling = element.NextElementSibling;
+        while (sibling != null) {
+            if (string.Equals(sibling.LocalName, "p", StringComparison.OrdinalIgnoreCase)) {
+                return NormalizeWhitespace(sibling.TextContent);
+            }
+            if (Regex.IsMatch(sibling.LocalName, "^h[1-6]$", RegexOptions.IgnoreCase)) {
+                break;
+            }
+
+            sibling = sibling.NextElementSibling;
+        }
+
+        return null;
+    }
+
+    private static string? BuildStructuredApiPrimaryResource(string? path) {
+        return GetStructuredApiLiteralPathSegments(path).FirstOrDefault();
+    }
+
+    private static IList<string> BuildStructuredApiTags(string? path, string? title, string? description) {
+        List<string> tags = new();
+        foreach (string segment in GetStructuredApiLiteralPathSegments(path)) {
+            AppendDistinct(tags, segment);
+        }
+
+        if (tags.Count == 0) {
+            foreach (string token in ExtractStructuredTitleTokens(title)) {
+                AppendDistinct(tags, token);
+            }
+        }
+
+        if (tags.Count == 0 && !string.IsNullOrWhiteSpace(description)) {
+            foreach (string token in ExtractStructuredTitleTokens(description).Take(2)) {
+                AppendDistinct(tags, token);
+            }
+        }
+
+        return tags;
+    }
+
+    private static string BuildStructuredApiOperationId(string method, string path, string? title) {
+        List<string> tokens = new();
+        tokens.Add(method.ToLowerInvariant());
+
+        List<string> segments = GetStructuredApiPathSegments(path);
+        foreach (string segment in segments) {
+            if (segment.StartsWith("{", StringComparison.Ordinal) && segment.EndsWith("}", StringComparison.Ordinal)) {
+                string parameterName = segment.Substring(1, segment.Length - 2);
+                tokens.Add("by");
+                tokens.Add(parameterName);
+                continue;
+            }
+
+            if (!IsStructuredApiVersionSegment(segment)) {
+                tokens.Add(segment);
+            }
+        }
+
+        if (tokens.Count <= 1) {
+            foreach (string token in ExtractStructuredTitleTokens(title)) {
+                tokens.Add(token);
+            }
+        }
+
+        if (tokens.Count <= 1) {
+            tokens.Add("operation");
+        }
+
+        return BuildStructuredCamelIdentifier(tokens);
+    }
+
+    private static List<string> GetStructuredApiLiteralPathSegments(string? path) {
+        return GetStructuredApiPathSegments(path)
+            .Where(segment => !segment.StartsWith("{", StringComparison.Ordinal) || !segment.EndsWith("}", StringComparison.Ordinal))
+            .Where(segment => !IsStructuredApiVersionSegment(segment))
+            .ToList();
+    }
+
+    private static List<string> GetStructuredApiPathSegments(string? path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return new List<string>();
+        }
+
+        string normalized = path!;
+        int queryIndex = normalized.IndexOf('?');
+        if (queryIndex >= 0) {
+            normalized = normalized.Substring(0, queryIndex);
+        }
+
+        return normalized.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(segment => NormalizeWhitespace(segment))
+            .Where(segment => !string.IsNullOrWhiteSpace(segment))
+            .ToList();
+    }
+
+    private static bool IsStructuredApiVersionSegment(string segment) =>
+        Regex.IsMatch(segment, @"^v\d+(?:\.\d+)?$", RegexOptions.IgnoreCase);
+
+    private static IEnumerable<string> ExtractStructuredTitleTokens(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return Array.Empty<string>();
+        }
+
+        return Regex.Matches(value, @"[A-Za-z][A-Za-z0-9]*")
+            .Cast<Match>()
+            .Select(match => match.Value)
+            .Where(token => !IsStructuredStopWord(token))
+            .Select(token => token.ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool IsStructuredStopWord(string token) =>
+        token.Equals("a", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("an", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("the", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("and", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("or", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("for", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("from", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("with", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("your", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("endpoint", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("api", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("request", StringComparison.OrdinalIgnoreCase)
+        || token.Equals("response", StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildStructuredCamelIdentifier(IEnumerable<string> tokens) {
+        List<string> parts = tokens
+            .Where(token => !string.IsNullOrWhiteSpace(token))
+            .SelectMany(token => Regex.Matches(token, @"[A-Za-z0-9]+").Cast<Match>().Select(match => match.Value))
+            .Where(token => !string.IsNullOrWhiteSpace(token))
+            .ToList();
+        if (parts.Count == 0) {
+            return "operation";
+        }
+
+        StringBuilder builder = new(parts[0].ToLowerInvariant());
+        for (int index = 1; index < parts.Count; index++) {
+            string part = parts[index].ToLowerInvariant();
+            builder.Append(char.ToUpperInvariant(part[0]));
+            if (part.Length > 1) {
+                builder.Append(part.Substring(1));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool ContainsAnyToken(string text, params string[] tokens) {
+        if (string.IsNullOrWhiteSpace(text)) {
+            return false;
+        }
+
+        return tokens.Any(token => text.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    private static void AppendDistinct(IList<string> values, string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        if (!values.Contains(value, StringComparer.OrdinalIgnoreCase)) {
+            values.Add(value);
+        }
+    }
+
+    private static string? DetectCodeBlockLanguage(IElement element) {
+        foreach (IElement candidate in new[] { element, element.ParentElement }.Where(item => item != null)!) {
+            string? attributeLanguage = candidate.GetAttribute("data-language")
+                ?? candidate.GetAttribute("data-lang")
+                ?? candidate.GetAttribute("language")
+                ?? candidate.GetAttribute("lang");
+            if (!string.IsNullOrWhiteSpace(attributeLanguage)) {
+                return NormalizeStructuredLanguage(attributeLanguage);
+            }
+
+            foreach (string className in candidate.ClassList) {
+                if (className.StartsWith("language-", StringComparison.OrdinalIgnoreCase)) {
+                    return NormalizeStructuredLanguage(className.Substring("language-".Length));
+                }
+                if (className.StartsWith("lang-", StringComparison.OrdinalIgnoreCase)) {
+                    return NormalizeStructuredLanguage(className.Substring("lang-".Length));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizeCodeBlockText(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        string normalized = value!.Replace("\r\n", "\n").Replace('\r', '\n');
+        string[] lines = normalized.Split(new[] { '\n' }, StringSplitOptions.None);
+        int start = 0;
+        int end = lines.Length - 1;
+        while (start <= end && string.IsNullOrWhiteSpace(lines[start])) {
+            start++;
+        }
+        while (end >= start && string.IsNullOrWhiteSpace(lines[end])) {
+            end--;
+        }
+
+        if (start > end) {
+            return string.Empty;
+        }
+
+        return string.Join("\n", lines.Skip(start).Take(end - start + 1));
+    }
+
+    private static string NormalizeStructuredLanguage(string language) {
+        return language.Trim().Trim('.', ':').ToLowerInvariant();
+    }
+
+    private static string CultureInfoInvariantTitle(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        string normalized = value.Trim().ToLowerInvariant();
+        return char.ToUpperInvariant(normalized[0]) + normalized.Substring(1);
+    }
+
+    private static bool TryParseApiMethodAndPath(string input, out string? method, out string? path) {
+        method = null;
+        path = null;
+        if (string.IsNullOrWhiteSpace(input)) {
+            return false;
+        }
+
+        Match directMatch = Regex.Match(input, @"(?im)\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/[^\s'""]+)");
+        if (!directMatch.Success) {
+            directMatch = Regex.Match(input, @"(?im)\bcurl\b[\s\S]*?\b-X\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\b[\s\S]*?((?:https?://[^\s'""]+)?/[^\s'""]+)");
+        }
+
+        if (!directMatch.Success) {
+            return false;
+        }
+
+        method = directMatch.Groups[1].Value.ToUpperInvariant();
+        path = NormalizeStructuredApiPath(directMatch.Groups[2].Value);
+        return !string.IsNullOrWhiteSpace(path);
+    }
+
+    private static string NormalizeStructuredApiPath(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        if (Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)) {
+            return uri.PathAndQuery;
+        }
+
+        return value.Trim();
+    }
+
+    private static bool LooksLikeJson(string code) {
+        string trimmed = code.Trim();
+        return (trimmed.StartsWith("{", StringComparison.Ordinal) && trimmed.EndsWith("}", StringComparison.Ordinal))
+            || (trimmed.StartsWith("[", StringComparison.Ordinal) && trimmed.EndsWith("]", StringComparison.Ordinal));
+    }
+
+    private static string? TryResolveStructuredHref(Uri? baseUri, string? href) {
+        if (string.IsNullOrWhiteSpace(href)) {
+            return null;
+        }
+
+        if (baseUri == null) {
+            return href;
+        }
+
+        return TryResolveAbsoluteUri(baseUri, href!, out Uri? resolved) && resolved != null ? resolved.AbsoluteUri : href;
+    }
+
+    private static string? FindMetaContent(IEnumerable<HtmlMetaTag> metaTags, params string[] names) {
+        foreach (string name in names) {
+            HtmlMetaTag? match = metaTags.FirstOrDefault(tag =>
+                string.Equals(tag.Name, name, StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(tag.Content));
+            if (match != null) {
+                return match.Content;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? FindOpenGraphValue(HtmlOpenGraph openGraph, string propertyName) {
+        OpenGraphProperty? match = openGraph.Properties.FirstOrDefault(property =>
+            string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+        return match?.Values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+    }
+
+    private static IList<string> SplitMetadataKeywords(string? keywords) {
+        if (string.IsNullOrWhiteSpace(keywords)) {
+            return new List<string>();
+        }
+
+        return keywords.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(value => value.Trim())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static IDictionary<string, object?> BuildStructuredSchemaExtraction(
+        HtmlCrawlStructuredJson structuredJson,
+        IDocument document,
+        IDocument selectedDocument,
+        IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema) {
+        Dictionary<string, object?> extracted = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, HtmlCrawlJsonSchemaField> field in structuredSchema) {
+            extracted[field.Key] = ExtractStructuredSchemaFieldValue(structuredJson, document, selectedDocument, field.Value);
+        }
+
+        return extracted;
+    }
+
+    private static object? ExtractStructuredSchemaFieldValue(
+        HtmlCrawlStructuredJson structuredJson,
+        IDocument document,
+        IDocument selectedDocument,
+        HtmlCrawlJsonSchemaField field) {
+        if (!string.IsNullOrWhiteSpace(field.Path)) {
+            return ResolveStructuredPath(structuredJson, field.Path!);
+        }
+
+        if (string.IsNullOrWhiteSpace(field.Selector)) {
+            return null;
+        }
+
+        IDocument sourceDocument = ResolveStructuredSchemaSourceDocument(document, selectedDocument, field.Source);
+        IHtmlCollection<IElement> elements = sourceDocument.QuerySelectorAll(field.Selector!);
+        string mode = string.IsNullOrWhiteSpace(field.Mode) ? "Text" : field.Mode!.Trim();
+        if (string.Equals(mode, "Exists", StringComparison.OrdinalIgnoreCase)) {
+            return elements.Length > 0;
+        }
+
+        if (string.Equals(mode, "Count", StringComparison.OrdinalIgnoreCase)) {
+            return elements.Length;
+        }
+
+        if (field.All) {
+            return elements
+                .Select(element => ExtractStructuredSchemaElementValue(element, mode, field.Attribute))
+                .Where(value => value != null)
+                .ToList();
+        }
+
+        IElement? first = elements.FirstOrDefault();
+        return first == null ? null : ExtractStructuredSchemaElementValue(first, mode, field.Attribute);
+    }
+
+    private static IDocument ResolveStructuredSchemaSourceDocument(IDocument document, IDocument selectedDocument, string? source) {
+        if (string.IsNullOrWhiteSpace(source)) {
+            return selectedDocument;
+        }
+
+        return source.Trim().ToLowerInvariant() switch {
+            "page" or "document" or "full" => document,
+            _ => selectedDocument
+        };
+    }
+
+    private static object? ExtractStructuredSchemaElementValue(IElement element, string mode, string? attribute) {
+        if (string.Equals(mode, "Html", StringComparison.OrdinalIgnoreCase)) {
+            return element.OuterHtml;
+        }
+
+        if (string.Equals(mode, "Markdown", StringComparison.OrdinalIgnoreCase)) {
+            return ConvertSelectedHtmlToMarkdown(element.OuterHtml, null);
+        }
+
+        if (string.Equals(mode, "Attribute", StringComparison.OrdinalIgnoreCase)) {
+            return string.IsNullOrWhiteSpace(attribute) ? null : element.GetAttribute(attribute);
+        }
+
+        return NormalizeWhitespace(element.TextContent);
+    }
+
+    private static object? ResolveStructuredPath(object? current, string path) {
+        if (current == null || string.IsNullOrWhiteSpace(path)) {
+            return null;
+        }
+
+        object? value = current;
+        foreach (string segment in path.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)) {
+            if (value == null) {
+                return null;
+            }
+
+            if (value is IDictionary<string, object?> dictionary) {
+                if (!TryGetDictionaryValue(dictionary, segment, out value)) {
+                    return null;
+                }
+                continue;
+            }
+
+            if (value is IDictionary nonGenericDictionary) {
+                if (!TryGetDictionaryValue(nonGenericDictionary, segment, out value)) {
+                    return null;
+                }
+                continue;
+            }
+
+            if (value is IList list) {
+                if (string.Equals(segment, "Count", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(segment, "Length", StringComparison.OrdinalIgnoreCase)) {
+                    value = list.Count;
+                    continue;
+                }
+
+                if (!int.TryParse(segment, out int index) || index < 0 || index >= list.Count) {
+                    return null;
+                }
+
+                value = list[index];
+                continue;
+            }
+
+            PropertyInfo? property = value.GetType()
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(item => string.Equals(item.Name, segment, StringComparison.OrdinalIgnoreCase));
+            if (property == null) {
+                return null;
+            }
+
+            value = property.GetValue(value);
+        }
+
+        return value;
+    }
+
+    private static bool TryGetDictionaryValue(IDictionary<string, object?> dictionary, string key, out object? value) {
+        foreach (KeyValuePair<string, object?> item in dictionary) {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase)) {
+                value = item.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryGetDictionaryValue(IDictionary dictionary, string key, out object? value) {
+        foreach (DictionaryEntry item in dictionary) {
+            string? itemKey = Convert.ToString(item.Key, System.Globalization.CultureInfo.InvariantCulture);
+            if (string.Equals(itemKey, key, StringComparison.OrdinalIgnoreCase)) {
+                value = item.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
     }
 
     private static string[] ExtractHeadings(string? html) {
@@ -1805,6 +6894,9 @@ public static class HtmlCrawler {
         AppendArtifactLink(builder, indexHtmlPath, "Skipped Assets JSONL", result.SkippedAssetsJsonlPath);
         AppendArtifactLink(builder, indexHtmlPath, "Links JSONL", result.LinksJsonlPath);
         AppendArtifactLink(builder, indexHtmlPath, "Assets JSONL", result.AssetsJsonlPath);
+        AppendArtifactLink(builder, indexHtmlPath, "Structured Pages JSONL", result.StructuredJsonPagesJsonlPath);
+        AppendArtifactLink(builder, indexHtmlPath, "OpenAPI-Like JSON", result.OpenApiLikePath);
+        AppendArtifactLink(builder, indexHtmlPath, "OpenAPI JSON", result.OpenApiPath);
         AppendArtifactLink(builder, indexHtmlPath, "Chunks JSONL", result.ChunksJsonlPath);
         AppendArtifactLink(builder, indexHtmlPath, "Graph JSON", result.GraphJsonPath);
         AppendArtifactLink(builder, indexHtmlPath, "Summary JSON", result.SummaryPath);
@@ -2085,11 +7177,19 @@ public static class HtmlCrawler {
             builder.AppendLine("</td>");
             builder.Append("          <td>");
             AppendOptionalFileLink(builder, indexHtmlPath, "HTML", page.HtmlPath);
-            if (!string.IsNullOrWhiteSpace(page.HtmlPath) && HasAnyFollowingFile(page.TextPath, page.ManifestPath)) {
+            if (!string.IsNullOrWhiteSpace(page.HtmlPath) && HasAnyFollowingFile(page.TextPath, page.MarkdownPath, page.StructuredJsonPath, page.ManifestPath)) {
                 builder.Append(" | ");
             }
             AppendOptionalFileLink(builder, indexHtmlPath, "Text", page.TextPath);
-            if (!string.IsNullOrWhiteSpace(page.TextPath) && HasAnyFollowingFile(page.ManifestPath)) {
+            if (!string.IsNullOrWhiteSpace(page.TextPath) && HasAnyFollowingFile(page.MarkdownPath, page.StructuredJsonPath, page.ManifestPath)) {
+                builder.Append(" | ");
+            }
+            AppendOptionalFileLink(builder, indexHtmlPath, "Markdown", page.MarkdownPath);
+            if (!string.IsNullOrWhiteSpace(page.MarkdownPath) && HasAnyFollowingFile(page.StructuredJsonPath, page.ManifestPath)) {
+                builder.Append(" | ");
+            }
+            AppendOptionalFileLink(builder, indexHtmlPath, "Structured JSON", page.StructuredJsonPath);
+            if (!string.IsNullOrWhiteSpace(page.StructuredJsonPath) && HasAnyFollowingFile(page.ManifestPath)) {
                 builder.Append(" | ");
             }
             AppendOptionalFileLink(builder, indexHtmlPath, "Manifest", page.ManifestPath);
@@ -2266,6 +7366,9 @@ public static class HtmlCrawler {
                 SkippedAssetsJsonlPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "skipped-assets.jsonl"), fullPath),
                 LinksJsonlPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "links.jsonl"), fullPath),
                 AssetsJsonlPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "assets.jsonl"), fullPath),
+                StructuredJsonPagesJsonlPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "structured-pages.jsonl"), fullPath),
+                OpenApiLikeJsonPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "openapi-like.json"), fullPath),
+                OpenApiJsonPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "openapi.json"), fullPath),
                 ChunksJsonlPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "chunks.jsonl"), fullPath),
                 GraphJsonPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "graph.json"), fullPath),
                 SummaryJsonPath = EnsurePathIsWithinDirectory(Path.Combine(fullPath, "summary.json"), fullPath),
@@ -2291,6 +7394,9 @@ public static class HtmlCrawler {
             SkippedAssetsJsonlPath = EnsurePathIsWithinDirectory(stem + ".skipped-assets.jsonl", baseDirectory),
             LinksJsonlPath = EnsurePathIsWithinDirectory(stem + ".links.jsonl", baseDirectory),
             AssetsJsonlPath = EnsurePathIsWithinDirectory(stem + ".assets.jsonl", baseDirectory),
+            StructuredJsonPagesJsonlPath = EnsurePathIsWithinDirectory(stem + ".structured-pages.jsonl", baseDirectory),
+            OpenApiLikeJsonPath = EnsurePathIsWithinDirectory(stem + ".openapi-like.json", baseDirectory),
+            OpenApiJsonPath = EnsurePathIsWithinDirectory(stem + ".openapi.json", baseDirectory),
             ChunksJsonlPath = EnsurePathIsWithinDirectory(stem + ".chunks.jsonl", baseDirectory),
             GraphJsonPath = EnsurePathIsWithinDirectory(stem + ".graph.json", baseDirectory),
             SummaryJsonPath = EnsurePathIsWithinDirectory(stem + ".summary.json", baseDirectory),
@@ -2306,6 +7412,47 @@ public static class HtmlCrawler {
         }
 
         return fullPath;
+    }
+
+    private static async Task<IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField>> LoadStructuredSchemaAsync(HtmlCrawlOptions options, CancellationToken cancellationToken) {
+        string? schemaJson = options.StructuredJsonSchema;
+        if (string.IsNullOrWhiteSpace(schemaJson) && !string.IsNullOrWhiteSpace(options.StructuredJsonSchemaPath)) {
+            schemaJson = await HtmlUtilities.ReadFileCheckedAsync(options.StructuredJsonSchemaPath!, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(schemaJson)) {
+            return new Dictionary<string, HtmlCrawlJsonSchemaField>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return ParseStructuredSchema(schemaJson);
+    }
+
+    private static IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> ParseStructuredSchema(string schemaJson) {
+        using JsonDocument document = JsonDocument.Parse(schemaJson);
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object) {
+            throw new ArgumentException("Structured JSON schema must be an object.", nameof(schemaJson));
+        }
+
+        if (root.TryGetProperty("fields", out JsonElement fieldsElement) && fieldsElement.ValueKind == JsonValueKind.Object) {
+            root = fieldsElement;
+        }
+
+        Dictionary<string, HtmlCrawlJsonSchemaField> fields = new(StringComparer.OrdinalIgnoreCase);
+        JsonSerializerOptions options = new() {
+            PropertyNameCaseInsensitive = true
+        };
+        foreach (JsonProperty property in root.EnumerateObject()) {
+            fields[property.Name] = property.Value.ValueKind switch {
+                JsonValueKind.String => new HtmlCrawlJsonSchemaField {
+                    Path = property.Value.GetString()
+                },
+                JsonValueKind.Object => JsonSerializer.Deserialize<HtmlCrawlJsonSchemaField>(property.Value.GetRawText(), options) ?? new HtmlCrawlJsonSchemaField(),
+                _ => throw new ArgumentException($"Structured JSON schema field '{property.Name}' must be a string path or an object rule.", nameof(schemaJson))
+            };
+        }
+
+        return fields;
     }
 
     private static JsonSerializerOptions CreateJsonOptions() {
@@ -2348,7 +7495,7 @@ public static class HtmlCrawler {
         return normalized;
     }
 
-    private static async Task<FetchedPageData> FetchHttpPageAsync(HttpClient client, CrawlRequest request, HtmlCrawlOptions options, CancellationToken cancellationToken) {
+    private static async Task<FetchedPageData> FetchHttpPageAsync(HttpClient client, CrawlRequest request, HtmlCrawlOptions options, IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema, CancellationToken cancellationToken) {
         HtmlCrawlPage page = new() {
             Url = NormalizeUrl(request.Uri, options),
             RequestedUrl = request.Uri.AbsoluteUri,
@@ -2378,7 +7525,7 @@ public static class HtmlCrawler {
                 };
             }
 
-            PopulatePageFromHtml(page, html, request.Uri, options);
+            PopulatePageFromHtml(page, html, request.Uri, options, structuredSchema);
             return new FetchedPageData {
                 Page = page,
                 RawHtml = html
@@ -2395,7 +7542,7 @@ public static class HtmlCrawler {
         };
     }
 
-    private static async Task<FetchedPageData> FetchRenderedPageAsync(HtmlBrowserSession session, CrawlRequest request, HtmlCrawlOptions options, CancellationToken cancellationToken) {
+    private static async Task<FetchedPageData> FetchRenderedPageAsync(HtmlBrowserSession session, CrawlRequest request, HtmlCrawlOptions options, IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema, CancellationToken cancellationToken) {
         HtmlCrawlPage page = new() {
             Url = NormalizeUrl(request.Uri, options),
             RequestedUrl = request.Uri.AbsoluteUri,
@@ -2445,7 +7592,7 @@ public static class HtmlCrawler {
             }
 
             string? title = await session.Page.TitleAsync().ConfigureAwait(false);
-            PopulatePageFromHtml(page, fullHtml, request.Uri, options, title);
+            PopulatePageFromHtml(page, fullHtml, request.Uri, options, structuredSchema, title);
             return new FetchedPageData {
                 Page = page,
                 RawHtml = fullHtml
@@ -2538,7 +7685,7 @@ public static class HtmlCrawler {
         }
     }
 
-    private static void PopulatePageFromHtml(HtmlCrawlPage page, string html, Uri requestUri, HtmlCrawlOptions options, string? titleOverride = null) {
+    private static void PopulatePageFromHtml(HtmlCrawlPage page, string html, Uri requestUri, HtmlCrawlOptions options, IReadOnlyDictionary<string, HtmlCrawlJsonSchemaField> structuredSchema, string? titleOverride = null) {
         page.Title = string.IsNullOrWhiteSpace(titleOverride) ? ExtractTitle(html) : titleOverride;
         page.CanonicalUrl = ExtractCanonicalUrl(html, requestUri, options);
         page.Links = ExtractLinks(html, requestUri, options);
@@ -2569,8 +7716,23 @@ public static class HtmlCrawler {
             : null;
         page.ContentComparisonDeltaSummary = BuildContentComparisonDeltaSummary(page.ContentComparisons, bestComparison);
         page.ContentComparisonPreviewSummary = BuildContentComparisonPreviewSummary(page.ContentComparisons, bestComparison);
+        string selectedText = HtmlParserToText.ConvertToText(PrepareHtmlForTextExtraction(selectedHtml, options));
+        string selectedMarkdown = options.IncludeMarkdown || options.IncludeStructuredJson
+            ? ConvertSelectedHtmlToMarkdown(selectedHtml, page.Url)
+            : string.Empty;
         page.Html = options.IncludeHtml ? selectedHtml : string.Empty;
-        page.Text = options.IncludeText ? HtmlParserToText.ConvertToText(PrepareHtmlForTextExtraction(selectedHtml, options)) : string.Empty;
+        page.Text = options.IncludeText ? selectedText : string.Empty;
+        page.Markdown = options.IncludeMarkdown ? selectedMarkdown : string.Empty;
+        page.StructuredJson = options.IncludeStructuredJson ? BuildStructuredJson(page, html, selectedHtml, selectedText, selectedMarkdown, structuredSchema, options.StructuredJsonPreset) : null;
+    }
+
+    private static string ConvertSelectedHtmlToMarkdown(string html, string? pageUrl) {
+        HtmlToMarkdownOptions markdownOptions = HtmlToMarkdownOptions.CreatePortableProfile();
+        if (!string.IsNullOrWhiteSpace(pageUrl) && Uri.TryCreate(pageUrl, UriKind.Absolute, out Uri? baseUri)) {
+            markdownOptions.BaseUri = baseUri;
+        }
+
+        return html.ToMarkdown(markdownOptions);
     }
 
     private static ProfileSelectionDecision ResolveInitialProfileDecision(
@@ -3530,6 +8692,10 @@ public static class HtmlCrawler {
     private static void StripBoilerplateElements(IParentNode container, HtmlCrawlOptions options) {
         foreach (IElement element in container.QuerySelectorAll(
                      "script,style,noscript,svg,header,nav,footer,aside,[role='banner'],[role='navigation'],[role='contentinfo'],[role='search'],form[role='search'],.wpml-ls,.sharing-popup,.post-footer-sharing,.socials-sharing,.gem-pagination,.menu-toggle,.minisearch,.skip-link,.skip-link-screen-reader-text").ToArray()) {
+            if (ShouldPreserveStructuredContentElement(element)) {
+                continue;
+            }
+
             element.Remove();
         }
 
@@ -3540,6 +8706,14 @@ public static class HtmlCrawler {
         foreach (IElement element in container.QuerySelectorAll("*").Where(ShouldRemoveBoilerplateElement).ToArray()) {
             element.Remove();
         }
+    }
+
+    private static bool ShouldPreserveStructuredContentElement(IElement element) {
+        if (element == null) {
+            return false;
+        }
+
+        return LooksLikeStructuredCalloutElement(element);
     }
 
     private static void RemoveConfiguredElements(IParentNode container, HtmlCrawlOptions options) {

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -1485,14 +1485,15 @@ public static class HtmlCrawler {
 
     private static List<object> BuildStrictOpenApiParameters(HtmlCrawlStructuredOpenApiOperation operation) {
         return operation.Parameters
-            .Where(parameter => !string.Equals(NormalizeWhitespace(parameter.Location), "body", StringComparison.OrdinalIgnoreCase))
-            .OrderBy(parameter => parameter.Location, StringComparer.OrdinalIgnoreCase)
+            .Where(parameter => !string.Equals(ResolveStructuredApiParameterLocation(operation.Path, parameter), "body", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(parameter => ResolveStructuredApiParameterLocation(operation.Path, parameter), StringComparer.OrdinalIgnoreCase)
             .ThenBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
             .Select(parameter => {
+                string location = ResolveStructuredApiParameterLocation(operation.Path, parameter);
                 Dictionary<string, object?> value = new(StringComparer.OrdinalIgnoreCase) {
                     ["name"] = parameter.Name,
-                    ["in"] = NormalizeStrictOpenApiParameterLocation(parameter.Location),
-                    ["required"] = string.Equals(parameter.Location, "path", StringComparison.OrdinalIgnoreCase) || parameter.Required == true,
+                    ["in"] = NormalizeStrictOpenApiParameterLocation(location),
+                    ["required"] = string.Equals(location, "path", StringComparison.OrdinalIgnoreCase) || parameter.Required == true,
                     ["description"] = parameter.Description,
                     ["schema"] = BuildStrictOpenApiParameterSchema(parameter)
                 };
@@ -1549,7 +1550,7 @@ public static class HtmlCrawler {
         }
 
         return new Dictionary<string, object?> {
-            ["required"] = operation.Parameters.Any(parameter => string.Equals(parameter.Location, "body", StringComparison.OrdinalIgnoreCase) && parameter.Required == true),
+            ["required"] = operation.Parameters.Any(parameter => string.Equals(ResolveStructuredApiParameterLocation(operation.Path, parameter), "body", StringComparison.OrdinalIgnoreCase) && parameter.Required == true),
             ["content"] = new Dictionary<string, object?> {
                 [contentType] = mediaType
             }
@@ -1639,7 +1640,16 @@ public static class HtmlCrawler {
         foreach (KeyValuePair<string, HtmlCrawlStructuredApiAuthentication> item in authProfiles.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
             Dictionary<string, object?> scheme = new(StringComparer.OrdinalIgnoreCase);
             string? primaryHeader = item.Value.Headers.FirstOrDefault();
-            if (item.Value.Schemes.Any(schemeName => string.Equals(schemeName, "bearer", StringComparison.OrdinalIgnoreCase))) {
+            if (item.Value.Schemes.Any(schemeName => string.Equals(schemeName, "oauth2", StringComparison.OrdinalIgnoreCase))) {
+                scheme["type"] = "oauth2";
+                scheme["flows"] = new Dictionary<string, object?> {
+                    ["clientCredentials"] = new Dictionary<string, object?> {
+                        ["tokenUrl"] = "https://example.invalid/token",
+                        ["scopes"] = new Dictionary<string, object?>()
+                    }
+                };
+                scheme["x-htmltinkerx-oauth2FlowPlaceholder"] = true;
+            } else if (item.Value.Schemes.Any(schemeName => string.Equals(schemeName, "bearer", StringComparison.OrdinalIgnoreCase))) {
                 scheme["type"] = "http";
                 scheme["scheme"] = "bearer";
             } else if (item.Value.Schemes.Any(schemeName => string.Equals(schemeName, "basic", StringComparison.OrdinalIgnoreCase))) {
@@ -2652,7 +2662,7 @@ public static class HtmlCrawler {
                 continue;
             }
 
-            if (items.Count > 0 && string.Equals(items[^1].Label, label, StringComparison.OrdinalIgnoreCase)) {
+            if (items.Count > 0 && string.Equals(items[items.Count - 1].Label, label, StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 
@@ -2678,7 +2688,7 @@ public static class HtmlCrawler {
                 .Select(item => item.Url!)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList(),
-            CurrentLabel = items.LastOrDefault(item => item.IsCurrent)?.Label ?? items[^1].Label,
+            CurrentLabel = items.LastOrDefault(item => item.IsCurrent)?.Label ?? items[items.Count - 1].Label,
             SelectorHint = BuildElementSelectorHint(container)
         };
     }

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -6511,11 +6511,19 @@ public static class HtmlCrawler {
             return string.Empty;
         }
 
-        if (Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)) {
-            return uri.PathAndQuery;
+        string trimmed = value.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out Uri? uri)
+            && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))) {
+            int authorityLength = uri.GetLeftPart(UriPartial.Authority).Length;
+            if (trimmed.Length > authorityLength) {
+                return trimmed.Substring(authorityLength);
+            }
+
+            return "/";
         }
 
-        return value.Trim();
+        return trimmed;
     }
 
     private static bool LooksLikeJson(string code) {

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -6034,17 +6034,12 @@ public static class HtmlCrawler {
             return false;
         }
 
-        Match methodMatch = Regex.Match(code, @"(?is)\b(?:-X|--request)\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\b");
-        if (methodMatch.Success) {
-            method = methodMatch.Groups[1].Value.ToUpperInvariant();
+        TryExtractCurlMethod(code, out method);
+        if (TryExtractCurlTarget(code, out string? target)) {
+            path = NormalizeStructuredApiPath(target!);
         }
 
-        Match urlMatch = Regex.Match(code, @"(?is)\b(https?://[^\s'""]+|/[^\s'""]+)");
-        if (urlMatch.Success) {
-            path = NormalizeStructuredApiPath(urlMatch.Groups[1].Value);
-        }
-
-        foreach (Match headerMatch in Regex.Matches(code, @"(?is)\b(?:-H|--header)\s+(?:""([^""]+)""|'([^']+)'|([^\s]+))")) {
+        foreach (Match headerMatch in Regex.Matches(code, @"(?is)(?<!\S)(?:-H|--header)\s+(?:""([^""]+)""|'([^']+)'|([^\s]+))")) {
             string rawHeader = NormalizeWhitespace(headerMatch.Groups[1].Value);
             if (string.IsNullOrWhiteSpace(rawHeader)) {
                 rawHeader = NormalizeWhitespace(headerMatch.Groups[2].Value);
@@ -6066,7 +6061,7 @@ public static class HtmlCrawler {
                 rawHeader.Substring(separatorIndex + 1));
         }
 
-        Match bodyMatch = Regex.Match(code, @"(?is)\b(?:--data-raw|--data-binary|--data|-d)\s+(?:""([\s\S]*?)""|'([\s\S]*?)'|([^\s]+))");
+        Match bodyMatch = Regex.Match(code, @"(?is)(?<!\S)(?:--data-raw|--data-binary|--data|-d)\s+(?:""([\s\S]*?)""|'([\s\S]*?)'|([^\s]+))");
         if (bodyMatch.Success) {
             body = NormalizeWhitespace(bodyMatch.Groups[1].Value);
             if (string.IsNullOrWhiteSpace(body)) {
@@ -6494,17 +6489,175 @@ public static class HtmlCrawler {
 
         Match directMatch = Regex.Match(input, @"(?im)\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/[^\s'""]+)");
         if (!directMatch.Success) {
-            directMatch = Regex.Match(input, @"(?im)\bcurl\b[\s\S]*?\b-X\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\b[\s\S]*?((?:https?://[^\s'""]+)?/[^\s'""]+)");
-        }
-
-        if (!directMatch.Success) {
-            return false;
+            return TryParseCurlMethodAndPath(input, out method, out path);
         }
 
         method = directMatch.Groups[1].Value.ToUpperInvariant();
         path = NormalizeStructuredApiPath(directMatch.Groups[2].Value);
         return !string.IsNullOrWhiteSpace(path);
     }
+
+    private static bool TryParseCurlMethodAndPath(string input, out string? method, out string? path) {
+        method = null;
+        path = null;
+        if (string.IsNullOrWhiteSpace(input) || !Regex.IsMatch(input, @"(?im)^\s*curl\b")) {
+            return false;
+        }
+
+        if (TryExtractCurlMethod(input, out string? parsedMethod)) {
+            method = parsedMethod;
+        }
+
+        if (TryExtractCurlTarget(input, out string? target)) {
+            path = NormalizeStructuredApiPath(target!);
+        }
+
+        if (string.IsNullOrWhiteSpace(method)) {
+            method = Regex.IsMatch(input, @"(?is)(?<!\S)(?:--data-raw|--data-binary|--data|--data-urlencode|-d)(?:\s|$)")
+                ? "POST"
+                : "GET";
+        }
+
+        return !string.IsNullOrWhiteSpace(method) && !string.IsNullOrWhiteSpace(path);
+    }
+
+    private static bool TryExtractCurlMethod(string code, out string? method) {
+        method = null;
+        if (string.IsNullOrWhiteSpace(code)) {
+            return false;
+        }
+
+        Match methodMatch = Regex.Match(code, @"(?is)(?<!\S)(?:-X|--request)(?:\s+|=)(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\b");
+        if (!methodMatch.Success) {
+            return false;
+        }
+
+        method = methodMatch.Groups[1].Value.ToUpperInvariant();
+        return true;
+    }
+
+    private static bool TryExtractCurlTarget(string code, out string? target) {
+        target = null;
+        if (string.IsNullOrWhiteSpace(code) || !Regex.IsMatch(code, @"(?im)^\s*curl\b")) {
+            return false;
+        }
+
+        Match urlOptionMatch = Regex.Match(code, @"(?is)(?<!\S)--url(?:\s+|=)(?:""([^""]+)""|'([^']+)'|([^\s]+))");
+        if (urlOptionMatch.Success) {
+            target = FirstNonEmptyValue(
+                urlOptionMatch.Groups[1].Value,
+                urlOptionMatch.Groups[2].Value,
+                urlOptionMatch.Groups[3].Value);
+            return !string.IsNullOrWhiteSpace(target);
+        }
+
+        List<string> tokens = TokenizeShellLikeArguments(code);
+        if (tokens.Count == 0 || !string.Equals(tokens[0], "curl", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        HashSet<string> optionsWithSeparateValue = new(StringComparer.OrdinalIgnoreCase) {
+            "-X",
+            "--request",
+            "-H",
+            "--header",
+            "-d",
+            "--data",
+            "--data-raw",
+            "--data-binary",
+            "--data-urlencode",
+            "-e",
+            "--referer",
+            "-A",
+            "--user-agent",
+            "-u",
+            "--user",
+            "-F",
+            "--form",
+            "-o",
+            "--output",
+            "--url",
+            "--cookie",
+            "-b",
+            "--proxy",
+            "-x",
+            "--cacert",
+            "--cert",
+            "--key"
+        };
+
+        for (int index = 1; index < tokens.Count; index++) {
+            string token = tokens[index];
+            if (string.IsNullOrWhiteSpace(token)) {
+                continue;
+            }
+
+            if (token == "--") {
+                continue;
+            }
+
+            if (optionsWithSeparateValue.Contains(token)) {
+                index++;
+                continue;
+            }
+
+            if (LooksLikeCurlOptionWithInlineValue(token)) {
+                continue;
+            }
+
+            if (LooksLikeCurlTargetToken(token)) {
+                target = token;
+            }
+        }
+
+        return !string.IsNullOrWhiteSpace(target);
+    }
+
+    private static bool LooksLikeCurlOptionWithInlineValue(string token) {
+        if (string.IsNullOrWhiteSpace(token) || !token.StartsWith("-", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return token.StartsWith("--request=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--header=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--data=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--data-raw=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--data-binary=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--data-urlencode=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--url=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("--referer=", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-X", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-H", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-d", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-e", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-A", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-u", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-F", StringComparison.OrdinalIgnoreCase)
+            || token.StartsWith("-o", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeCurlTargetToken(string token) =>
+        !string.IsNullOrWhiteSpace(token)
+        && (Regex.IsMatch(token, @"^https?://", RegexOptions.IgnoreCase)
+            || token.StartsWith("/", StringComparison.Ordinal));
+
+    private static List<string> TokenizeShellLikeArguments(string command) {
+        List<string> tokens = new();
+        foreach (Match match in Regex.Matches(command, @"(?:""((?:\\""|[^""])*)""|'((?:\\'|[^'])*)'|(\S+))")) {
+            string? value = FirstNonEmptyValue(
+                match.Groups[1].Value.Replace("\\\"", "\""),
+                match.Groups[2].Value.Replace("\\'", "'"),
+                match.Groups[3].Value);
+            if (!string.IsNullOrWhiteSpace(value)) {
+                tokens.Add(value);
+            }
+        }
+
+        return tokens;
+    }
+
+    private static string? FirstNonEmptyValue(params string[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 
     private static string NormalizeStructuredApiPath(string value) {
         if (string.IsNullOrWhiteSpace(value)) {

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -2610,6 +2610,14 @@ public static class HtmlCrawler {
             string? method = null;
             string? path = null;
             TryParseApiMethodAndPath(code, out method, out path);
+            if (string.IsNullOrWhiteSpace(method)
+                && string.IsNullOrWhiteSpace(path)
+                && LooksLikeRequestPayloadHeading(heading)) {
+                string? apiHeading = FindNearbyApiHeadingText(element);
+                if (!string.IsNullOrWhiteSpace(apiHeading)) {
+                    TryParseApiMethodAndPath(apiHeading, out method, out path);
+                }
+            }
 
             samples.Add(new HtmlCrawlStructuredCodeSample {
                 Title = BuildStructuredCodeSampleTitle(heading, kind, method, path, language),
@@ -4720,6 +4728,9 @@ public static class HtmlCrawler {
         if (ContainsAnyToken(combined, "query")) {
             return "query";
         }
+        if (ContainsAnyToken(combined, "cookie")) {
+            return "cookie";
+        }
         if (ContainsAnyToken(combined, "header")) {
             return "header";
         }
@@ -6271,11 +6282,40 @@ public static class HtmlCrawler {
         };
     }
 
+    private static bool LooksLikeRequestPayloadHeading(string? heading) {
+        if (string.IsNullOrWhiteSpace(heading)) {
+            return false;
+        }
+
+        return ContainsAnyToken(heading,
+            "request body",
+            "request payload",
+            "payload",
+            "example request",
+            "request example");
+    }
+
     private static string? FindNearbyHeadingText(IElement element) {
         IElement? sibling = element.PreviousElementSibling;
         while (sibling != null) {
             if (Regex.IsMatch(sibling.LocalName, "^h[1-6]$", RegexOptions.IgnoreCase)) {
                 return NormalizeWhitespace(sibling.TextContent);
+            }
+
+            sibling = sibling.PreviousElementSibling;
+        }
+
+        return null;
+    }
+
+    private static string? FindNearbyApiHeadingText(IElement element) {
+        IElement? sibling = element.PreviousElementSibling;
+        while (sibling != null) {
+            if (Regex.IsMatch(sibling.LocalName, "^h[1-6]$", RegexOptions.IgnoreCase)) {
+                string heading = NormalizeWhitespace(sibling.TextContent);
+                if (TryParseApiMethodAndPath(heading, out _, out _)) {
+                    return heading;
+                }
             }
 
             sibling = sibling.PreviousElementSibling;

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -1,6 +1,5 @@
 using AngleSharp.Dom;
 using Microsoft.Playwright;
-using OfficeIMO.Markdown.Html;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -1486,6 +1485,7 @@ public static class HtmlCrawler {
 
     private static List<object> BuildStrictOpenApiParameters(HtmlCrawlStructuredOpenApiOperation operation) {
         return operation.Parameters
+            .Where(parameter => !string.Equals(NormalizeWhitespace(parameter.Location), "body", StringComparison.OrdinalIgnoreCase))
             .OrderBy(parameter => parameter.Location, StringComparer.OrdinalIgnoreCase)
             .ThenBy(parameter => parameter.Name, StringComparer.OrdinalIgnoreCase)
             .Select(parameter => {
@@ -7727,12 +7727,7 @@ public static class HtmlCrawler {
     }
 
     private static string ConvertSelectedHtmlToMarkdown(string html, string? pageUrl) {
-        HtmlToMarkdownOptions markdownOptions = HtmlToMarkdownOptions.CreatePortableProfile();
-        if (!string.IsNullOrWhiteSpace(pageUrl) && Uri.TryCreate(pageUrl, UriKind.Absolute, out Uri? baseUri)) {
-            markdownOptions.BaseUri = baseUri;
-        }
-
-        return html.ToMarkdown(markdownOptions);
+        return HtmlMarkdownConverterAdapter.ConvertToMarkdown(html, pageUrl);
     }
 
     private static ProfileSelectionDecision ResolveInitialProfileDecision(

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -6487,7 +6487,7 @@ public static class HtmlCrawler {
             return false;
         }
 
-        Match directMatch = Regex.Match(input, @"(?im)\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/[^\s'""]+)");
+        Match directMatch = Regex.Match(input, @"(?im)\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/(?:[^\s'""]*)?)");
         if (!directMatch.Success) {
             return TryParseCurlMethodAndPath(input, out method, out path);
         }

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -5989,7 +5989,7 @@ public static class HtmlCrawler {
             return false;
         }
 
-        Match requestLine = Regex.Match(lines[0].Trim(), @"^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/[^\s'""]+)(?:\s+HTTP/\d(?:\.\d)?)?$", RegexOptions.IgnoreCase);
+        Match requestLine = Regex.Match(lines[0].Trim(), @"^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+((?:https?://[^\s'""]+)?/(?:[^\s'""]*)?)(?:\s+HTTP/\d(?:\.\d)?)?$", RegexOptions.IgnoreCase);
         if (!requestLine.Success) {
             return false;
         }

--- a/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
+++ b/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
@@ -1,0 +1,395 @@
+using AngleSharp.Dom;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace HtmlTinkerX;
+
+internal static class HtmlMarkdownConverterAdapter {
+    private static readonly Regex ConsecutiveBlankLinesRegex = new(@"\n{3,}", RegexOptions.Compiled);
+    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+
+    public static string ConvertToMarkdown(string html, string? pageUrl) {
+        if (string.IsNullOrWhiteSpace(html)) {
+            return string.Empty;
+        }
+
+        if (TryConvertWithOfficeImo(html, pageUrl, out string markdown)) {
+            return markdown;
+        }
+
+        return ConvertWithFallback(html, pageUrl);
+    }
+
+    private static bool TryConvertWithOfficeImo(string html, string? pageUrl, out string markdown) {
+        markdown = string.Empty;
+        try {
+            Assembly? assembly = TryLoadOfficeImoMarkdownAssembly();
+            if (assembly == null) {
+                return false;
+            }
+
+            Type? optionsType = assembly.GetType("OfficeIMO.Markdown.Html.HtmlToMarkdownOptions", throwOnError: false);
+            Type? extensionsType = assembly.GetType("OfficeIMO.Markdown.Html.HtmlMarkdownConverterExtensions", throwOnError: false);
+            if (optionsType == null || extensionsType == null) {
+                return false;
+            }
+
+            object? options = optionsType.GetMethod("CreatePortableProfile", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, Array.Empty<object>());
+            if (options == null) {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(pageUrl) && Uri.TryCreate(pageUrl, UriKind.Absolute, out Uri? baseUri)) {
+                optionsType.GetProperty("BaseUri", BindingFlags.Public | BindingFlags.Instance)?.SetValue(options, baseUri);
+            }
+
+            MethodInfo? toMarkdownMethod = extensionsType
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(method => string.Equals(method.Name, "ToMarkdown", StringComparison.Ordinal) && method.GetParameters().Length == 2);
+            if (toMarkdownMethod == null) {
+                return false;
+            }
+
+            markdown = NormalizeMarkdown((string?)toMarkdownMethod.Invoke(null, new[] { html, options }) ?? string.Empty);
+            return !string.IsNullOrWhiteSpace(markdown);
+        } catch {
+            markdown = string.Empty;
+            return false;
+        }
+    }
+
+    private static Assembly? TryLoadOfficeImoMarkdownAssembly() {
+        Assembly? loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(assembly => string.Equals(assembly.GetName().Name, "OfficeIMO.Markdown.Html", StringComparison.OrdinalIgnoreCase));
+        if (loadedAssembly != null) {
+            return loadedAssembly;
+        }
+
+        try {
+            return Assembly.Load("OfficeIMO.Markdown.Html");
+        } catch {
+        }
+
+        foreach (string candidatePath in GetAssemblyProbePaths()) {
+            if (!File.Exists(candidatePath)) {
+                continue;
+            }
+
+            try {
+                return Assembly.LoadFrom(candidatePath);
+            } catch {
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> GetAssemblyProbePaths() {
+        string[] roots = {
+            AppContext.BaseDirectory,
+            Directory.GetCurrentDirectory()
+        };
+
+        foreach (string root in roots.Where(path => !string.IsNullOrWhiteSpace(path)).Distinct(StringComparer.OrdinalIgnoreCase)) {
+            yield return Path.Combine(root, "OfficeIMO.Markdown.Html.dll");
+            yield return Path.Combine(root, "OfficeIMO.Markdown.Html", "bin", "Debug", "net8.0", "OfficeIMO.Markdown.Html.dll");
+            yield return Path.Combine(root, "OfficeIMO.Markdown.Html", "bin", "Debug", "netstandard2.0", "OfficeIMO.Markdown.Html.dll");
+            yield return Path.Combine(root, "..", "OfficeIMO", "OfficeIMO.Markdown.Html", "bin", "Debug", "net8.0", "OfficeIMO.Markdown.Html.dll");
+            yield return Path.Combine(root, "..", "OfficeIMO", "OfficeIMO.Markdown.Html", "bin", "Debug", "netstandard2.0", "OfficeIMO.Markdown.Html.dll");
+        }
+    }
+
+    private static string ConvertWithFallback(string html, string? pageUrl) {
+        global::AngleSharp.Html.Parser.HtmlParser parser = new();
+        IDocument document = parser.ParseDocument(html);
+        Uri? baseUri = !string.IsNullOrWhiteSpace(pageUrl) && Uri.TryCreate(pageUrl, UriKind.Absolute, out Uri? resolvedBaseUri)
+            ? resolvedBaseUri
+            : null;
+        INode container = document.Body ?? (INode?)document.DocumentElement ?? document;
+        StringBuilder builder = new();
+
+        foreach (INode node in container.ChildNodes) {
+            AppendBlockNode(builder, node, baseUri, 0);
+        }
+
+        return NormalizeMarkdown(builder.ToString());
+    }
+
+    private static void AppendBlockNode(StringBuilder builder, INode node, Uri? baseUri, int listDepth) {
+        if (node is IText textNode) {
+            AppendParagraph(builder, NormalizeInlineText(textNode.Data));
+            return;
+        }
+
+        if (node is not IElement element) {
+            return;
+        }
+
+        string tagName = element.LocalName.ToLowerInvariant();
+        switch (tagName) {
+            case "h1":
+            case "h2":
+            case "h3":
+            case "h4":
+            case "h5":
+            case "h6":
+                int level = int.Parse(tagName.Substring(1), System.Globalization.CultureInfo.InvariantCulture);
+                AppendParagraph(builder, new string('#', level) + " " + RenderInlineChildren(element, baseUri));
+                return;
+            case "p":
+                AppendParagraph(builder, RenderInlineChildren(element, baseUri));
+                return;
+            case "ul":
+                AppendList(builder, element.Children.Where(child => string.Equals(child.LocalName, "li", StringComparison.OrdinalIgnoreCase)), baseUri, listDepth, ordered: false);
+                return;
+            case "ol":
+                AppendList(builder, element.Children.Where(child => string.Equals(child.LocalName, "li", StringComparison.OrdinalIgnoreCase)), baseUri, listDepth, ordered: true);
+                return;
+            case "pre":
+                AppendCodeBlock(builder, element);
+                return;
+            case "blockquote":
+                AppendBlockQuote(builder, element, baseUri);
+                return;
+            case "table":
+                AppendTable(builder, element, baseUri);
+                return;
+            case "hr":
+                AppendParagraph(builder, "---");
+                return;
+            case "script":
+            case "style":
+            case "noscript":
+            case "template":
+                return;
+            default:
+                foreach (INode child in element.ChildNodes) {
+                    AppendBlockNode(builder, child, baseUri, listDepth);
+                }
+                return;
+        }
+    }
+
+    private static void AppendList(StringBuilder builder, IEnumerable<IElement> items, Uri? baseUri, int listDepth, bool ordered) {
+        int index = 1;
+        foreach (IElement item in items) {
+            string prefix = ordered ? index.ToString(System.Globalization.CultureInfo.InvariantCulture) + ". " : "- ";
+            string indent = new string(' ', listDepth * 2);
+            string text = RenderListItem(item, baseUri, listDepth);
+            if (!string.IsNullOrWhiteSpace(text)) {
+                EnsureBlockSeparation(builder);
+                builder.Append(indent);
+                builder.Append(prefix);
+                builder.AppendLine(text);
+            }
+            index++;
+        }
+        EnsureTrailingBlankLine(builder);
+    }
+
+    private static string RenderListItem(IElement item, Uri? baseUri, int listDepth) {
+        StringBuilder builder = new();
+        foreach (INode child in item.ChildNodes) {
+            if (child is IElement childElement && (string.Equals(childElement.LocalName, "ul", StringComparison.OrdinalIgnoreCase) || string.Equals(childElement.LocalName, "ol", StringComparison.OrdinalIgnoreCase))) {
+                if (builder.Length > 0 && builder[^1] != '\n') {
+                    builder.AppendLine();
+                }
+                AppendList(builder, childElement.Children.Where(element => string.Equals(element.LocalName, "li", StringComparison.OrdinalIgnoreCase)), baseUri, listDepth + 1, ordered: string.Equals(childElement.LocalName, "ol", StringComparison.OrdinalIgnoreCase));
+            } else {
+                builder.Append(RenderInlineNode(child, baseUri));
+            }
+        }
+
+        return NormalizeInlineText(builder.ToString());
+    }
+
+    private static void AppendCodeBlock(StringBuilder builder, IElement element) {
+        string language = element.QuerySelector("code")?.GetAttribute("class")
+            ?.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(value => value.StartsWith("language-", StringComparison.OrdinalIgnoreCase)
+                ? value.Substring("language-".Length)
+                : value.StartsWith("lang-", StringComparison.OrdinalIgnoreCase)
+                    ? value.Substring("lang-".Length)
+                    : null)
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
+            ?? string.Empty;
+        string code = element.TextContent?.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(code)) {
+            return;
+        }
+
+        EnsureBlockSeparation(builder);
+        builder.Append("```");
+        builder.AppendLine(language);
+        builder.AppendLine(code);
+        builder.AppendLine("```");
+        builder.AppendLine();
+    }
+
+    private static void AppendBlockQuote(StringBuilder builder, IElement element, Uri? baseUri) {
+        string content = NormalizeInlineText(RenderInlineChildren(element, baseUri));
+        if (string.IsNullOrWhiteSpace(content)) {
+            return;
+        }
+
+        EnsureBlockSeparation(builder);
+        foreach (string line in content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
+            builder.Append("> ");
+            builder.AppendLine(line.Trim());
+        }
+        builder.AppendLine();
+    }
+
+    private static void AppendTable(StringBuilder builder, IElement table, Uri? baseUri) {
+        List<IElement> rows = table.QuerySelectorAll("tr").OfType<IElement>().ToList();
+        if (rows.Count == 0) {
+            return;
+        }
+
+        List<string[]> cells = rows
+            .Select(row => row.Children
+                .Where(cell => string.Equals(cell.LocalName, "th", StringComparison.OrdinalIgnoreCase) || string.Equals(cell.LocalName, "td", StringComparison.OrdinalIgnoreCase))
+                .Select(cell => NormalizeInlineText(RenderInlineChildren(cell, baseUri)))
+                .ToArray())
+            .Where(row => row.Length > 0)
+            .ToList();
+        if (cells.Count == 0) {
+            return;
+        }
+
+        int width = cells.Max(row => row.Length);
+        string[] header = cells[0].Concat(Enumerable.Repeat(string.Empty, Math.Max(0, width - cells[0].Length))).ToArray();
+
+        EnsureBlockSeparation(builder);
+        builder.AppendLine("| " + string.Join(" | ", header) + " |");
+        builder.AppendLine("| " + string.Join(" | ", Enumerable.Repeat("---", width)) + " |");
+        foreach (string[] row in cells.Skip(1)) {
+            string[] paddedRow = row.Concat(Enumerable.Repeat(string.Empty, Math.Max(0, width - row.Length))).ToArray();
+            builder.AppendLine("| " + string.Join(" | ", paddedRow) + " |");
+        }
+        builder.AppendLine();
+    }
+
+    private static void AppendParagraph(StringBuilder builder, string? value) {
+        string content = NormalizeInlineText(value);
+        if (string.IsNullOrWhiteSpace(content)) {
+            return;
+        }
+
+        EnsureBlockSeparation(builder);
+        builder.AppendLine(content);
+        builder.AppendLine();
+    }
+
+    private static string RenderInlineChildren(IElement element, Uri? baseUri) {
+        StringBuilder builder = new();
+        foreach (INode child in element.ChildNodes) {
+            builder.Append(RenderInlineNode(child, baseUri));
+        }
+
+        return NormalizeInlineText(builder.ToString());
+    }
+
+    private static string RenderInlineNode(INode node, Uri? baseUri) {
+        if (node is IText textNode) {
+            return NormalizeInlineText(textNode.Data);
+        }
+
+        if (node is not IElement element) {
+            return string.Empty;
+        }
+
+        return element.LocalName.ToLowerInvariant() switch {
+            "strong" or "b" => WrapInline("**", RenderInlineChildren(element, baseUri)),
+            "em" or "i" => WrapInline("*", RenderInlineChildren(element, baseUri)),
+            "code" when element.Closest("pre") == null => WrapInline("`", NormalizeInlineText(element.TextContent)),
+            "a" => RenderLink(element, baseUri),
+            "br" => "\n",
+            "img" => RenderImage(element, baseUri),
+            "ul" or "ol" => string.Empty,
+            _ => RenderInlineChildren(element, baseUri)
+        };
+    }
+
+    private static string RenderLink(IElement element, Uri? baseUri) {
+        string label = RenderInlineChildren(element, baseUri);
+        string? href = element.GetAttribute("href");
+        if (string.IsNullOrWhiteSpace(label)) {
+            label = string.IsNullOrWhiteSpace(href) ? string.Empty : href;
+        }
+        if (string.IsNullOrWhiteSpace(href)) {
+            return label;
+        }
+
+        return "[" + label + "](" + ResolveUrl(href, baseUri) + ")";
+    }
+
+    private static string RenderImage(IElement element, Uri? baseUri) {
+        string? src = element.GetAttribute("src");
+        if (string.IsNullOrWhiteSpace(src)) {
+            return string.Empty;
+        }
+
+        string alt = NormalizeInlineText(element.GetAttribute("alt"));
+        return "![" + alt + "](" + ResolveUrl(src, baseUri) + ")";
+    }
+
+    private static string ResolveUrl(string href, Uri? baseUri) {
+        if (baseUri != null && Uri.TryCreate(baseUri, href, out Uri? resolvedUri)) {
+            return resolvedUri.ToString();
+        }
+
+        return href;
+    }
+
+    private static string WrapInline(string delimiter, string? content) {
+        string value = NormalizeInlineText(content);
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : delimiter + value + delimiter;
+    }
+
+    private static void EnsureBlockSeparation(StringBuilder builder) {
+        if (builder.Length == 0) {
+            return;
+        }
+
+        string current = builder.ToString();
+        if (current.EndsWith("\n\n", StringComparison.Ordinal)) {
+            return;
+        }
+        if (current.EndsWith("\n", StringComparison.Ordinal)) {
+            builder.AppendLine();
+            return;
+        }
+
+        builder.AppendLine();
+        builder.AppendLine();
+    }
+
+    private static void EnsureTrailingBlankLine(StringBuilder builder) {
+        if (builder.Length == 0) {
+            return;
+        }
+
+        if (!builder.ToString().EndsWith("\n\n", StringComparison.Ordinal)) {
+            builder.AppendLine();
+        }
+    }
+
+    private static string NormalizeInlineText(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        return WhitespaceRegex.Replace(value.Replace("\r\n", "\n", StringComparison.Ordinal), " ").Trim();
+    }
+
+    private static string NormalizeMarkdown(string value) {
+        string normalized = value.Replace("\r\n", "\n", StringComparison.Ordinal).Trim();
+        return ConsecutiveBlankLinesRegex.Replace(normalized, "\n\n");
+    }
+}

--- a/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
+++ b/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
@@ -196,7 +196,7 @@ internal static class HtmlMarkdownConverterAdapter {
         StringBuilder builder = new();
         foreach (INode child in item.ChildNodes) {
             if (child is IElement childElement && (string.Equals(childElement.LocalName, "ul", StringComparison.OrdinalIgnoreCase) || string.Equals(childElement.LocalName, "ol", StringComparison.OrdinalIgnoreCase))) {
-                if (builder.Length > 0 && builder[^1] != '\n') {
+                if (builder.Length > 0 && builder[builder.Length - 1] != '\n') {
                     builder.AppendLine();
                 }
                 AppendList(builder, childElement.Children.Where(element => string.Equals(element.LocalName, "li", StringComparison.OrdinalIgnoreCase)), baseUri, listDepth + 1, ordered: string.Equals(childElement.LocalName, "ol", StringComparison.OrdinalIgnoreCase));
@@ -218,7 +218,7 @@ internal static class HtmlMarkdownConverterAdapter {
                     : null)
             .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))
             ?? string.Empty;
-        string code = element.TextContent?.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd() ?? string.Empty;
+        string code = (element.TextContent ?? string.Empty).Replace("\r\n", "\n").TrimEnd();
         if (string.IsNullOrWhiteSpace(code)) {
             return;
         }
@@ -385,11 +385,11 @@ internal static class HtmlMarkdownConverterAdapter {
             return string.Empty;
         }
 
-        return WhitespaceRegex.Replace(value.Replace("\r\n", "\n", StringComparison.Ordinal), " ").Trim();
+        return WhitespaceRegex.Replace(value.Replace("\r\n", "\n"), " ").Trim();
     }
 
     private static string NormalizeMarkdown(string value) {
-        string normalized = value.Replace("\r\n", "\n", StringComparison.Ordinal).Trim();
+        string normalized = value.Replace("\r\n", "\n").Trim();
         return ConsecutiveBlankLinesRegex.Replace(normalized, "\n\n");
     }
 }

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -34,10 +34,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\OfficeIMO\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
         <Using Include="System.Net.Http" />
     </ItemGroup>
 

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -34,6 +34,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\..\OfficeIMO\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Using Include="System.Net.Http" />
     </ItemGroup>
 

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlJsonSchemaField.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlJsonSchemaField.cs
@@ -1,0 +1,24 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Defines one extracted field in a structured crawl JSON schema.
+/// </summary>
+public sealed class HtmlCrawlJsonSchemaField {
+    /// <summary>Property path into the built-in structured object graph, for example <c>Metadata.Title</c>.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>CSS selector used for DOM-driven extraction.</summary>
+    public string? Selector { get; set; }
+
+    /// <summary>Extraction mode. Supported values are <c>Text</c>, <c>Html</c>, <c>Markdown</c>, <c>Attribute</c>, <c>Exists</c>, and <c>Count</c>.</summary>
+    public string? Mode { get; set; }
+
+    /// <summary>DOM source. Supported values are <c>Selected</c> and <c>Page</c>.</summary>
+    public string? Source { get; set; }
+
+    /// <summary>Attribute name used when <see cref="Mode"/> is <c>Attribute</c>.</summary>
+    public string? Attribute { get; set; }
+
+    /// <summary>When true, returns all matches as an array instead of only the first match.</summary>
+    public bool All { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlOptions.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlOptions.cs
@@ -84,6 +84,21 @@ public sealed class HtmlCrawlOptions {
     /// <summary>Stores plain text extracted from the page in the result.</summary>
     public bool IncludeText { get; set; } = true;
 
+    /// <summary>Stores Markdown converted from the selected page content in the result.</summary>
+    public bool IncludeMarkdown { get; set; }
+
+    /// <summary>Stores structured JSON-friendly page data extracted from the crawl.</summary>
+    public bool IncludeStructuredJson { get; set; }
+
+    /// <summary>Optional built-in structured JSON preset that adds flattened extracted fields for common page types.</summary>
+    public HtmlCrawlStructuredJsonPreset StructuredJsonPreset { get; set; }
+
+    /// <summary>Optional inline JSON schema describing caller-defined extracted fields for structured crawl output.</summary>
+    public string? StructuredJsonSchema { get; set; }
+
+    /// <summary>Optional JSON file path containing a structured crawl extraction schema.</summary>
+    public string? StructuredJsonSchemaPath { get; set; }
+
     /// <summary>Optional CSS selector used to extract a focused section from the page.</summary>
     public string? Selector { get; set; }
 
@@ -293,6 +308,11 @@ public sealed class HtmlCrawlOptions {
             Scenario = Scenario,
             IncludeHtml = IncludeHtml,
             IncludeText = IncludeText,
+            IncludeMarkdown = IncludeMarkdown,
+            IncludeStructuredJson = IncludeStructuredJson,
+            StructuredJsonPreset = StructuredJsonPreset,
+            StructuredJsonSchema = StructuredJsonSchema,
+            StructuredJsonSchemaPath = StructuredJsonSchemaPath,
             Selector = Selector,
             ContentMode = ContentMode,
             CompareContentModes = CompareContentModes,

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlPage.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlPage.cs
@@ -55,6 +55,18 @@ public sealed class HtmlCrawlPage {
     /// <summary>Optional persisted file path for the stored text.</summary>
     public string? TextPath { get; set; }
 
+    /// <summary>Stored Markdown content converted from the selected HTML.</summary>
+    public string Markdown { get; set; } = string.Empty;
+
+    /// <summary>Optional persisted file path for the stored Markdown.</summary>
+    public string? MarkdownPath { get; set; }
+
+    /// <summary>Structured JSON-friendly data extracted from the page.</summary>
+    public HtmlCrawlStructuredJson? StructuredJson { get; set; }
+
+    /// <summary>Optional persisted file path for the structured page JSON.</summary>
+    public string? StructuredJsonPath { get; set; }
+
     /// <summary>Optional persisted file path for the page-level manifest sidecar.</summary>
     public string? ManifestPath { get; set; }
 

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlResult.cs
@@ -71,6 +71,15 @@ public sealed class HtmlCrawlResult {
     /// <summary>Path to the generated downloaded-assets JSONL dataset file.</summary>
     public string? AssetsJsonlPath { get; set; }
 
+    /// <summary>Path to the generated structured-pages JSONL dataset file.</summary>
+    public string? StructuredJsonPagesJsonlPath { get; set; }
+
+    /// <summary>Path to the generated crawl-level OpenAPI-like JSON artifact.</summary>
+    public string? OpenApiLikePath { get; set; }
+
+    /// <summary>Path to the generated crawl-level strict OpenAPI JSON artifact.</summary>
+    public string? OpenApiPath { get; set; }
+
     /// <summary>Path to the generated deduplicated text chunks JSONL dataset file.</summary>
     public string? ChunksJsonlPath { get; set; }
 
@@ -112,6 +121,12 @@ public sealed class HtmlCrawlResult {
 
     /// <summary>Path to the generated browsable HTML index report.</summary>
     public string? IndexHtmlPath { get; set; }
+
+    /// <summary>Merged crawl-level OpenAPI-like snapshot derived from all structured endpoints.</summary>
+    public HtmlCrawlStructuredOpenApiLike OpenApiLike { get; set; } = new();
+
+    /// <summary>Merged crawl-level strict OpenAPI document derived from the offline contract when possible.</summary>
+    public IDictionary<string, object?> OpenApiDocument { get; set; } = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Total crawl duration.</summary>
     public TimeSpan Duration => Finished - Started;

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiAuthentication.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiAuthentication.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured authentication hints inferred for an API endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredApiAuthentication {
+    /// <summary>Whether the endpoint appears to require authentication.</summary>
+    public bool? Required { get; set; }
+
+    /// <summary>Normalized authentication schemes such as bearer, basic, oauth2, or api-key.</summary>
+    public IList<string> Schemes { get; set; } = new List<string>();
+
+    /// <summary>Relevant request headers such as Authorization or X-API-Key.</summary>
+    public IList<string> Headers { get; set; } = new List<string>();
+
+    /// <summary>Short nearby summary that mentioned the authentication requirement.</summary>
+    public string? Summary { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiCatalog.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiCatalog.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Lightweight page-level API catalog built from inferred endpoints.
+/// </summary>
+public sealed class HtmlCrawlStructuredApiCatalog {
+    /// <summary>Short title for the catalog, typically from page metadata.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Short description for the catalog, typically from page metadata.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Total number of operations inferred on the page.</summary>
+    public int OperationCount { get; set; }
+
+    /// <summary>Total number of unique paths inferred on the page.</summary>
+    public int PathCount { get; set; }
+
+    /// <summary>Total number of operations that require authentication.</summary>
+    public int AuthenticatedOperationCount { get; set; }
+
+    /// <summary>Total number of operations with rate-limit hints.</summary>
+    public int RateLimitedOperationCount { get; set; }
+
+    /// <summary>Total number of aggregated documented error families.</summary>
+    public int ErrorCatalogCount { get; set; }
+
+    /// <summary>Distinct resources inferred from endpoint paths.</summary>
+    public IList<string> Resources { get; set; } = new List<string>();
+
+    /// <summary>Distinct tags inferred from endpoint paths and context.</summary>
+    public IList<string> Tags { get; set; } = new List<string>();
+
+    /// <summary>Stable operation identifiers inferred for page endpoints.</summary>
+    public IList<string> OperationIds { get; set; } = new List<string>();
+
+    /// <summary>Distinct normalized paths inferred on the page.</summary>
+    public IList<string> Paths { get; set; } = new List<string>();
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiEndpoint.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiEndpoint.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured API endpoint inferred from docs headings and request examples.
+/// </summary>
+public sealed class HtmlCrawlStructuredApiEndpoint {
+    /// <summary>HTTP method in uppercase.</summary>
+    public string Method { get; set; } = string.Empty;
+
+    /// <summary>Normalized endpoint path or URL path.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Short title, typically from a nearby heading.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Nearby descriptive paragraph when available.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Stable operation identifier derived from the method and path.</summary>
+    public string? OperationId { get; set; }
+
+    /// <summary>Primary resource or group name derived from the endpoint path.</summary>
+    public string? Resource { get; set; }
+
+    /// <summary>Tags inferred for the endpoint to support grouping and filtering.</summary>
+    public IList<string> Tags { get; set; } = new List<string>();
+
+    /// <summary>Parameters documented for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredApiParameter> Parameters { get; set; } = new List<HtmlCrawlStructuredApiParameter>();
+
+    /// <summary>Path parameters for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredApiParameter> PathParameters { get; set; } = new List<HtmlCrawlStructuredApiParameter>();
+
+    /// <summary>Query parameters for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredApiParameter> QueryParameters { get; set; } = new List<HtmlCrawlStructuredApiParameter>();
+
+    /// <summary>Header parameters for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredApiParameter> HeaderParameters { get; set; } = new List<HtmlCrawlStructuredApiParameter>();
+
+    /// <summary>Request body fields for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredApiParameter> BodyParameters { get; set; } = new List<HtmlCrawlStructuredApiParameter>();
+
+    /// <summary>Flattened request body schema keyed by field name.</summary>
+    public IDictionary<string, string?> RequestBodySchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>First-class request body fields inferred from parameter tables.</summary>
+    public IList<HtmlCrawlStructuredField> RequestBodyFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Authentication requirements and hints inferred for the endpoint.</summary>
+    public HtmlCrawlStructuredApiAuthentication Authentication { get; set; } = new();
+
+    /// <summary>Rate-limit requirements and hints inferred for the endpoint.</summary>
+    public HtmlCrawlStructuredApiRateLimit RateLimit { get; set; } = new();
+
+    /// <summary>Request examples documented for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredRequestExample> RequestExamples { get; set; } = new List<HtmlCrawlStructuredRequestExample>();
+
+    /// <summary>Request headers documented for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> RequestHeaders { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Response examples documented for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredResponseExample> ResponseExamples { get; set; } = new List<HtmlCrawlStructuredResponseExample>();
+
+    /// <summary>Response headers documented for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> ResponseHeaders { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Error responses documented for the endpoint.</summary>
+    public IList<HtmlCrawlStructuredResponseExample> ErrorResponses { get; set; } = new List<HtmlCrawlStructuredResponseExample>();
+
+    /// <summary>Aggregated error catalog entries grouped by error response shape.</summary>
+    public IList<HtmlCrawlStructuredApiError> ErrorCatalog { get; set; } = new List<HtmlCrawlStructuredApiError>();
+
+    /// <summary>Flattened schema merged from successful JSON response examples.</summary>
+    public IDictionary<string, string?> SuccessResponseSchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>First-class fields merged from successful JSON response examples.</summary>
+    public IList<HtmlCrawlStructuredField> SuccessResponseFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Flattened schema merged from error JSON response examples.</summary>
+    public IDictionary<string, string?> ErrorResponseSchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>First-class fields merged from error JSON response examples.</summary>
+    public IList<HtmlCrawlStructuredField> ErrorResponseFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Languages or formats of related request examples.</summary>
+    public IList<string> ExampleLanguages { get; set; } = new List<string>();
+
+    /// <summary>Sources that contributed to this endpoint, such as heading or code-sample.</summary>
+    public IList<string> Sources { get; set; } = new List<string>();
+
+    /// <summary>Compact selector-like hint for the primary source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiError.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiError.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Aggregated error information inferred for an API endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredApiError {
+    /// <summary>Status code when one can be inferred from error examples or prose.</summary>
+    public int? StatusCode { get; set; }
+
+    /// <summary>Status text when one can be inferred from error examples or prose.</summary>
+    public string? StatusText { get; set; }
+
+    /// <summary>Short summary describing the failure mode.</summary>
+    public string? Summary { get; set; }
+
+    /// <summary>Headers documented for this error family.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> Headers { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Detected content type when one can be inferred from examples.</summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>Flattened schema merged from matching error examples.</summary>
+    public IDictionary<string, string?> Schema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>First-class fields merged from matching error examples.</summary>
+    public IList<HtmlCrawlStructuredField> Fields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Number of matching error examples that contributed to this catalog entry.</summary>
+    public int SampleCount { get; set; }
+
+    /// <summary>Compact selector-like hint for the primary source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiParameter.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiParameter.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured API parameter inferred from docs tables near an endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredApiParameter {
+    /// <summary>Parameter name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Parameter type when documented.</summary>
+    public string? Type { get; set; }
+
+    /// <summary>Parameter format when documented or inferred, for example uuid or date-time.</summary>
+    public string? Format { get; set; }
+
+    /// <summary>Parameter location such as path, query, body, or header.</summary>
+    public string? Location { get; set; }
+
+    /// <summary>Whether the parameter is required when that was documented.</summary>
+    public bool? Required { get; set; }
+
+    /// <summary>Whether the parameter may be null when that was documented or inferred.</summary>
+    public bool? Nullable { get; set; }
+
+    /// <summary>Parameter description when available.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Default value when documented.</summary>
+    public string? DefaultValue { get; set; }
+
+    /// <summary>Example value when documented.</summary>
+    public string? ExampleValue { get; set; }
+
+    /// <summary>Regex or other pattern hint when documented.</summary>
+    public string? Pattern { get; set; }
+
+    /// <summary>Allowed enum values when documented or inferred.</summary>
+    public IList<string> EnumValues { get; set; } = new List<string>();
+
+    /// <summary>Compact selector-like hint for the source parameter table.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiRateLimit.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredApiRateLimit.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured rate-limit hints inferred for an API endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredApiRateLimit {
+    /// <summary>Whether rate limiting was explicitly mentioned for the endpoint.</summary>
+    public bool Mentioned { get; set; }
+
+    /// <summary>Status code associated with throttling behavior when one was documented.</summary>
+    public int? StatusCode { get; set; }
+
+    /// <summary>Relevant response headers such as Retry-After or X-RateLimit-Remaining.</summary>
+    public IList<string> Headers { get; set; } = new List<string>();
+
+    /// <summary>Short textual quota limit such as 60 requests per minute.</summary>
+    public string? Limit { get; set; }
+
+    /// <summary>Normalized quota window such as second, minute, hour, or day.</summary>
+    public string? Window { get; set; }
+
+    /// <summary>Short nearby summary that mentioned rate limiting.</summary>
+    public string? Summary { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredBreadcrumbItem.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredBreadcrumbItem.cs
@@ -1,0 +1,15 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// One item within a structured breadcrumb trail.
+/// </summary>
+public sealed class HtmlCrawlStructuredBreadcrumbItem {
+    /// <summary>Visible breadcrumb label.</summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>Resolved breadcrumb URL when available.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>Whether this item represents the current page.</summary>
+    public bool IsCurrent { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredBreadcrumbTrail.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredBreadcrumbTrail.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured breadcrumb trail kept separate from the main document content.
+/// </summary>
+public sealed class HtmlCrawlStructuredBreadcrumbTrail {
+    /// <summary>Ordered breadcrumb items.</summary>
+    public IList<HtmlCrawlStructuredBreadcrumbItem> Items { get; set; } = new List<HtmlCrawlStructuredBreadcrumbItem>();
+
+    /// <summary>Flattened breadcrumb labels for quick downstream access.</summary>
+    public IList<string> Labels { get; set; } = new List<string>();
+
+    /// <summary>Flattened breadcrumb URLs for quick downstream access.</summary>
+    public IList<string> Urls { get; set; } = new List<string>();
+
+    /// <summary>The current page label when the trail marks it explicitly.</summary>
+    public string? CurrentLabel { get; set; }
+
+    /// <summary>Compact selector-like hint for the breadcrumb container.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredCallout.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredCallout.cs
@@ -1,0 +1,21 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured callout, alert, note, or advisory block extracted from selected content.
+/// </summary>
+public sealed class HtmlCrawlStructuredCallout {
+    /// <summary>Normalized callout kind such as note, warning, tip, or danger.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Short title when a heading-like label is present.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Normalized plain-text content of the callout.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Markdown representation of the callout content.</summary>
+    public string Markdown { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredCodeBlock.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredCodeBlock.cs
@@ -1,0 +1,21 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured representation of a code block captured from the selected content.
+/// </summary>
+public sealed class HtmlCrawlStructuredCodeBlock {
+    /// <summary>Detected programming or markup language when available.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Code text with line breaks preserved.</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Number of lines in the code block.</summary>
+    public int LineCount { get; set; }
+
+    /// <summary>Number of characters in the code block.</summary>
+    public int CharacterCount { get; set; }
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredCodeSample.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredCodeSample.cs
@@ -1,0 +1,30 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured code sample extracted from selected content.
+/// </summary>
+public sealed class HtmlCrawlStructuredCodeSample {
+    /// <summary>Short title derived from a nearby heading when available.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Nearby heading text associated with the sample when available.</summary>
+    public string? Heading { get; set; }
+
+    /// <summary>Detected programming or markup language when available.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Normalized sample kind such as code, command, curl, http, or json.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Sample code text with line breaks preserved.</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Detected HTTP method when the sample represents an API request.</summary>
+    public string? Method { get; set; }
+
+    /// <summary>Detected API path when the sample represents an API request.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredContent.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredContent.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Lightweight content-analysis metadata for a structured crawl document.
+/// </summary>
+public sealed class HtmlCrawlStructuredContent {
+    /// <summary>Number of words in the extracted document text.</summary>
+    public int WordCount { get; set; }
+
+    /// <summary>Number of characters in the extracted document text.</summary>
+    public int CharacterCount { get; set; }
+
+    /// <summary>Number of generated chunks for the extracted document text.</summary>
+    public int ChunkCount { get; set; }
+
+    /// <summary>Short summary of the extracted document text.</summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Headings extracted from the selected content.</summary>
+    public IList<string> Headings { get; set; } = new List<string>();
+
+    /// <summary>Keywords extracted from the document text.</summary>
+    public IList<string> Keywords { get; set; } = new List<string>();
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredDocument.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredDocument.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Self-contained document-style page data intended for downstream JSON consumers.
+/// </summary>
+public sealed class HtmlCrawlStructuredDocument {
+    /// <summary>Resolved page URL.</summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>Original URL requested before any canonical rewrite.</summary>
+    public string? RequestedUrl { get; set; }
+
+    /// <summary>URL that discovered this page.</summary>
+    public string? ParentUrl { get; set; }
+
+    /// <summary>Canonical URL discovered in the page markup, when available.</summary>
+    public string? CanonicalUrl { get; set; }
+
+    /// <summary>Distance from the starting URL.</summary>
+    public int Depth { get; set; }
+
+    /// <summary>Page title when available.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Response content type when available.</summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>Indicates whether the page was rendered in a browser.</summary>
+    public bool Rendered { get; set; }
+
+    /// <summary>Describes whether the page stayed static, was rendered directly, or was auto-rendered after a static pass.</summary>
+    public HtmlCrawlRenderMode RenderMode { get; set; }
+
+    /// <summary>Categorizes why the selected render mode was used for this page.</summary>
+    public HtmlCrawlRenderReasonCode RenderReasonCode { get; set; }
+
+    /// <summary>Records which content-selection mode produced the stored content for this page.</summary>
+    public HtmlCrawlContentMode ContentModeUsed { get; set; }
+
+    /// <summary>Categorizes how the crawler chose the content region used for extraction.</summary>
+    public HtmlCrawlContentSelectionReasonCode ContentSelectionReasonCode { get; set; }
+
+    /// <summary>Explains how the crawler chose the content region used for extraction.</summary>
+    public string? ContentSelectionReason { get; set; }
+
+    /// <summary>Compact selector-like hint for the selected content element when available.</summary>
+    public string? ContentElementSelectorHint { get; set; }
+
+    /// <summary>Number of words in the extracted document text.</summary>
+    public int WordCount { get; set; }
+
+    /// <summary>Number of characters in the extracted document text.</summary>
+    public int CharacterCount { get; set; }
+
+    /// <summary>Number of generated chunks for the extracted document text.</summary>
+    public int ChunkCount { get; set; }
+
+    /// <summary>Number of discovered outbound links for the page.</summary>
+    public int LinkCount { get; set; }
+
+    /// <summary>Number of discovered asset references for the page.</summary>
+    public int AssetCount { get; set; }
+
+    /// <summary>Number of applied rendered interactions for the page.</summary>
+    public int InteractionCount { get; set; }
+
+    /// <summary>Short summary of the extracted document text.</summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Headings extracted from the selected content.</summary>
+    public IList<string> Headings { get; set; } = new List<string>();
+
+    /// <summary>Keywords extracted from the document text.</summary>
+    public IList<string> Keywords { get; set; } = new List<string>();
+
+    /// <summary>Normalized outbound links discovered on the page.</summary>
+    public IList<string> Links { get; set; } = new List<string>();
+
+    /// <summary>Rendered interactions that were successfully applied before extraction.</summary>
+    public IList<string> AppliedInteractions { get; set; } = new List<string>();
+
+    /// <summary>Extracted plain text for the selected content.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Markdown representation of the selected content.</summary>
+    public string Markdown { get; set; } = string.Empty;
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredFaqItem.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredFaqItem.cs
@@ -1,0 +1,21 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured FAQ-style question and answer extracted from the selected content.
+/// </summary>
+public sealed class HtmlCrawlStructuredFaqItem {
+    /// <summary>Question or prompt text.</summary>
+    public string Question { get; set; } = string.Empty;
+
+    /// <summary>Answer text with whitespace normalized for ingestion.</summary>
+    public string Answer { get; set; } = string.Empty;
+
+    /// <summary>Markdown representation of the answer when available.</summary>
+    public string AnswerMarkdown { get; set; } = string.Empty;
+
+    /// <summary>Extraction source category, such as microdata or details.</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredField.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredField.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured request or response field inferred from API documentation content.
+/// </summary>
+public sealed class HtmlCrawlStructuredField {
+    /// <summary>Field name, typically the final segment of <see cref="Path"/>.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Dot-separated field path relative to the request or response body.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Parent field path when this field is nested inside an object or array.</summary>
+    public string? ParentPath { get; set; }
+
+    /// <summary>Child field paths nested under this field.</summary>
+    public IList<string> ChildPaths { get; set; } = new List<string>();
+
+    /// <summary>Logical node kind such as field, object, array, or array-item.</summary>
+    public string Kind { get; set; } = "field";
+
+    /// <summary>Nesting depth relative to the request or response body root.</summary>
+    public int Depth { get; set; }
+
+    /// <summary>Field type such as string, integer, object, or array.</summary>
+    public string? Type { get; set; }
+
+    /// <summary>Field format such as uuid, date-time, email, or uri.</summary>
+    public string? Format { get; set; }
+
+    /// <summary>Whether the field is required when that can be determined.</summary>
+    public bool? Required { get; set; }
+
+    /// <summary>Whether the field may be null when that can be determined.</summary>
+    public bool? Nullable { get; set; }
+
+    /// <summary>Example value captured for the field when available.</summary>
+    public string? ExampleValue { get; set; }
+
+    /// <summary>Allowed enum values when documented or inferred.</summary>
+    public IList<string> EnumValues { get; set; } = new List<string>();
+
+    /// <summary>Origin of the field, for example ParameterTable or JsonResponse.</summary>
+    public string? Source { get; set; }
+
+    /// <summary>Detailed provenance entries explaining which rows or samples introduced the field.</summary>
+    public IList<HtmlCrawlStructuredFieldProvenanceEntry> Provenance { get; set; } = new List<HtmlCrawlStructuredFieldProvenanceEntry>();
+
+    /// <summary>Evidence count used to estimate how strongly this field is supported by the crawl.</summary>
+    public int EvidenceCount { get; set; }
+
+    /// <summary>Confidence score from 0-100 estimating how reliable this field is for downstream automation.</summary>
+    public int ConfidenceScore { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredFieldProvenanceEntry.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredFieldProvenanceEntry.cs
@@ -1,0 +1,18 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Provenance metadata for a structured request or response field.
+/// </summary>
+public sealed class HtmlCrawlStructuredFieldProvenanceEntry {
+    /// <summary>URL of the page that contributed this field evidence.</summary>
+    public string PageUrl { get; set; } = string.Empty;
+
+    /// <summary>Kind of source that introduced this field, such as ParameterTable or JsonResponse.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like hint for the contributing source element.</summary>
+    public string? SelectorHint { get; set; }
+
+    /// <summary>Short label describing the contributing row or sample.</summary>
+    public string? Label { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredHttpHeader.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredHttpHeader.cs
@@ -1,0 +1,12 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured HTTP header inferred from request or response examples.
+/// </summary>
+public sealed class HtmlCrawlStructuredHttpHeader {
+    /// <summary>Header name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Header value when one was documented.</summary>
+    public string? Value { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredJson.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredJson.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured JSON-friendly page data extracted from the crawl.
+/// </summary>
+public sealed class HtmlCrawlStructuredJson {
+    /// <summary>Preset that was resolved for this page when structured extracted fields were built.</summary>
+    public HtmlCrawlStructuredJsonPreset ResolvedPreset { get; set; }
+
+    /// <summary>Self-contained document-style representation of the extracted page content.</summary>
+    public HtmlCrawlStructuredDocument Document { get; set; } = new();
+
+    /// <summary>Lightweight content-analysis metadata for downstream filtering and search.</summary>
+    public HtmlCrawlStructuredContent Content { get; set; } = new();
+
+    /// <summary>Promoted page-level metadata for easier downstream ingestion.</summary>
+    public HtmlCrawlStructuredMetadata Metadata { get; set; } = new();
+
+    /// <summary>Detected page-level layout and chrome regions kept separate from main content.</summary>
+    public HtmlCrawlStructuredLayout Layout { get; set; } = new();
+
+    /// <summary>Caller-defined extracted fields built from a structured schema, when one was supplied.</summary>
+    public IDictionary<string, object?> Extracted { get; set; } = new Dictionary<string, object?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Meta tags extracted from the full HTML document.</summary>
+    public IList<HtmlMetaTag> MetaTags { get; set; } = new List<HtmlMetaTag>();
+
+    /// <summary>Open Graph properties extracted from the full HTML document.</summary>
+    public HtmlOpenGraph OpenGraph { get; set; } = new();
+
+    /// <summary>Microdata items extracted from the full HTML document.</summary>
+    public IList<HtmlMicrodataItem> MicrodataItems { get; set; } = new List<HtmlMicrodataItem>();
+
+    /// <summary>Forms extracted from the full HTML document.</summary>
+    public IList<HtmlFormResult> Forms { get; set; } = new List<HtmlFormResult>();
+
+    /// <summary>Lists extracted from the selected page content.</summary>
+    public IList<HtmlListResult> Lists { get; set; } = new List<HtmlListResult>();
+
+    /// <summary>Tables extracted from the selected page content.</summary>
+    public IList<HtmlTableResult> Tables { get; set; } = new List<HtmlTableResult>();
+
+    /// <summary>Code blocks extracted from the selected page content.</summary>
+    public IList<HtmlCrawlStructuredCodeBlock> CodeBlocks { get; set; } = new List<HtmlCrawlStructuredCodeBlock>();
+
+    /// <summary>Semantic code samples extracted from the selected content.</summary>
+    public IList<HtmlCrawlStructuredCodeSample> CodeSamples { get; set; } = new List<HtmlCrawlStructuredCodeSample>();
+
+    /// <summary>Breadcrumb trails extracted from page chrome.</summary>
+    public IList<HtmlCrawlStructuredBreadcrumbTrail> Breadcrumbs { get; set; } = new List<HtmlCrawlStructuredBreadcrumbTrail>();
+
+    /// <summary>FAQ-style question and answer pairs extracted from the selected content.</summary>
+    public IList<HtmlCrawlStructuredFaqItem> FaqItems { get; set; } = new List<HtmlCrawlStructuredFaqItem>();
+
+    /// <summary>Specification-style tables extracted from selected content.</summary>
+    public IList<HtmlCrawlStructuredSpecTable> SpecTables { get; set; } = new List<HtmlCrawlStructuredSpecTable>();
+
+    /// <summary>Callout or alert blocks extracted from selected content.</summary>
+    public IList<HtmlCrawlStructuredCallout> Callouts { get; set; } = new List<HtmlCrawlStructuredCallout>();
+
+    /// <summary>Prominent action links or buttons extracted from selected content.</summary>
+    public IList<HtmlCrawlStructuredPrimaryAction> PrimaryActions { get; set; } = new List<HtmlCrawlStructuredPrimaryAction>();
+
+    /// <summary>API endpoints inferred from docs-style headings and request examples.</summary>
+    public IList<HtmlCrawlStructuredApiEndpoint> ApiEndpoints { get; set; } = new List<HtmlCrawlStructuredApiEndpoint>();
+
+    /// <summary>Lightweight API catalog derived from inferred endpoints on the page.</summary>
+    public HtmlCrawlStructuredApiCatalog ApiCatalog { get; set; } = new();
+
+    /// <summary>Compact OpenAPI-like snapshot derived from inferred page endpoints.</summary>
+    public HtmlCrawlStructuredOpenApiLike OpenApiLike { get; set; } = new();
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredLayout.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredLayout.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Detected page-level layout regions kept separate from the extracted main document.
+/// </summary>
+public sealed class HtmlCrawlStructuredLayout {
+    /// <summary>Detected layout regions.</summary>
+    public IList<HtmlCrawlStructuredRegion> Regions { get; set; } = new List<HtmlCrawlStructuredRegion>();
+
+    /// <summary>Detected header region count.</summary>
+    public int HeaderCount { get; set; }
+
+    /// <summary>Detected navigation or menu region count.</summary>
+    public int NavigationCount { get; set; }
+
+    /// <summary>Detected main region count.</summary>
+    public int MainCount { get; set; }
+
+    /// <summary>Detected article region count.</summary>
+    public int ArticleCount { get; set; }
+
+    /// <summary>Detected aside/sidebar region count.</summary>
+    public int AsideCount { get; set; }
+
+    /// <summary>Detected footer region count.</summary>
+    public int FooterCount { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredMetadata.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredMetadata.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Common page-level metadata promoted for easier downstream ingestion.
+/// </summary>
+public sealed class HtmlCrawlStructuredMetadata {
+    /// <summary>Page title derived from the document title or equivalent metadata.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Short page description from metadata when available.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Canonical URL discovered in markup, when available.</summary>
+    public string? CanonicalUrl { get; set; }
+
+    /// <summary>Document language when declared on the root HTML element.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Open Graph or application site name when available.</summary>
+    public string? SiteName { get; set; }
+
+    /// <summary>Open Graph page type when available.</summary>
+    public string? Type { get; set; }
+
+    /// <summary>Author metadata when available.</summary>
+    public string? Author { get; set; }
+
+    /// <summary>Published timestamp metadata when available.</summary>
+    public string? PublishedTime { get; set; }
+
+    /// <summary>Modified timestamp metadata when available.</summary>
+    public string? ModifiedTime { get; set; }
+
+    /// <summary>Robots metadata when available.</summary>
+    public string? Robots { get; set; }
+
+    /// <summary>Generator metadata when available.</summary>
+    public string? Generator { get; set; }
+
+    /// <summary>Primary image URL when available.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Keywords metadata split into normalized items.</summary>
+    public IList<string> Keywords { get; set; } = new List<string>();
+
+    /// <summary>Total number of collected meta tags.</summary>
+    public int MetaTagCount { get; set; }
+
+    /// <summary>Total number of collected Open Graph properties.</summary>
+    public int OpenGraphPropertyCount { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiComponents.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiComponents.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Reusable component definitions deduped across OpenAPI-like operations.
+/// </summary>
+public sealed class HtmlCrawlStructuredOpenApiComponents {
+    /// <summary>Reusable flattened schema maps keyed by component name.</summary>
+    public IDictionary<string, IDictionary<string, string?>> Schemas { get; set; } = new Dictionary<string, IDictionary<string, string?>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable first-class field trees keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredField>> FieldSets { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredField>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable authentication profiles keyed by component name.</summary>
+    public IDictionary<string, HtmlCrawlStructuredApiAuthentication> AuthProfiles { get; set; } = new Dictionary<string, HtmlCrawlStructuredApiAuthentication>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable rate-limit profiles keyed by component name.</summary>
+    public IDictionary<string, HtmlCrawlStructuredApiRateLimit> RateLimitProfiles { get; set; } = new Dictionary<string, HtmlCrawlStructuredApiRateLimit>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable parameter sets keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredApiParameter>> ParameterSets { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredApiParameter>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable request-header sets keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredHttpHeader>> RequestHeaderSets { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredHttpHeader>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable response-header sets keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredHttpHeader>> ResponseHeaderSets { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredHttpHeader>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable request-example sets keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredRequestExample>> RequestExampleSets { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredRequestExample>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable response-example sets keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredResponseExample>> ResponseExampleSets { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredResponseExample>>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable error-catalog sets keyed by component name.</summary>
+    public IDictionary<string, IList<HtmlCrawlStructuredApiError>> ErrorCatalogs { get; set; } = new Dictionary<string, IList<HtmlCrawlStructuredApiError>>(System.StringComparer.OrdinalIgnoreCase);
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiLike.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiLike.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Compact OpenAPI-like snapshot derived from inferred page endpoints.
+/// </summary>
+public sealed class HtmlCrawlStructuredOpenApiLike {
+    /// <summary>Short title for the API snapshot, typically from page metadata.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Short description for the API snapshot, typically from page metadata.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Distinct server origins inferred from the crawled page.</summary>
+    public IList<string> Servers { get; set; } = new List<string>();
+
+    /// <summary>Distinct tags inferred across operations.</summary>
+    public IList<string> Tags { get; set; } = new List<string>();
+
+    /// <summary>Distinct resources inferred across operations.</summary>
+    public IList<string> Resources { get; set; } = new List<string>();
+
+    /// <summary>Reusable component definitions deduped across operations.</summary>
+    public HtmlCrawlStructuredOpenApiComponents Components { get; set; } = new();
+
+    /// <summary>Minimum score required before an inferred operation is promoted into the strict OpenAPI export.</summary>
+    public int StrictOpenApiPromotionThreshold { get; set; }
+
+    /// <summary>Number of operations promoted into the strict OpenAPI export.</summary>
+    public int StrictOpenApiEligibleOperationCount { get; set; }
+
+    /// <summary>Number of operations kept only in the richer OpenAPI-like export because they were too weak for strict promotion.</summary>
+    public int StrictOpenApiSkippedOperationCount { get; set; }
+
+    /// <summary>Average promotion score across inferred operations.</summary>
+    public double StrictOpenApiAverageScore { get; set; }
+
+    /// <summary>Path items grouped by normalized path.</summary>
+    public IDictionary<string, HtmlCrawlStructuredOpenApiPathItem> Paths { get; set; } = new Dictionary<string, HtmlCrawlStructuredOpenApiPathItem>(System.StringComparer.OrdinalIgnoreCase);
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiOperation.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiOperation.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Compact OpenAPI-like operation derived from an inferred endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredOpenApiOperation {
+    /// <summary>Stable operation identifier derived from method and path.</summary>
+    public string? OperationId { get; set; }
+
+    /// <summary>Lowercase HTTP method.</summary>
+    public string Method { get; set; } = string.Empty;
+
+    /// <summary>Normalized path for the operation.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Short operation summary.</summary>
+    public string? Summary { get; set; }
+
+    /// <summary>Longer operation description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Primary resource inferred from the path.</summary>
+    public string? Resource { get; set; }
+
+    /// <summary>Tags inferred for grouping and filtering.</summary>
+    public IList<string> Tags { get; set; } = new List<string>();
+
+    /// <summary>Authentication hints for the operation.</summary>
+    public HtmlCrawlStructuredApiAuthentication Authentication { get; set; } = new();
+
+    /// <summary>Reusable authentication component reference when one was assigned.</summary>
+    public string? AuthenticationRef { get; set; }
+
+    /// <summary>Rate-limit hints for the operation.</summary>
+    public HtmlCrawlStructuredApiRateLimit RateLimit { get; set; } = new();
+
+    /// <summary>Reusable rate-limit component reference when one was assigned.</summary>
+    public string? RateLimitRef { get; set; }
+
+    /// <summary>All parameters documented for the operation.</summary>
+    public IList<HtmlCrawlStructuredApiParameter> Parameters { get; set; } = new List<HtmlCrawlStructuredApiParameter>();
+
+    /// <summary>Reusable parameter-set component reference when one was assigned.</summary>
+    public string? ParametersRef { get; set; }
+
+    /// <summary>Request headers documented for the operation.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> RequestHeaders { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Reusable request-header-set component reference when one was assigned.</summary>
+    public string? RequestHeadersRef { get; set; }
+
+    /// <summary>Response headers documented for the operation.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> ResponseHeaders { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Reusable response-header-set component reference when one was assigned.</summary>
+    public string? ResponseHeadersRef { get; set; }
+
+    /// <summary>Request examples documented for the operation.</summary>
+    public IList<HtmlCrawlStructuredRequestExample> RequestExamples { get; set; } = new List<HtmlCrawlStructuredRequestExample>();
+
+    /// <summary>Reusable request-example-set component reference when one was assigned.</summary>
+    public string? RequestExamplesRef { get; set; }
+
+    /// <summary>Response examples documented for the operation.</summary>
+    public IList<HtmlCrawlStructuredResponseExample> ResponseExamples { get; set; } = new List<HtmlCrawlStructuredResponseExample>();
+
+    /// <summary>Reusable response-example-set component reference when one was assigned.</summary>
+    public string? ResponseExamplesRef { get; set; }
+
+    /// <summary>Aggregated documented error families for the operation.</summary>
+    public IList<HtmlCrawlStructuredApiError> ErrorCatalog { get; set; } = new List<HtmlCrawlStructuredApiError>();
+
+    /// <summary>Reusable error-catalog component reference when one was assigned.</summary>
+    public string? ErrorCatalogRef { get; set; }
+
+    /// <summary>Flattened request body schema keyed by field name.</summary>
+    public IDictionary<string, string?> RequestBodySchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable request-body schema component reference when one was assigned.</summary>
+    public string? RequestBodySchemaRef { get; set; }
+
+    /// <summary>First-class request body fields.</summary>
+    public IList<HtmlCrawlStructuredField> RequestBodyFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Reusable request-body field-tree component reference when one was assigned.</summary>
+    public string? RequestBodyFieldsRef { get; set; }
+
+    /// <summary>Flattened schema merged from successful JSON response examples.</summary>
+    public IDictionary<string, string?> SuccessResponseSchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable successful-response schema component reference when one was assigned.</summary>
+    public string? SuccessResponseSchemaRef { get; set; }
+
+    /// <summary>First-class fields merged from successful JSON response examples.</summary>
+    public IList<HtmlCrawlStructuredField> SuccessResponseFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Reusable successful-response field-tree component reference when one was assigned.</summary>
+    public string? SuccessResponseFieldsRef { get; set; }
+
+    /// <summary>Flattened schema merged from error JSON response examples.</summary>
+    public IDictionary<string, string?> ErrorResponseSchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Reusable error-response schema component reference when one was assigned.</summary>
+    public string? ErrorResponseSchemaRef { get; set; }
+
+    /// <summary>First-class fields merged from error JSON response examples.</summary>
+    public IList<HtmlCrawlStructuredField> ErrorResponseFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Reusable error-response field-tree component reference when one was assigned.</summary>
+    public string? ErrorResponseFieldsRef { get; set; }
+
+    /// <summary>Provenance metadata describing which page artifacts contributed to this operation.</summary>
+    public HtmlCrawlStructuredOpenApiProvenance Provenance { get; set; } = new();
+
+    /// <summary>Promotion score used when deciding whether this operation is strong enough for strict OpenAPI export.</summary>
+    public int StrictOpenApiScore { get; set; }
+
+    /// <summary>Indicates whether this operation is considered strong enough for strict OpenAPI export.</summary>
+    public bool StrictOpenApiEligible { get; set; }
+
+    /// <summary>Reasons this operation was considered incomplete for strict OpenAPI export.</summary>
+    public IList<string> StrictOpenApiWarnings { get; set; } = new List<string>();
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiPathItem.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiPathItem.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Compact OpenAPI-like path item derived from inferred operations.
+/// </summary>
+public sealed class HtmlCrawlStructuredOpenApiPathItem {
+    /// <summary>Normalized path represented by this item.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Resources associated with this path.</summary>
+    public IList<string> Resources { get; set; } = new List<string>();
+
+    /// <summary>Operations keyed by lowercase HTTP method.</summary>
+    public IDictionary<string, HtmlCrawlStructuredOpenApiOperation> Operations { get; set; } = new Dictionary<string, HtmlCrawlStructuredOpenApiOperation>(System.StringComparer.OrdinalIgnoreCase);
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiProvenance.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiProvenance.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Provenance metadata explaining where an inferred OpenAPI-like operation came from.
+/// </summary>
+public sealed class HtmlCrawlStructuredOpenApiProvenance {
+    /// <summary>Distinct source pages that contributed to the operation.</summary>
+    public IList<string> PageUrls { get; set; } = new List<string>();
+
+    /// <summary>Distinct source kinds that contributed to the operation, such as Heading or CodeSample.</summary>
+    public IList<string> SourceKinds { get; set; } = new List<string>();
+
+    /// <summary>Detailed provenance entries for debugging and trust inspection.</summary>
+    public IList<HtmlCrawlStructuredOpenApiProvenanceEntry> Entries { get; set; } = new List<HtmlCrawlStructuredOpenApiProvenanceEntry>();
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiProvenanceEntry.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredOpenApiProvenanceEntry.cs
@@ -1,0 +1,18 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Single provenance entry describing one contributing source for an inferred operation.
+/// </summary>
+public sealed class HtmlCrawlStructuredOpenApiProvenanceEntry {
+    /// <summary>URL of the page that contributed this evidence.</summary>
+    public string PageUrl { get; set; } = string.Empty;
+
+    /// <summary>Kind of evidence, such as Heading, CodeSample, RequestExample, or ResponseExample.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like hint for the contributing source element.</summary>
+    public string? SelectorHint { get; set; }
+
+    /// <summary>Short label describing the specific contributing artifact.</summary>
+    public string? Label { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredPrimaryAction.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredPrimaryAction.cs
@@ -1,0 +1,21 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Prominent action link or button extracted from selected content.
+/// </summary>
+public sealed class HtmlCrawlStructuredPrimaryAction {
+    /// <summary>Visible label presented to the user.</summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>Resolved URL when the action is link-based.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>Action element type such as link, button, or submit.</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Normalized action intent such as install, download, buy, or start.</summary>
+    public string Intent { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredRegion.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredRegion.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Lightweight summary of a detected page region such as navigation or footer.
+/// </summary>
+public sealed class HtmlCrawlStructuredRegion {
+    /// <summary>Semantic region kind.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>HTML tag name of the detected region.</summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>Element ID when available.</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Element class names when available.</summary>
+    public IList<string> Classes { get; set; } = new List<string>();
+
+    /// <summary>Compact selector-like hint for the detected element.</summary>
+    public string? SelectorHint { get; set; }
+
+    /// <summary>Element role when available.</summary>
+    public string? Role { get; set; }
+
+    /// <summary>ARIA label when available.</summary>
+    public string? AriaLabel { get; set; }
+
+    /// <summary>Normalized short summary of the region text.</summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Word count of the detected region.</summary>
+    public int WordCount { get; set; }
+
+    /// <summary>Anchor count of the detected region.</summary>
+    public int LinkCount { get; set; }
+
+    /// <summary>Heading count of the detected region.</summary>
+    public int HeadingCount { get; set; }
+
+    /// <summary>Distinct link labels captured from the region.</summary>
+    public IList<string> LinkLabels { get; set; } = new List<string>();
+
+    /// <summary>Whether the region looks like boilerplate or chrome.</summary>
+    public bool IsLikelyBoilerplate { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredRequestExample.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredRequestExample.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured request example associated with an inferred API endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredRequestExample {
+    /// <summary>Short title or nearby heading for the request example.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Nearby description or prose documenting the request when available.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Detected content language or format.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Normalized request example kind such as http, curl, json, or command.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>HTTP method when one can be inferred from the example.</summary>
+    public string? Method { get; set; }
+
+    /// <summary>Normalized request path when one can be inferred from the example.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>Headers documented alongside the request.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> Headers { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Detected content type when one can be inferred from headers or body.</summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>Request body or example text.</summary>
+    public string Body { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredResponseExample.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredResponseExample.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured response example associated with an inferred API endpoint.
+/// </summary>
+public sealed class HtmlCrawlStructuredResponseExample {
+    /// <summary>Short title or nearby heading for the response example.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Nearby description or prose documenting the response when available.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Detected content language or format.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Normalized response example kind such as json or http.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Status code when one can be inferred from the heading or example.</summary>
+    public int? StatusCode { get; set; }
+
+    /// <summary>Status text when one can be inferred from the heading or example.</summary>
+    public string? StatusText { get; set; }
+
+    /// <summary>Headers documented alongside the response.</summary>
+    public IList<HtmlCrawlStructuredHttpHeader> Headers { get; set; } = new List<HtmlCrawlStructuredHttpHeader>();
+
+    /// <summary>Detected content type when one can be inferred from headers or language.</summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>Whether this response represents an error status.</summary>
+    public bool IsError { get; set; }
+
+    /// <summary>Response body or example text.</summary>
+    public string Body { get; set; } = string.Empty;
+
+    /// <summary>Flattened schema inferred from a JSON response body.</summary>
+    public IDictionary<string, string?> BodySchema { get; set; } = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Top-level keys inferred from a JSON object response body.</summary>
+    public IList<string> TopLevelKeys { get; set; } = new List<string>();
+
+    /// <summary>Parsed JSON payload when the response body is valid JSON.</summary>
+    public object? JsonBody { get; set; }
+
+    /// <summary>First-class fields inferred from the parsed JSON payload.</summary>
+    public IList<HtmlCrawlStructuredField> BodyFields { get; set; } = new List<HtmlCrawlStructuredField>();
+
+    /// <summary>Compact selector-like hint for the source element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredSpecItem.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredSpecItem.cs
@@ -1,0 +1,12 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// One normalized key/value entry from a structured specification table.
+/// </summary>
+public sealed class HtmlCrawlStructuredSpecItem {
+    /// <summary>Specification field or property name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Specification value.</summary>
+    public string Value { get; set; } = string.Empty;
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredSpecTable.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlStructuredSpecTable.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Structured specification-style table extracted from selected content.
+/// </summary>
+public sealed class HtmlCrawlStructuredSpecTable {
+    /// <summary>Table index within the selected content.</summary>
+    public int TableIndex { get; set; }
+
+    /// <summary>Optional caption or nearby heading describing the table.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Detected table headers.</summary>
+    public IList<string> Headers { get; set; } = new List<string>();
+
+    /// <summary>Normalized key/value entries extracted from the table.</summary>
+    public IList<HtmlCrawlStructuredSpecItem> Entries { get; set; } = new List<HtmlCrawlStructuredSpecItem>();
+
+    /// <summary>Flattened key/value map for simple ingestion.</summary>
+    public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Compact selector-like hint for the source table element.</summary>
+    public string? SelectorHint { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlSummary.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlSummary.cs
@@ -60,6 +60,81 @@ public sealed class HtmlCrawlSummary {
     /// <summary>Number of downloaded assets.</summary>
     public int AssetCount { get; set; }
 
+    /// <summary>Number of pages that include structured extracted data.</summary>
+    public int StructuredPageCount { get; set; }
+
+    /// <summary>Total structured code blocks captured across fetched pages.</summary>
+    public int StructuredCodeBlockCount { get; set; }
+
+    /// <summary>Total structured code samples captured across fetched pages.</summary>
+    public int StructuredCodeSampleCount { get; set; }
+
+    /// <summary>Total structured API endpoints captured across fetched pages.</summary>
+    public int StructuredApiEndpointCount { get; set; }
+
+    /// <summary>Total distinct structured API paths merged across fetched pages.</summary>
+    public int StructuredApiPathCount { get; set; }
+
+    /// <summary>Total distinct structured API resources merged across fetched pages.</summary>
+    public int StructuredApiResourceCount { get; set; }
+
+    /// <summary>Total structured API operations strong enough to be promoted into the strict OpenAPI export.</summary>
+    public int StructuredOpenApiPromotedOperationCount { get; set; }
+
+    /// <summary>Total structured API operations retained only in the OpenAPI-like export because they were too weak for strict promotion.</summary>
+    public int StructuredOpenApiSkippedOperationCount { get; set; }
+
+    /// <summary>Average promotion score across inferred structured API operations.</summary>
+    public double StructuredOpenApiAveragePromotionScore { get; set; }
+
+    /// <summary>Total reusable structured API schema components merged across fetched pages.</summary>
+    public int StructuredApiSchemaComponentCount { get; set; }
+
+    /// <summary>Total reusable structured API field-set components merged across fetched pages.</summary>
+    public int StructuredApiFieldSetComponentCount { get; set; }
+
+    /// <summary>Total reusable structured API authentication profile components merged across fetched pages.</summary>
+    public int StructuredApiAuthProfileCount { get; set; }
+
+    /// <summary>Total reusable structured API rate-limit profile components merged across fetched pages.</summary>
+    public int StructuredApiRateLimitProfileCount { get; set; }
+
+    /// <summary>Total reusable structured API parameter-set components merged across fetched pages.</summary>
+    public int StructuredApiParameterSetCount { get; set; }
+
+    /// <summary>Total reusable structured API header-set components merged across fetched pages.</summary>
+    public int StructuredApiHeaderSetCount { get; set; }
+
+    /// <summary>Total reusable structured API example-set components merged across fetched pages.</summary>
+    public int StructuredApiExampleSetCount { get; set; }
+
+    /// <summary>Total reusable structured API error-catalog components merged across fetched pages.</summary>
+    public int StructuredApiErrorCatalogComponentCount { get; set; }
+
+    /// <summary>Total structured API endpoints with authentication hints across fetched pages.</summary>
+    public int StructuredAuthenticatedApiEndpointCount { get; set; }
+
+    /// <summary>Total structured API endpoints with rate-limit hints across fetched pages.</summary>
+    public int StructuredRateLimitedApiEndpointCount { get; set; }
+
+    /// <summary>Total structured API error responses captured across fetched pages.</summary>
+    public int StructuredApiErrorResponseCount { get; set; }
+
+    /// <summary>Total structured breadcrumb trails captured across fetched pages.</summary>
+    public int StructuredBreadcrumbCount { get; set; }
+
+    /// <summary>Total structured FAQ items captured across fetched pages.</summary>
+    public int StructuredFaqCount { get; set; }
+
+    /// <summary>Total structured specification tables captured across fetched pages.</summary>
+    public int StructuredSpecTableCount { get; set; }
+
+    /// <summary>Total structured callouts captured across fetched pages.</summary>
+    public int StructuredCalloutCount { get; set; }
+
+    /// <summary>Total structured primary actions captured across fetched pages.</summary>
+    public int StructuredPrimaryActionCount { get; set; }
+
     /// <summary>Number of exported text chunks.</summary>
     public int ChunkCount { get; set; }
 
@@ -148,6 +223,31 @@ public sealed class HtmlCrawlSummary {
             PendingPageCount = result.PendingPages.Count,
             SitemapCount = result.SitemapUrls.Count,
             AssetCount = result.Assets.Count,
+            StructuredPageCount = result.Pages.Count(page => page.StructuredJson != null),
+            StructuredCodeBlockCount = result.Pages.Sum(page => page.StructuredJson?.CodeBlocks.Count ?? 0),
+            StructuredCodeSampleCount = result.Pages.Sum(page => page.StructuredJson?.CodeSamples.Count ?? 0),
+            StructuredApiEndpointCount = result.Pages.Sum(page => page.StructuredJson?.ApiEndpoints.Count ?? 0),
+            StructuredApiPathCount = result.OpenApiLike.Paths.Count,
+            StructuredApiResourceCount = result.OpenApiLike.Resources.Count,
+            StructuredOpenApiPromotedOperationCount = result.OpenApiLike.StrictOpenApiEligibleOperationCount,
+            StructuredOpenApiSkippedOperationCount = result.OpenApiLike.StrictOpenApiSkippedOperationCount,
+            StructuredOpenApiAveragePromotionScore = result.OpenApiLike.StrictOpenApiAverageScore,
+            StructuredApiSchemaComponentCount = result.OpenApiLike.Components.Schemas.Count,
+            StructuredApiFieldSetComponentCount = result.OpenApiLike.Components.FieldSets.Count,
+            StructuredApiAuthProfileCount = result.OpenApiLike.Components.AuthProfiles.Count,
+            StructuredApiRateLimitProfileCount = result.OpenApiLike.Components.RateLimitProfiles.Count,
+            StructuredApiParameterSetCount = result.OpenApiLike.Components.ParameterSets.Count,
+            StructuredApiHeaderSetCount = result.OpenApiLike.Components.RequestHeaderSets.Count + result.OpenApiLike.Components.ResponseHeaderSets.Count,
+            StructuredApiExampleSetCount = result.OpenApiLike.Components.RequestExampleSets.Count + result.OpenApiLike.Components.ResponseExampleSets.Count,
+            StructuredApiErrorCatalogComponentCount = result.OpenApiLike.Components.ErrorCatalogs.Count,
+            StructuredAuthenticatedApiEndpointCount = result.Pages.Sum(page => HtmlCrawler.GetStructuredAuthenticatedApiEndpointCount(page.StructuredJson)),
+            StructuredRateLimitedApiEndpointCount = result.Pages.Sum(page => HtmlCrawler.GetStructuredRateLimitedApiEndpointCount(page.StructuredJson)),
+            StructuredApiErrorResponseCount = result.Pages.Sum(page => HtmlCrawler.GetStructuredApiErrorResponseCount(page.StructuredJson)),
+            StructuredBreadcrumbCount = result.Pages.Sum(page => page.StructuredJson?.Breadcrumbs.Count ?? 0),
+            StructuredFaqCount = result.Pages.Sum(page => page.StructuredJson?.FaqItems.Count ?? 0),
+            StructuredSpecTableCount = result.Pages.Sum(page => page.StructuredJson?.SpecTables.Count ?? 0),
+            StructuredCalloutCount = result.Pages.Sum(page => page.StructuredJson?.Callouts.Count ?? 0),
+            StructuredPrimaryActionCount = result.Pages.Sum(page => page.StructuredJson?.PrimaryActions.Count ?? 0),
             DurationMs = result.Finished > result.Started ? (long)(result.Finished - result.Started).TotalMilliseconds : 0,
             TotalDiscoveredLinks = result.Pages.Sum(page => page.Links?.Count ?? 0)
         };
@@ -247,6 +347,31 @@ public sealed class HtmlCrawlSummary {
         report.AppendLine($"Pending candidates: {PendingPageCount}");
         report.AppendLine($"Sitemaps used: {SitemapCount}");
         report.AppendLine($"Downloaded assets: {AssetCount}");
+        report.AppendLine($"Structured pages: {StructuredPageCount}");
+        report.AppendLine($"Structured code blocks: {StructuredCodeBlockCount}");
+        report.AppendLine($"Structured code samples: {StructuredCodeSampleCount}");
+        report.AppendLine($"Structured API endpoints: {StructuredApiEndpointCount}");
+        report.AppendLine($"Structured API paths: {StructuredApiPathCount}");
+        report.AppendLine($"Structured API resources: {StructuredApiResourceCount}");
+        report.AppendLine($"Structured OpenAPI promoted operations: {StructuredOpenApiPromotedOperationCount}");
+        report.AppendLine($"Structured OpenAPI skipped operations: {StructuredOpenApiSkippedOperationCount}");
+        report.AppendLine($"Structured OpenAPI average promotion score: {StructuredOpenApiAveragePromotionScore:0.##}");
+        report.AppendLine($"Structured API schema components: {StructuredApiSchemaComponentCount}");
+        report.AppendLine($"Structured API field-set components: {StructuredApiFieldSetComponentCount}");
+        report.AppendLine($"Structured API auth profiles: {StructuredApiAuthProfileCount}");
+        report.AppendLine($"Structured API rate-limit profiles: {StructuredApiRateLimitProfileCount}");
+        report.AppendLine($"Structured API parameter sets: {StructuredApiParameterSetCount}");
+        report.AppendLine($"Structured API header sets: {StructuredApiHeaderSetCount}");
+        report.AppendLine($"Structured API example sets: {StructuredApiExampleSetCount}");
+        report.AppendLine($"Structured API error catalogs: {StructuredApiErrorCatalogComponentCount}");
+        report.AppendLine($"Structured authenticated endpoints: {StructuredAuthenticatedApiEndpointCount}");
+        report.AppendLine($"Structured rate-limited endpoints: {StructuredRateLimitedApiEndpointCount}");
+        report.AppendLine($"Structured API error responses: {StructuredApiErrorResponseCount}");
+        report.AppendLine($"Structured breadcrumbs: {StructuredBreadcrumbCount}");
+        report.AppendLine($"Structured FAQ items: {StructuredFaqCount}");
+        report.AppendLine($"Structured spec tables: {StructuredSpecTableCount}");
+        report.AppendLine($"Structured callouts: {StructuredCalloutCount}");
+        report.AppendLine($"Structured primary actions: {StructuredPrimaryActionCount}");
         report.AppendLine($"Exported chunks: {ChunkCount}");
         report.AppendLine($"Graph nodes: {GraphNodeCount}");
         report.AppendLine($"Graph edges: {GraphEdgeCount}");

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -12,6 +12,8 @@ namespace HtmlTinkerX;
 /// Helper methods for retrieving HTML content using a headless browser.
 /// </summary>
 public static partial class HtmlBrowser {
+    private const int DownloadDiscoveryTimeoutMs = 30000;
+
     /// <summary>
     /// Saves any files downloaded while loading the specified URL.
     /// </summary>
@@ -105,7 +107,7 @@ public static partial class HtmlBrowser {
                 : $"a[href*=\"{filter}\"]";
 
             cancellationToken.ThrowIfCancellationRequested();
-            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = 10000 }).ConfigureAwait(false);
+            await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions { Timeout = DownloadDiscoveryTimeoutMs }).ConfigureAwait(false);
             var anchors = await page.QuerySelectorAllAsync(selector).ConfigureAwait(false);
             foreach (var anchor in anchors) {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.SaveAttachment.cs
@@ -13,6 +13,7 @@ namespace HtmlTinkerX;
 /// </summary>
 public static partial class HtmlBrowser {
     private const int DownloadDiscoveryTimeoutMs = 30000;
+    private const int DownloadNavigationTimeoutMs = 30000;
 
     /// <summary>
     /// Saves any files downloaded while loading the specified URL.
@@ -37,6 +38,7 @@ public static partial class HtmlBrowser {
             headless,
             slowMo,
             null,
+            timeout: DownloadNavigationTimeoutMs,
             cancellationToken: cancellationToken).ConfigureAwait(false);
         var page = session.Page;
         string dir = directory.ToFullPath();
@@ -100,7 +102,7 @@ public static partial class HtmlBrowser {
         Task producer = Task.Run(async () => {
             cancellationToken.ThrowIfCancellationRequested();
             await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)").ConfigureAwait(false);
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = DownloadDiscoveryTimeoutMs }).ConfigureAwait(false);
 
             string selector = string.IsNullOrEmpty(filter)
                 ? "a[download],a[href*='/download/'],a[href*='/archive/']"
@@ -111,7 +113,7 @@ public static partial class HtmlBrowser {
             var anchors = await page.QuerySelectorAllAsync(selector).ConfigureAwait(false);
             foreach (var anchor in anchors) {
                 cancellationToken.ThrowIfCancellationRequested();
-                await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync()).ConfigureAwait(false);
+                await page.RunAndWaitForDownloadAsync(() => anchor.ClickAsync(), new PageRunAndWaitForDownloadOptions { Timeout = DownloadDiscoveryTimeoutMs }).ConfigureAwait(false);
             }
 
             await Task.WhenAll(saveTasks).ConfigureAwait(false);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Video.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Video.cs
@@ -148,6 +148,13 @@ public static partial class HtmlBrowser {
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+        if (session.Video != null) {
+            try {
+                await session.Page.WaitForTimeoutAsync(500).ConfigureAwait(false);
+            } catch (PlaywrightException) {
+                // Ignore cases where the page is already closed while stopping the recording.
+            }
+        }
         await session.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlCrawl.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlCrawl.cs
@@ -327,6 +327,26 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter IncludeText { get; set; } = true;
 
+    /// <summary>Include Markdown converted from the selected content in the result.</summary>
+    [Parameter]
+    public SwitchParameter IncludeMarkdown { get; set; }
+
+    /// <summary>Include structured JSON-friendly data extracted from each crawled page.</summary>
+    [Parameter]
+    public SwitchParameter IncludeStructuredJson { get; set; }
+
+    /// <summary>Optional built-in structured JSON preset used to flatten common page types.</summary>
+    [Parameter]
+    public HtmlCrawlStructuredJsonPreset StructuredJsonPreset { get; set; }
+
+    /// <summary>Optional inline JSON schema describing caller-defined extracted structured fields.</summary>
+    [Parameter]
+    public string? StructuredJsonSchema { get; set; }
+
+    /// <summary>Optional JSON file path containing a structured extraction schema.</summary>
+    [Parameter]
+    public string? StructuredJsonSchemaPath { get; set; }
+
     /// <summary>Token used to cancel the operation.</summary>
     [Parameter]
     public CancellationToken CancellationToken { get; set; }
@@ -378,6 +398,11 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
             Scenario = Scenario,
             IncludeHtml = IncludeHtml.IsPresent,
             IncludeText = IncludeText.IsPresent,
+            IncludeMarkdown = IncludeMarkdown.IsPresent,
+            IncludeStructuredJson = IncludeStructuredJson.IsPresent,
+            StructuredJsonPreset = StructuredJsonPreset,
+            StructuredJsonSchema = StructuredJsonSchema,
+            StructuredJsonSchemaPath = StructuredJsonSchemaPath?.ToFullPath(),
             Selector = Selector,
             ContentMode = ContentMode,
             CompareContentModes = CompareContentModes.IsPresent,

--- a/Tests/Documents/multi_manual_download.html
+++ b/Tests/Documents/multi_manual_download.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+</head>
+<body>
+    <a id="link1" href="download1.txt" download>download1</a>
+    <a id="link2" href="download2.txt" download>download2</a>
+</body>
+</html>

--- a/Tests/Save-HTMLDownloadUrl.Tests.ps1
+++ b/Tests/Save-HTMLDownloadUrl.Tests.ps1
@@ -1,25 +1,74 @@
+$script:Python3Path = $null
+$script:Python3Available = $false
+$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
+if ($pythonCommand) {
+    try {
+        & $pythonCommand.Source --version *> $null
+        if ($LASTEXITCODE -eq 0) {
+            $script:Python3Path = $pythonCommand.Source
+            $script:Python3Available = $true
+        }
+    } catch {
+        $script:Python3Available = $false
+    }
+}
+
 Describe 'Save-HTMLAttachment' {
-    It 'Saves downloads on the page by filter' {
-        $Dest = Join-Path $TestDrive 'dl\DnsClientX-PowerShellModule.v0.4.0.zip'
-        [Array] $File = Save-HTMLAttachment -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$Dest" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip'
-        $File.Count | Should -BeGreaterOrEqual 2
-        $Item1 = Get-Item -Path $File[0]
-        $Item2 = Get-Item -Path $File[1]
+    It 'Saves downloads on the page by filter' -Skip:(-not $script:Python3Available) {
+        $server = Start-Process -FilePath $script:Python3Path -ArgumentList '-u', '-m', 'http.server', '8011', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
+        Start-Sleep -Seconds 1
+        $timeout = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($true) {
+            try {
+                $socket = New-Object Net.Sockets.TcpClient
+                $socket.Connect('127.0.0.1', 8011)
+                $socket.Dispose()
+                break
+            } catch {
+                if ($timeout.Elapsed -gt [TimeSpan]::FromSeconds(10)) {
+                    throw 'HTTP server failed to start.'
+                }
+                Start-Sleep -Milliseconds 500
+            }
+        }
 
-        $List = @(
-            'DnsClientX-PowerShellModule.v0.4.0.zip',
-            'DnsClientX-DnsClientX-PowerShellModule.v0.4.0.zip'
-        )
-
-        $List | Should -Contain $Item1.Name
-        $List | Should -Contain $Item2.Name
+        try {
+            $dest = Join-Path $TestDrive 'dl'
+            [array] $files = Save-HTMLAttachment -Url 'http://127.0.0.1:8011/multi_manual_download.html' -Path $dest -Filter 'download'
+            $files.Count | Should -Be 2
+            (Get-Item -Path $files[0]).Name | Should -BeIn @('download1.txt', 'download2.txt')
+            (Get-Item -Path $files[1]).Name | Should -BeIn @('download1.txt', 'download2.txt')
+        } finally {
+            $server | Stop-Process
+        }
     }
 
-    It 'Downloads are fully written to disk' {
-        $Dest = Join-Path $TestDrive 'dl-full'
-        [array] $File = Save-HTMLAttachment -Url 'https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-PowerShellModule.v0.4.0' -Path "$Dest" -Filter 'DnsClientX-PowerShellModule.v0.4.0.zip'
-        foreach ($path in $File) {
-            (Get-Item $path).Length | Should -BeGreaterThan 0
+    It 'Downloads are fully written to disk' -Skip:(-not $script:Python3Available) {
+        $server = Start-Process -FilePath $script:Python3Path -ArgumentList '-u', '-m', 'http.server', '8012', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
+        Start-Sleep -Seconds 1
+        $timeout = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($true) {
+            try {
+                $socket = New-Object Net.Sockets.TcpClient
+                $socket.Connect('127.0.0.1', 8012)
+                $socket.Dispose()
+                break
+            } catch {
+                if ($timeout.Elapsed -gt [TimeSpan]::FromSeconds(10)) {
+                    throw 'HTTP server failed to start.'
+                }
+                Start-Sleep -Milliseconds 500
+            }
+        }
+
+        try {
+            $dest = Join-Path $TestDrive 'dl-full'
+            [array] $files = Save-HTMLAttachment -Url 'http://127.0.0.1:8012/multi_manual_download.html' -Path $dest -Filter 'download'
+            foreach ($path in $files) {
+                (Get-Item $path).Length | Should -BeGreaterThan 0
+            }
+        } finally {
+            $server | Stop-Process
         }
     }
 }

--- a/Tests/Save-HTMLDownloadUrl.Tests.ps1
+++ b/Tests/Save-HTMLDownloadUrl.Tests.ps1
@@ -1,11 +1,9 @@
-$script:Python3Path = $null
 $script:Python3Available = $false
 $pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
 if ($pythonCommand) {
     try {
-        & $pythonCommand.Source --version *> $null
+        & python3 --version *> $null
         if ($LASTEXITCODE -eq 0) {
-            $script:Python3Path = $pythonCommand.Source
             $script:Python3Available = $true
         }
     } catch {
@@ -15,7 +13,7 @@ if ($pythonCommand) {
 
 Describe 'Save-HTMLAttachment' {
     It 'Saves downloads on the page by filter' -Skip:(-not $script:Python3Available) {
-        $server = Start-Process -FilePath $script:Python3Path -ArgumentList '-u', '-m', 'http.server', '8011', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
+        $server = Start-Process -FilePath 'python3' -ArgumentList '-u', '-m', 'http.server', '8011', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
         Start-Sleep -Seconds 1
         $timeout = [System.Diagnostics.Stopwatch]::StartNew()
         while ($true) {
@@ -44,7 +42,7 @@ Describe 'Save-HTMLAttachment' {
     }
 
     It 'Downloads are fully written to disk' -Skip:(-not $script:Python3Available) {
-        $server = Start-Process -FilePath $script:Python3Path -ArgumentList '-u', '-m', 'http.server', '8012', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
+        $server = Start-Process -FilePath 'python3' -ArgumentList '-u', '-m', 'http.server', '8012', '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
         Start-Sleep -Seconds 1
         $timeout = [System.Diagnostics.Stopwatch]::StartNew()
         while ($true) {

--- a/Tests/StartStop-HTMLVideoRecording.Tests.ps1
+++ b/Tests/StartStop-HTMLVideoRecording.Tests.ps1
@@ -6,8 +6,7 @@ describe 'HTML Video Recording' {
         $session = Start-HtmlBrowserVideoCapture -Url $uri -OutFile $out -Width 320 -Height 240
         Invoke-HTMLNavigation -Session $session -Url $uri
         $null = $session.Page.WaitForSelectorAsync('#loaded').GetAwaiter().GetResult()
-        $delay = if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) { 1000 } else { 250 }
-        $null = $session.Page.WaitForTimeoutAsync($delay).GetAwaiter().GetResult()
+        $null = $session.Page.WaitForTimeoutAsync(1000).GetAwaiter().GetResult()
         Stop-HtmlBrowserVideoCapture -Session $session
         (Test-Path $out) | Should -BeTrue
     }


### PR DESCRIPTION
## Summary
- add offline markdown and structured JSON crawl artifacts for local AI-ready datasets
- add richer docs, article, and product extraction with endpoint-aware structured JSON
- add merged OpenApiLike and strict openapi.json exports with promotion, provenance, lineage, and confidence metadata
- expand tests and README examples for both C# and PowerShell

## Validation
- dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj -f net8.0 -p:BuildProjectReferences=false
- dotnet build Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj -f net8.0 -p:BuildProjectReferences=false
- dotnet build Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 -p:BuildProjectReferences=false --no-restore
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --filter HtmlCrawlerStructuredJsonTests --no-build
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --filter HtmlCrawlerMarkdownTests --no-build
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj -f net8.0 --filter HtmlCrawlerTests --no-build
