### PR TITLE
Improve crawl portability, offline diagnostics, and listing-card controls

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -49,9 +49,15 @@ jobs:
       - name: Build solution
         run: dotnet build Sources/HtmlTinkerX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
-      - name: Run tests for ${{ matrix.framework }}
-        run: dotnet test Sources/HtmlTinkerX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --framework ${{ matrix.framework }} --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+      - name: Run tests for net8.0
+        if: matrix.framework == 'net8.0'
+        run: dotnet test Sources/HtmlTinkerX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --framework net8.0 --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
         timeout-minutes: 10
+
+      - name: Run tests for net472
+        if: matrix.framework == 'net472'
+        run: dotnet test Sources/HtmlTinkerX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --framework net472 --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+        timeout-minutes: 20
 
       - name: Summarize failing tests
         if: failure() && env.SUMMARIZE_FAILURES == 'true'

--- a/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-art-direction-picture-article.markdown.snapshot.txt
+++ b/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-art-direction-picture-article.markdown.snapshot.txt
@@ -1,4 +1,4 @@
 # Storm Update
 
-![Flooded street at dawn](http://localhost/news/2026/media/storm-wide.webp "Open full photo"){width=1280 height=720}
+![Flooded street at dawn](http://localhost/news/2026/media/storm-wide.webp "Open full photo")
 _Residents navigate floodwater after the overnight storm._

--- a/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-linked-picture-article.markdown.snapshot.txt
+++ b/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-linked-picture-article.markdown.snapshot.txt
@@ -2,7 +2,7 @@
 
 Read the [briefing](http://localhost/news/2026/briefing.html) before crews enter the river district.
 
-[![Flooded street at dawn](http://localhost/news/2026/media/storm-center.webp "Open full photo")](http://localhost/news/2026/gallery/storm-center "Open photo"){width=1280 height=720}
+[![Flooded street at dawn](http://localhost/news/2026/media/storm-center.webp "Open full photo")](http://localhost/news/2026/gallery/storm-center "Open photo")
 _Residents navigate floodwater after the overnight storm._
 
 Photo credit: City Desk

--- a/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-noscript-linked-picture-article.markdown.snapshot.txt
+++ b/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-noscript-linked-picture-article.markdown.snapshot.txt
@@ -1,6 +1,6 @@
 # Storm Update
 
-[![Flooded street at dawn](http://localhost/news/2026/media/storm-center.webp "Open full photo")](http://localhost/news/2026/gallery/storm-center "Open photo"){width=1280 height=720}
+[![Flooded street at dawn](http://localhost/news/2026/media/storm-center.webp "Open full photo")](http://localhost/news/2026/gallery/storm-center "Open photo")
 _Residents navigate floodwater after the overnight storm._
 
 Photo credit: City Desk

--- a/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-width-descriptor-picture-article.markdown.snapshot.txt
+++ b/Sources/HtmlTinkerX.Tests/Fixtures/Expected/publisher-width-descriptor-picture-article.markdown.snapshot.txt
@@ -1,4 +1,4 @@
 # Storm Update
 
-![Flooded street at dawn](http://localhost/news/2026/media/storm-wide.webp?fit=cover&crop=10,20,300,400 "Open full photo"){width=1280 height=720}
+![Flooded street at dawn](http://localhost/news/2026/media/storm-wide.webp?fit=cover&crop=10,20,300,400 "Open full photo")
 _Residents navigate floodwater after the overnight storm._

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
@@ -53,6 +53,20 @@ public class HtmlCrawlerMarkdownTests {
         return listener;
     }
 
+    private static void DisposeListenerSafely(HttpListener listener) {
+        try {
+            listener.Stop();
+        } catch (HttpListenerException) {
+        } catch (ObjectDisposedException) {
+        }
+
+        try {
+            listener.Close();
+        } catch (HttpListenerException) {
+        } catch (ObjectDisposedException) {
+        }
+    }
+
     [Fact]
     public async Task CrawlAsync_IncludeMarkdown_PopulatesMarkdownAndPersistsFile() {
         Dictionary<string, string> responses = new() {
@@ -84,8 +98,7 @@ public class HtmlCrawlerMarkdownTests {
             string manifest = File.ReadAllText(page.ManifestPath!);
             Assert.Contains("MarkdownPath", manifest, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -159,8 +172,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("![Hero](http://localhost", page.Markdown, StringComparison.Ordinal);
             Assert.DoesNotContain("{width=", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 
@@ -194,8 +206,7 @@ public class HtmlCrawlerMarkdownTests {
             HtmlCrawlPage page = Assert.Single(result.Pages);
             Assert.Contains("{width=256 height=128}", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 
@@ -287,8 +298,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("[15 Jun: First post](", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("First summary.", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 
@@ -340,8 +350,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("By Przemyslaw Klys", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("[Read More](", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 
@@ -623,8 +632,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("hero.webp", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("_Hero image_", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -668,8 +676,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("![Hero](http://localhost", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("/assets/img/hero.png", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -712,8 +719,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("_Hero image_", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("Photo credit: Team", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -759,8 +765,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("\"Hero page\")", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("_Hero image_", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -813,8 +818,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("_Hero image_", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("Photo credit: Team", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -864,8 +868,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("_Hero image_", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("Photo credit: Team", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -903,8 +906,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("[flood map](http://localhost", page.Markdown, StringComparison.Ordinal);
             Assert.Contains("/news/maps/flood-zones.html", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -935,8 +937,7 @@ public class HtmlCrawlerMarkdownTests {
             HtmlCrawlPage page = Assert.Single(result.Pages);
             AssertMarkdownSnapshot(snapshotFileName, page.Markdown);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -971,8 +972,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("Photo credit: City Desk", page.Markdown, StringComparison.Ordinal);
             Assert.DoesNotContain("data:image/gif", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
@@ -1003,8 +1003,7 @@ public class HtmlCrawlerMarkdownTests {
             Assert.Contains("_Residents navigate floodwater after the overnight storm._", page.Markdown, StringComparison.Ordinal);
             Assert.DoesNotContain("data:image/gif", page.Markdown, StringComparison.Ordinal);
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Text;
 using System.Threading.Tasks;
 using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
 using Xunit;
 
 namespace HtmlTinkerX.Tests;
@@ -88,6 +89,259 @@ public class HtmlCrawlerMarkdownTests {
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }
+        }
+    }
+
+    [Theory]
+    [InlineData(MarkdownImageRenderingMode.PortableMarkdown)]
+    [InlineData(MarkdownImageRenderingMode.RichMarkdown)]
+    [InlineData(MarkdownImageRenderingMode.Html)]
+    public void ConvertToMarkdown_CanSwitchImageRenderingModes(MarkdownImageRenderingMode imageMode) {
+        const string html = """
+<main>
+  <figure>
+    <a href="/gallery/hero" title="Open photo">
+      <img src="/img/hero.png" alt="Hero" title="View hero" width="256" height="128" />
+    </a>
+    <figcaption>Hero image</figcaption>
+  </figure>
+</main>
+""";
+
+        string markdown = HtmlMarkdownConverterAdapter.ConvertToMarkdown(html, "https://example.com/docs/start", imageMode);
+
+        switch (imageMode) {
+            case MarkdownImageRenderingMode.PortableMarkdown:
+                Assert.Contains("[![Hero](https://example.com/img/hero.png \"View hero\")](https://example.com/gallery/hero \"Open photo\")", markdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("{width=", markdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("<img ", markdown, StringComparison.Ordinal);
+                break;
+            case MarkdownImageRenderingMode.RichMarkdown:
+                Assert.Contains("[![Hero](https://example.com/img/hero.png \"View hero\")](https://example.com/gallery/hero \"Open photo\"){width=256 height=128}", markdown, StringComparison.Ordinal);
+                break;
+            case MarkdownImageRenderingMode.Html:
+                Assert.Contains("<a href=\"https://example.com/gallery/hero\" title=\"Open photo\">", markdown, StringComparison.Ordinal);
+                Assert.Contains("<img src=\"https://example.com/img/hero.png\" alt=\"Hero\" title=\"View hero\" width=\"256\" height=\"128\"", markdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("{width=", markdown, StringComparison.Ordinal);
+                break;
+        }
+
+        Assert.Contains("Hero image", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_DefaultPortableMode_OmitsImageSizeSuffixes() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <figure>
+        <img src="/img/hero.png" alt="Hero" title="View hero" width="256" height="128" />
+        <figcaption>Hero image</figcaption>
+      </figure>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains("![Hero](http://localhost", page.Markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("{width=", page.Markdown, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_CanEmitRichMarkdownImageSizes() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <figure>
+        <img src="/img/hero.png" alt="Hero" title="View hero" width="256" height="128" />
+        <figcaption>Hero image</figcaption>
+      </figure>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true,
+                MarkdownImageMode = MarkdownImageRenderingMode.RichMarkdown
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains("{width=256 height=128}", page.Markdown, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public void ConvertToMarkdown_CanSuppress_Repeated_Listing_Card_Metadata() {
+        const string html = """
+<main>
+  <div class="blog-feed">
+    <article class="post-card">
+      <div class="post-date">15 June</div>
+      <div class="post-time">21:52</div>
+      <div class="entry-meta"><span class="post-meta-author">By Przemyslaw Klys</span></div>
+      <div class="post-title"><h3><a href="/post-one" rel="bookmark">15 Jun: First post</a></h3></div>
+      <div class="summary"><p>First summary.</p></div>
+      <div class="post-read-more"><a href="/post-one">Read More</a></div>
+    </article>
+    <article class="post-card">
+      <div class="post-date">14 June</div>
+      <div class="post-time">19:20</div>
+      <div class="entry-meta"><span class="post-meta-author">By Another Author</span></div>
+      <div class="post-title"><h3><a href="/post-two" rel="bookmark">14 Jun: Second post</a></h3></div>
+      <div class="summary"><p>Second summary.</p></div>
+      <div class="post-read-more"><a href="/post-two">Read More</a></div>
+    </article>
+  </div>
+</main>
+""";
+
+        string markdown = HtmlMarkdownConverterAdapter.ConvertToMarkdown(
+            html,
+            "https://example.com/",
+            MarkdownImageRenderingMode.PortableMarkdown,
+            HtmlListingCardMetadataMode.SuppressInRepeatedCards);
+
+        Assert.DoesNotContain("15 June", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("21:52", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("By Przemyslaw Klys", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("[Read More](https://example.com/post-one)", markdown, StringComparison.Ordinal);
+        Assert.Contains("[15 Jun: First post](https://example.com/post-one)", markdown, StringComparison.Ordinal);
+        Assert.Contains("First summary.", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_DefaultSuppression_Removes_Repeated_Listing_Card_Metadata() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <div class="blog-feed">
+        <article class="post-card">
+          <div class="post-date">15 June</div>
+          <div class="post-time">21:52</div>
+          <div class="entry-meta"><span class="post-meta-author">By Przemyslaw Klys</span></div>
+          <div class="post-title"><h3><a href="/post-one" rel="bookmark">15 Jun: First post</a></h3></div>
+          <div class="summary"><p>First summary.</p></div>
+          <div class="post-read-more"><a href="/post-one">Read More</a></div>
+        </article>
+        <article class="post-card">
+          <div class="post-date">14 June</div>
+          <div class="post-time">19:20</div>
+          <div class="entry-meta"><span class="post-meta-author">By Another Author</span></div>
+          <div class="post-title"><h3><a href="/post-two" rel="bookmark">14 Jun: Second post</a></h3></div>
+          <div class="summary"><p>Second summary.</p></div>
+          <div class="post-read-more"><a href="/post-two">Read More</a></div>
+        </article>
+      </div>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Equal(HtmlListingCardMetadataMode.SuppressInRepeatedCards, result.ListingCardMetadataMode);
+            Assert.DoesNotContain("15 June", page.Markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("21:52", page.Markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("By Przemyslaw Klys", page.Markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("[Read More](", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("[15 Jun: First post](", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("First summary.", page.Markdown, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_CanPreserve_Repeated_Listing_Card_Metadata_WhenRequested() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <div class="blog-feed">
+        <article class="post-card">
+          <div class="post-date">15 June</div>
+          <div class="post-time">21:52</div>
+          <div class="entry-meta"><span class="post-meta-author">By Przemyslaw Klys</span></div>
+          <div class="post-title"><h3><a href="/post-one" rel="bookmark">15 Jun: First post</a></h3></div>
+          <div class="summary"><p>First summary.</p></div>
+          <div class="post-read-more"><a href="/post-one">Read More</a></div>
+        </article>
+        <article class="post-card">
+          <div class="post-date">14 June</div>
+          <div class="post-time">19:20</div>
+          <div class="entry-meta"><span class="post-meta-author">By Another Author</span></div>
+          <div class="post-title"><h3><a href="/post-two" rel="bookmark">14 Jun: Second post</a></h3></div>
+          <div class="summary"><p>Second summary.</p></div>
+          <div class="post-read-more"><a href="/post-two">Read More</a></div>
+        </article>
+      </div>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true,
+                ListingCardMetadataMode = HtmlListingCardMetadataMode.Preserve
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Equal(HtmlListingCardMetadataMode.Preserve, result.ListingCardMetadataMode);
+            Assert.Contains("15 June", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("21:52", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("By Przemyslaw Klys", page.Markdown, StringComparison.Ordinal);
+            Assert.Contains("[Read More](", page.Markdown, StringComparison.Ordinal);
+        } finally {
+            server.Stop();
+            server.Close();
         }
     }
 

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -48,6 +48,20 @@ public class HtmlCrawlerStructuredJsonTests {
         return listener;
     }
 
+    private static void DisposeListenerSafely(HttpListener listener) {
+        try {
+            listener.Stop();
+        } catch (HttpListenerException) {
+        } catch (ObjectDisposedException) {
+        }
+
+        try {
+            listener.Close();
+        } catch (HttpListenerException) {
+        } catch (ObjectDisposedException) {
+        }
+    }
+
     [Fact]
     public async Task CrawlAsync_IncludeStructuredJson_PopulatesStructuredJsonAndPersistsFiles() {
         Dictionary<string, string> responses = new() {
@@ -947,8 +961,7 @@ public class HtmlCrawlerStructuredJsonTests {
             Assert.Equal("oauth2", securityScheme["type"] as string);
             Assert.True(securityScheme.ContainsKey("flows"));
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
@@ -88,7 +88,7 @@ public class HtmlCrawlerTests {
 """
         };
 
-        using var server = StartServer(responses, out string rootUrl);
+        using var server = StartServer(responses, out string rootUrl, host: "127.0.0.1");
         HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
             MaxDepth = 0,
             MaxPages = 1,
@@ -301,9 +301,9 @@ public class HtmlCrawlerTests {
         return port;
     }
 
-    private static HttpListener StartServer(Dictionary<string, string> responses, out string rootUrl) {
+    private static HttpListener StartServer(Dictionary<string, string> responses, out string rootUrl, string host = "localhost") {
         int port = GetFreePort();
-        rootUrl = $"http://localhost:{port}/";
+        rootUrl = $"http://{host}:{port}/";
         HttpListener listener = new();
         listener.Prefixes.Add(rootUrl);
         listener.Start();

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
@@ -1,4 +1,5 @@
 using HtmlTinkerX;
+using Microsoft.Playwright;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -88,7 +89,7 @@ public class HtmlCrawlerTests {
 """
         };
 
-        using var server = StartServer(responses, out string rootUrl, host: "127.0.0.1");
+        using var server = StartServer(responses, out string rootUrl);
         HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
             MaxDepth = 0,
             MaxPages = 1,
@@ -152,9 +153,14 @@ public class HtmlCrawlerTests {
     }
 
     [Fact]
-    public async Task CrawlAsync_Render_RespectsComputedHiddenContentFromStylesheets() {
-        var responses = new System.Collections.Generic.Dictionary<string, string> {
-            ["/"] = """
+    public async Task MarkRenderedHiddenElementsAsync_MarksComputedHiddenContentFromStylesheets() {
+        await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+        using IPlaywright playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        await using IBrowser browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions {
+            Headless = true
+        });
+        IPage page = await browser.NewPageAsync();
+        await page.SetContentAsync("""
 <html>
   <head>
     <style>
@@ -168,22 +174,37 @@ public class HtmlCrawlerTests {
     </main>
   </body>
 </html>
+""");
+
+        await HtmlCrawler.MarkRenderedHiddenElementsAsync(page);
+
+        Assert.Equal("true", await page.Locator(".theme-hidden").GetAttributeAsync("data-htmltinkerx-hidden"));
+        Assert.Null(await page.Locator("main > p:first-of-type").GetAttributeAsync("data-htmltinkerx-hidden"));
+    }
+
+    [Fact]
+    public async Task CrawlAsync_RespectsRenderedHiddenMarkerByDefault() {
+        var responses = new System.Collections.Generic.Dictionary<string, string> {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <p>Visible text</p>
+      <p data-htmltinkerx-hidden="true">Hidden by stylesheet</p>
+    </main>
+  </body>
+</html>
 """
         };
 
-        await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
         using var server = StartServer(responses, out string rootUrl);
         HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
             MaxDepth = 0,
             MaxPages = 1,
             Selector = "main",
-            Render = true,
             IncludeHtml = true,
             IncludeText = true,
-            IncludeMarkdown = true,
-            Browser = HtmlBrowserEngine.Chromium,
-            Headless = true,
-            Timeout = 15000
+            IncludeMarkdown = true
         });
 
         HtmlCrawlPage page = Assert.Single(result.Pages);

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
@@ -353,6 +353,20 @@ public class HtmlCrawlerTests {
         return listener;
     }
 
+    private static void DisposeListenerSafely(HttpListener listener) {
+        try {
+            listener.Stop();
+        } catch (HttpListenerException) {
+        } catch (ObjectDisposedException) {
+        }
+
+        try {
+            listener.Close();
+        } catch (HttpListenerException) {
+        } catch (ObjectDisposedException) {
+        }
+    }
+
     [Fact]
     public async Task CrawlAsync_FollowsSameHostLinksUpToDepth() {
         Dictionary<string, string> responses = new() {
@@ -374,8 +388,7 @@ public class HtmlCrawlerTests {
             Assert.DoesNotContain(result.Pages, page => page.Url.Contains("/team", StringComparison.OrdinalIgnoreCase));
             Assert.DoesNotContain(result.Pages, page => page.Url.Contains("example.com", StringComparison.OrdinalIgnoreCase));
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 
@@ -399,8 +412,7 @@ public class HtmlCrawlerTests {
             Assert.Contains(result.Pages, page => page.Url.EndsWith("/keep", StringComparison.OrdinalIgnoreCase));
             Assert.DoesNotContain(result.Pages, page => page.Url.EndsWith("/skip-me", StringComparison.OrdinalIgnoreCase));
         } finally {
-            server.Stop();
-            server.Close();
+            DisposeListenerSafely(server);
         }
     }
 

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 using Xunit;
 
 namespace HtmlTinkerX.Tests;
@@ -37,6 +38,9 @@ public class HtmlCrawlerTests {
         clone.ClickTexts.Add("Show more");
         clone.DismissSelectors.Add(".newsletter");
         clone.DismissTexts.Add("Dismiss");
+        clone.MarkdownImageMode = OfficeIMO.Markdown.MarkdownImageRenderingMode.Html;
+        clone.HiddenContentMode = HtmlCrawlHiddenContentMode.IncludeHidden;
+        clone.ListingCardMetadataMode = OfficeIMO.Markdown.Html.HtmlListingCardMetadataMode.Preserve;
         clone.ClearSensitiveData();
 
         Assert.Equal("secret", options.Password);
@@ -57,7 +61,136 @@ public class HtmlCrawlerTests {
         Assert.Equal(2, clone.DismissSelectors.Count);
         Assert.Equal(2, clone.DismissTexts.Count);
         Assert.Equal(HtmlCrawlStructuredJsonPreset.Docs, clone.StructuredJsonPreset);
+        Assert.Equal(OfficeIMO.Markdown.MarkdownImageRenderingMode.PortableMarkdown, options.MarkdownImageMode);
+        Assert.Equal(HtmlCrawlHiddenContentMode.RespectHidden, options.HiddenContentMode);
+        Assert.Equal(OfficeIMO.Markdown.Html.HtmlListingCardMetadataMode.SuppressInRepeatedCards, options.ListingCardMetadataMode);
+        Assert.Equal(OfficeIMO.Markdown.MarkdownImageRenderingMode.Html, clone.MarkdownImageMode);
+        Assert.Equal(HtmlCrawlHiddenContentMode.IncludeHidden, clone.HiddenContentMode);
+        Assert.Equal(OfficeIMO.Markdown.Html.HtmlListingCardMetadataMode.Preserve, clone.ListingCardMetadataMode);
         Assert.NotSame(options.FormLogin, clone.FormLogin);
+    }
+
+    [Fact]
+    public async Task CrawlAsync_RespectsHiddenContentByDefault() {
+        var responses = new System.Collections.Generic.Dictionary<string, string> {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <p>Visible text</p>
+      <div hidden>Hidden attribute text</div>
+      <p style="display:none">Display none text</p>
+      <span aria-hidden="true">Aria hidden text</span>
+      <input type="hidden" value="secret" />
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        using var server = StartServer(responses, out string rootUrl);
+        HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+            MaxDepth = 0,
+            MaxPages = 1,
+            Selector = "main",
+            IncludeHtml = true,
+            IncludeText = true,
+            IncludeMarkdown = true
+        });
+
+        HtmlCrawlPage page = Assert.Single(result.Pages);
+        Assert.Contains("Visible text", page.Text, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Hidden attribute text", page.Html, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Display none text", page.Html, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Aria hidden text", page.Html, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Hidden attribute text", page.Text, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Display none text", page.Text, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Aria hidden text", page.Text, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Hidden attribute text", page.Markdown, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Display none text", page.Markdown, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Aria hidden text", page.Markdown, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CrawlAsync_CanIncludeHiddenContentWhenRequested() {
+        var responses = new System.Collections.Generic.Dictionary<string, string> {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <p>Visible text</p>
+      <div hidden>Hidden attribute text</div>
+      <p style="display:none">Display none text</p>
+      <span aria-hidden="true">Aria hidden text</span>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        using var server = StartServer(responses, out string rootUrl);
+        HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+            MaxDepth = 0,
+            MaxPages = 1,
+            Selector = "main",
+            IncludeHtml = true,
+            IncludeText = true,
+            IncludeMarkdown = true,
+            HiddenContentMode = HtmlCrawlHiddenContentMode.IncludeHidden
+        });
+
+        HtmlCrawlPage page = Assert.Single(result.Pages);
+        Assert.Contains("Hidden attribute text", page.Html, System.StringComparison.Ordinal);
+        Assert.Contains("Display none text", page.Html, System.StringComparison.Ordinal);
+        Assert.Contains("Aria hidden text", page.Html, System.StringComparison.Ordinal);
+        Assert.Contains("Hidden attribute text", page.Text, System.StringComparison.Ordinal);
+        Assert.Contains("Display none text", page.Text, System.StringComparison.Ordinal);
+        Assert.Contains("Aria hidden text", page.Text, System.StringComparison.Ordinal);
+        Assert.Contains("Hidden attribute text", page.Markdown, System.StringComparison.Ordinal);
+        Assert.Contains("Display none text", page.Markdown, System.StringComparison.Ordinal);
+        Assert.Contains("Aria hidden text", page.Markdown, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Render_RespectsComputedHiddenContentFromStylesheets() {
+        var responses = new System.Collections.Generic.Dictionary<string, string> {
+            ["/"] = """
+<html>
+  <head>
+    <style>
+      .theme-hidden { display: none; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p>Visible text</p>
+      <p class="theme-hidden">Hidden by stylesheet</p>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+        using var server = StartServer(responses, out string rootUrl);
+        HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+            MaxDepth = 0,
+            MaxPages = 1,
+            Selector = "main",
+            Render = true,
+            IncludeHtml = true,
+            IncludeText = true,
+            IncludeMarkdown = true,
+            Browser = HtmlBrowserEngine.Chromium,
+            Headless = true,
+            Timeout = 15000
+        });
+
+        HtmlCrawlPage page = Assert.Single(result.Pages);
+        Assert.DoesNotContain("Hidden by stylesheet", page.Html, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Hidden by stylesheet", page.Text, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("Hidden by stylesheet", page.Markdown, System.StringComparison.Ordinal);
+        Assert.Contains("Visible text", page.Text, System.StringComparison.Ordinal);
     }
 
     [Fact]
@@ -830,6 +963,12 @@ public class HtmlCrawlerTests {
                     RenderReasonCode = HtmlCrawlRenderReasonCode.StaticRenderDisabled,
                     RenderReason = "Kept static because browser rendering was not enabled.",
                     AppliedInteractions = { "Dismissed text: Accept" },
+                    OfflineDependencyDiagnostics = {
+                        new HtmlCrawlOfflineDependencyDiagnostic {
+                            Kind = "fetch-api",
+                            Evidence = "fetch('/api/status')"
+                        }
+                    },
                     Text = "Hello world",
                     Started = DateTimeOffset.UtcNow.AddSeconds(-2),
                     Finished = DateTimeOffset.UtcNow.AddSeconds(-1)
@@ -842,6 +981,16 @@ public class HtmlCrawlerTests {
                     RenderReasonCode = HtmlCrawlRenderReasonCode.AutoRenderJavaScriptShell,
                     RenderReason = "Auto-render triggered because the static HTML looked like a JavaScript shell container.",
                     AppliedInteractions = { "Clicked text [1]: Load more", "Clicked text [2]: Load more" },
+                    OfflineDependencyDiagnostics = {
+                        new HtmlCrawlOfflineDependencyDiagnostic {
+                            Kind = "observed-fetch-api",
+                            Evidence = "https://example.com/api/items"
+                        },
+                        new HtmlCrawlOfflineDependencyDiagnostic {
+                            Kind = "observed-cross-origin-runtime",
+                            Evidence = "https://api.example.net/v1/items"
+                        }
+                    },
                     Text = "Rendered content",
                     Started = DateTimeOffset.UtcNow.AddSeconds(-1),
                     Finished = DateTimeOffset.UtcNow
@@ -858,6 +1007,19 @@ public class HtmlCrawlerTests {
         Assert.Equal(1, summary.AutoRenderedPageCount);
         Assert.Equal(2, summary.InteractedPageCount);
         Assert.Equal(3, summary.InteractionCount);
+        Assert.Equal(2, summary.OfflineRiskPageCount);
+        Assert.Equal(3, summary.OfflineRiskDiagnosticCount);
+        Assert.Equal(1, summary.HighOfflineRiskPageCount);
+        Assert.Equal("live-dependent", summary.OfflineReadinessGrade);
+        Assert.Equal(1, summary.OfflineReadinessCounts["partial"]);
+        Assert.Equal(1, summary.OfflineReadinessCounts["live-dependent"]);
+        Assert.Equal(1, summary.OfflineReadinessCountsByState["Success:partial"]);
+        Assert.Equal(1, summary.OfflineReadinessCountsByState["Success:live-dependent"]);
+        Assert.Equal(1, summary.OfflineDependencyKinds["fetch-api"]);
+        Assert.Equal(1, summary.OfflineDependencyKinds["observed-fetch-api"]);
+        Assert.Equal(1, summary.OfflineDependencyKinds["observed-cross-origin-runtime"]);
+        Assert.Equal(2, summary.OfflineDependencySeverityCounts["warning"]);
+        Assert.Equal(1, summary.OfflineDependencySeverityCounts["high"]);
         Assert.Equal(1, summary.InteractionCounts["Dismissed text: Accept"]);
         Assert.Equal(1, summary.InteractionCounts["Clicked text [1]: Load more"]);
         string report = summary.ToReportText(result.SitemapUrls);
@@ -866,6 +1028,66 @@ public class HtmlCrawlerTests {
         Assert.Contains("Render reason AutoRenderJavaScriptShell: 1", report, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Interaction summary:", report, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Applied interactions: 3", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline-risk pages: 2", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("High offline-risk pages: 1", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline readiness grade: live-dependent", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline readiness:", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline grade partial: 1", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline state Success:live-dependent: 1", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline severity high: 1", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Offline dependency observed-fetch-api: 1", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CrawlAsync_SummaryAndIndex_ExposeHiddenContentAndMarkdownGuidance() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerGuidanceTests", Guid.NewGuid().ToString("N"));
+        Dictionary<string, string> responses = new() {
+            ["/"] = "<html><head><title>Home</title></head><body><main><h1>Hello</h1><p>World</p></main></body></html>"
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true,
+                OutputPath = outputPath,
+                HiddenContentMode = HtmlCrawlHiddenContentMode.RespectHidden,
+                MarkdownImageMode = OfficeIMO.Markdown.MarkdownImageRenderingMode.PortableMarkdown,
+                ListingCardMetadataMode = OfficeIMO.Markdown.Html.HtmlListingCardMetadataMode.SuppressInRepeatedCards
+            });
+
+            HtmlCrawlSummary summary = result.Summary;
+            Assert.Equal(HtmlCrawlHiddenContentMode.RespectHidden, summary.HiddenContentMode);
+            Assert.Equal(OfficeIMO.Markdown.MarkdownImageRenderingMode.PortableMarkdown, summary.MarkdownImageMode);
+            Assert.Equal(OfficeIMO.Markdown.Html.HtmlListingCardMetadataMode.SuppressInRepeatedCards, summary.ListingCardMetadataMode);
+            Assert.Contains(summary.GuidanceNotes, note => note.Contains("static mode", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(summary.GuidanceNotes, note => note.Contains("portable output", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(summary.GuidanceNotes, note => note.Contains("listing-card", StringComparison.OrdinalIgnoreCase));
+
+            string summaryText = File.ReadAllText(result.SummaryTextPath!);
+            Assert.Contains("Hidden-content mode: RespectHidden", summaryText, StringComparison.Ordinal);
+            Assert.Contains("Markdown image mode: PortableMarkdown", summaryText, StringComparison.Ordinal);
+            Assert.Contains("Listing-card metadata mode: SuppressInRepeatedCards", summaryText, StringComparison.Ordinal);
+            Assert.Contains("static mode", summaryText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("portable output", summaryText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("listing-card", summaryText, StringComparison.OrdinalIgnoreCase);
+
+            string indexHtml = File.ReadAllText(result.IndexHtmlPath!);
+            Assert.Contains("Extraction Settings", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Hidden-content mode: <code>RespectHidden</code>", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Markdown image mode: <code>PortableMarkdown</code>", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Listing-card metadata mode: <code>SuppressInRepeatedCards</code>", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Guidance", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("external CSS", indexHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            server.Stop();
+            server.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
     }
 
     [Fact]
@@ -1209,6 +1431,7 @@ public class HtmlCrawlerTests {
                 MaxDepth = 0,
                 MaxPages = 5,
                 DownloadAssets = true,
+                ContentMode = HtmlCrawlContentMode.Raw,
                 OutputPath = outputPath
             });
 
@@ -1307,7 +1530,7 @@ public class HtmlCrawlerTests {
                     string contentType;
                     switch (key) {
                         case "/":
-                            body = "<html><head><title>Offline Home</title><base href='/docs/' /><link rel='stylesheet' href='css/site.css' /></head><body><h1>Offline Home</h1><p>Useful docs for offline testing and local search metadata.</p><a href='guide'>Guide</a><a href='manual.pdf'>Manual</a><a href='https://example.com/offsite'>Offsite</a><img src='images/logo.png' alt='Logo' /></body></html>";
+                            body = "<html><head><title>Offline Home</title><base href='/docs/' /><link rel='stylesheet' href='css/site.css' /></head><body><h1>Offline Home</h1><p>Useful docs for offline testing and local search metadata.</p><a href='guide'>Guide</a><a href='manual.pdf'>Manual</a><a href='https://example.com/offsite'>Offsite</a><img src='images/logo.png' alt='Logo' /><script>fetch('/api/status')</script></body></html>";
                             contentType = "text/html; charset=utf-8";
                             break;
                         case "/docs/guide":
@@ -1405,6 +1628,10 @@ public class HtmlCrawlerTests {
                 string.Equals(item.GetString(), "offline", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(manifest.RootElement.GetProperty("Search").GetProperty("Keywords").EnumerateArray(), item =>
                 string.Equals(item.GetString(), "testing", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("partial", manifest.RootElement.GetProperty("OfflineReadinessGrade").GetString());
+            Assert.Equal("warning", manifest.RootElement.GetProperty("HighestOfflineRiskSeverity").GetString());
+            Assert.Equal(1, manifest.RootElement.GetProperty("OfflineDependencyDiagnosticCount").GetInt32());
+            Assert.Equal("fetch-api", manifest.RootElement.GetProperty("OfflineDependencyKindsSummary").GetString());
             Assert.Contains(manifest.RootElement.GetProperty("Links").EnumerateArray(), item =>
                 string.Equals(item.GetProperty("Url").GetString(), rootUrl + "docs/guide", StringComparison.OrdinalIgnoreCase)
                 && string.Equals(item.GetProperty("LocalPagePath").GetString(), Path.GetFileName(guide.HtmlPath), StringComparison.OrdinalIgnoreCase));
@@ -1414,18 +1641,33 @@ public class HtmlCrawlerTests {
             Assert.Contains("\"ChunkId\"", chunksJson, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"ManifestPath\":\"pages/", chunksJson.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Keywords\":[\"offline\"", chunksJson, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"OfflineReadinessGrade\":\"partial\"", chunksJson, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"OfflineDependencyKindsSummary\":\"fetch-api\"", chunksJson, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(4, graph.RootElement.GetProperty("Summary").GetProperty("NodeCount").GetInt32());
+            Assert.Equal(3, graph.RootElement.GetProperty("Summary").GetProperty("EdgeCount").GetInt32());
+            Assert.Equal(1, graph.RootElement.GetProperty("Summary").GetProperty("OfflineRiskNodeCount").GetInt32());
+            Assert.Equal(0, graph.RootElement.GetProperty("Summary").GetProperty("HighOfflineRiskNodeCount").GetInt32());
+            Assert.Equal(1, graph.RootElement.GetProperty("Summary").GetProperty("OfflineReadinessCounts").GetProperty("partial").GetInt32());
+            Assert.Equal(1, graph.RootElement.GetProperty("Summary").GetProperty("OfflineReadinessCounts").GetProperty("ready").GetInt32());
+            Assert.Equal(2, graph.RootElement.GetProperty("Summary").GetProperty("OfflineReadinessCounts").GetProperty("not-assessed").GetInt32());
+            Assert.Equal(1, graph.RootElement.GetProperty("Summary").GetProperty("OfflineSeverityCounts").GetProperty("warning").GetInt32());
+            Assert.Equal(1, graph.RootElement.GetProperty("Summary").GetProperty("OfflineDependencyKindCounts").GetProperty("fetch-api").GetInt32());
             Assert.Equal(4, graph.RootElement.GetProperty("Nodes").GetArrayLength());
             Assert.Equal(3, graph.RootElement.GetProperty("Edges").GetArrayLength());
             Assert.Contains(graph.RootElement.GetProperty("Nodes").EnumerateArray(), node =>
                 string.Equals(node.GetProperty("Url").GetString(), rootUrl, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(node.GetProperty("Category").GetString(), "Fetched", StringComparison.OrdinalIgnoreCase));
+                && string.Equals(node.GetProperty("Category").GetString(), "Fetched", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(node.GetProperty("OfflineReadinessGrade").GetString(), "partial", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(node.GetProperty("OfflineDependencyKindsSummary").GetString(), "fetch-api", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(graph.RootElement.GetProperty("Nodes").EnumerateArray(), node =>
                 string.Equals(node.GetProperty("Url").GetString(), rootUrl + "docs/manual.pdf", StringComparison.OrdinalIgnoreCase)
                 && string.Equals(node.GetProperty("Category").GetString(), "Skipped", StringComparison.OrdinalIgnoreCase)
-                && string.Equals(node.GetProperty("SkipReason").GetString(), HtmlCrawlSkipReason.AssetPath.ToString(), StringComparison.OrdinalIgnoreCase));
+                && string.Equals(node.GetProperty("SkipReason").GetString(), HtmlCrawlSkipReason.AssetPath.ToString(), StringComparison.OrdinalIgnoreCase)
+                && string.Equals(node.GetProperty("OfflineReadinessGrade").GetString(), "not-assessed", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(graph.RootElement.GetProperty("Nodes").EnumerateArray(), node =>
                 string.Equals(node.GetProperty("Url").GetString(), "https://example.com/offsite", StringComparison.OrdinalIgnoreCase)
-                && string.Equals(node.GetProperty("Category").GetString(), "External", StringComparison.OrdinalIgnoreCase));
+                && string.Equals(node.GetProperty("Category").GetString(), "External", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(node.GetProperty("OfflineReadinessGrade").GetString(), "not-assessed", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(graph.RootElement.GetProperty("Edges").EnumerateArray(), edge =>
                 string.Equals(edge.GetProperty("SourceUrl").GetString(), rootUrl, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(edge.GetProperty("TargetUrl").GetString(), rootUrl + "docs/guide", StringComparison.OrdinalIgnoreCase)
@@ -1450,11 +1692,842 @@ public class HtmlCrawlerTests {
             Assert.Contains("Node category", indexHtml, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Edge relation", indexHtml, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Skipped-node reason", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline Readiness", indexHtml, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Skipped Pages", indexHtml, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Skipped Assets", indexHtml, StringComparison.OrdinalIgnoreCase);
         } finally {
             listener.Stop();
             listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Downloads_And_Rewrites_Script_Assets_To_LocalPaths() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerScriptAssetTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    string body;
+                    string contentType;
+                    switch (key) {
+                        case "/":
+                            body = "<html><head><title>Offline App</title></head><body><main><h1>Offline App</h1><p>Scripts should be mirrored locally.</p><script src='/app/runtime.js'></script><script src='/app/main.js'></script></main></body></html>";
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/app/runtime.js":
+                            body = "window.__runtimeLoaded = true;";
+                            contentType = "application/javascript";
+                            break;
+                        case "/app/main.js":
+                            body = "window.__mainLoaded = (window.__runtimeLoaded === true);";
+                            contentType = "application/javascript";
+                            break;
+                        default:
+                            context.Response.StatusCode = 404;
+                            context.Response.OutputStream.Close();
+                            continue;
+                    }
+
+                    byte[] data = Encoding.UTF8.GetBytes(body);
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                DownloadAssets = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "app/runtime.js", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "app/main.js", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "app/runtime.js", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "app/main.js", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+
+            string persistedHtml = File.ReadAllText(page.HtmlPath!);
+            Assert.Contains("<script src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/app/runtime.js", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/app/main.js", persistedHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Downloads_And_Rewrites_Lazy_Image_Attributes_To_LocalPaths() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerLazyAssetTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    byte[] data;
+                    string contentType;
+                    switch (key) {
+                        case "/":
+                            data = Encoding.UTF8.GetBytes("""
+                                <html>
+                                <head><title>Offline Lazy Media</title></head>
+                                <body>
+                                  <main>
+                                    <picture>
+                                      <source data-srcset="/media/hero.webp 1x, /media/hero@2x.webp 2x" type="image/webp" />
+                                      <img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20320%20180'%3E%3C/svg%3E"
+                                           data-src="/media/hero.jpg"
+                                           data-srcset="/media/hero-small.jpg 1x, /media/hero.jpg 2x"
+                                           alt="Lazy hero" />
+                                    </picture>
+                                  </main>
+                                </body>
+                                </html>
+                                """);
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/media/hero.webp":
+                        case "/media/hero@2x.webp":
+                            data = Encoding.UTF8.GetBytes("fake-webp");
+                            contentType = "image/webp";
+                            break;
+                        case "/media/hero-small.jpg":
+                        case "/media/hero.jpg":
+                            data = Encoding.UTF8.GetBytes("fake-jpg");
+                            contentType = "image/jpeg";
+                            break;
+                        default:
+                            context.Response.StatusCode = 404;
+                            context.Response.OutputStream.Close();
+                            continue;
+                    }
+
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                DownloadAssets = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/hero.webp", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/hero@2x.webp", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/hero-small.jpg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/hero.jpg", StringComparison.OrdinalIgnoreCase));
+
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/hero.webp", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/hero@2x.webp", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/hero-small.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/hero.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+
+            string persistedHtml = File.ReadAllText(page.HtmlPath!);
+            Assert.Contains("data-src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("data-srcset=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<source data-srcset=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/hero.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/hero-small.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/hero.webp", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/hero@2x.webp", persistedHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Downloads_And_Rewrites_Noscript_Media_Fallbacks_To_LocalPaths() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerNoscriptAssetTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    byte[] data;
+                    string contentType;
+                    switch (key) {
+                        case "/":
+                            data = Encoding.UTF8.GetBytes("""
+                                <html>
+                                <head><title>Offline Noscript Media</title></head>
+                                <body>
+                                  <main>
+                                    <a href="/story">
+                                      <img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20320%20180'%3E%3C/svg%3E" alt="Fallback teaser" />
+                                      <noscript><img src="/media/fallback.jpg" alt="Fallback teaser" srcset="/media/fallback.jpg 1x, /media/fallback@2x.jpg 2x" /></noscript>
+                                    </a>
+                                  </main>
+                                </body>
+                                </html>
+                                """);
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/media/fallback.jpg":
+                        case "/media/fallback@2x.jpg":
+                            data = Encoding.UTF8.GetBytes("fake-fallback");
+                            contentType = "image/jpeg";
+                            break;
+                        default:
+                            context.Response.StatusCode = 404;
+                            context.Response.OutputStream.Close();
+                            continue;
+                    }
+
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                DownloadAssets = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/fallback.jpg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/fallback@2x.jpg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/fallback.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/fallback@2x.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+
+            string persistedHtml = File.ReadAllText(page.HtmlPath!);
+            Assert.Contains("<noscript><img src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("srcset=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/fallback.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/fallback@2x.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Downloads_And_Rewrites_Preload_Assets_To_LocalPaths() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerPreloadAssetTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    string body;
+                    string contentType;
+                    switch (key) {
+                        case "/":
+                            body = """
+                                <html>
+                                <head>
+                                  <title>Offline Preload</title>
+                                </head>
+                                <body><main><link rel="preload" href="/assets/site.css" as="style" /><link rel="modulepreload" href="/assets/app.mjs" /><link rel="preload" as="image" href="/assets/poster.jpg" imagesrcset="/assets/poster-small.jpg 1x, /assets/poster.jpg 2x" imagesizes="100vw" /><h1>Offline Preload</h1></main></body>
+                                </html>
+                                """;
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/assets/site.css":
+                            body = "body{background:#fff;}";
+                            contentType = "text/css";
+                            break;
+                        case "/assets/app.mjs":
+                            body = "export const boot = true;";
+                            contentType = "application/javascript";
+                            break;
+                        case "/assets/poster-small.jpg":
+                        case "/assets/poster.jpg":
+                            body = "fake-image";
+                            contentType = "image/jpeg";
+                            break;
+                        default:
+                            context.Response.StatusCode = 404;
+                            context.Response.OutputStream.Close();
+                            continue;
+                    }
+
+                    byte[] data = Encoding.UTF8.GetBytes(body);
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                DownloadAssets = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "assets/site.css", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "assets/app.mjs", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "assets/poster-small.jpg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "assets/poster.jpg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "assets/site.css", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "assets/app.mjs", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "assets/poster-small.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "assets/poster.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+
+            string persistedHtml = File.ReadAllText(page.HtmlPath!);
+            Assert.Contains("<link rel=\"preload\" href=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<link rel=\"modulepreload\" href=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("imagesrcset=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/site.css", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/app.mjs", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/poster-small.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/poster.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Downloads_And_Rewrites_VideoPoster_And_Track_Assets_To_LocalPaths() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerVideoAssetTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    byte[] data;
+                    string contentType;
+                    switch (key) {
+                        case "/":
+                            data = Encoding.UTF8.GetBytes("""
+                                <html>
+                                <head><title>Offline Video</title></head>
+                                <body>
+                                  <main>
+                                    <video controls poster="/media/poster.jpg">
+                                      <source src="/media/story.mp4" type="video/mp4" />
+                                      <track kind="captions" srclang="en" src="/media/story.en.vtt" default />
+                                    </video>
+                                  </main>
+                                </body>
+                                </html>
+                                """);
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/media/poster.jpg":
+                            data = Encoding.UTF8.GetBytes("fake-poster");
+                            contentType = "image/jpeg";
+                            break;
+                        case "/media/story.mp4":
+                            data = Encoding.UTF8.GetBytes("fake-video");
+                            contentType = "video/mp4";
+                            break;
+                        case "/media/story.en.vtt":
+                            data = Encoding.UTF8.GetBytes("""
+                                WEBVTT
+
+                                00:00.000 --> 00:02.000
+                                Story intro
+                                """);
+                            contentType = "text/vtt";
+                            break;
+                        default:
+                            context.Response.StatusCode = 404;
+                            context.Response.OutputStream.Close();
+                            continue;
+                    }
+
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                DownloadAssets = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/poster.jpg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/story.mp4", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "media/story.en.vtt", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/poster.jpg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/story.mp4", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "media/story.en.vtt", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+
+            string persistedHtml = File.ReadAllText(page.HtmlPath!);
+            Assert.Contains("poster=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<source src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<track kind=\"captions\" srclang=\"en\" src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/poster.jpg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/story.mp4", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/media/story.en.vtt", persistedHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Downloads_And_Rewrites_Embedded_Resource_Assets_To_LocalPaths() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerEmbeddedAssetTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    byte[] data;
+                    string contentType;
+                    switch (key) {
+                        case "/":
+                            data = Encoding.UTF8.GetBytes("""
+                                <html>
+                                <head><title>Offline Embedded Resources</title></head>
+                                <body>
+                                  <main>
+                                    <iframe src="/frames/report.html" title="Report"></iframe>
+                                    <embed src="/widgets/chart.svg" type="image/svg+xml" />
+                                    <object data="/docs/guide.pdf" type="application/pdf"></object>
+                                  </main>
+                                </body>
+                                </html>
+                                """);
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/frames/report.html":
+                            data = Encoding.UTF8.GetBytes("<html><body><h1>Embedded report</h1></body></html>");
+                            contentType = "text/html; charset=utf-8";
+                            break;
+                        case "/widgets/chart.svg":
+                            data = Encoding.UTF8.GetBytes("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\"><circle cx=\"5\" cy=\"5\" r=\"4\" /></svg>");
+                            contentType = "image/svg+xml";
+                            break;
+                        case "/docs/guide.pdf":
+                            data = Encoding.UTF8.GetBytes("%PDF-1.4 fake pdf");
+                            contentType = "application/pdf";
+                            break;
+                        default:
+                            context.Response.StatusCode = 404;
+                            context.Response.OutputStream.Close();
+                            continue;
+                    }
+
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                DownloadAssets = true,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "frames/report.html", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "widgets/chart.svg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.AssetUrls, asset => string.Equals(asset, rootUrl + "docs/guide.pdf", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "frames/report.html", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "widgets/chart.svg", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+            Assert.Contains(result.Assets, asset => string.Equals(asset.Url, rootUrl + "docs/guide.pdf", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.FilePath));
+
+            string persistedHtml = File.ReadAllText(page.HtmlPath!);
+            Assert.Contains("<iframe src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<embed src=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<object data=\"../assets/", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/frames/report.html", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/widgets/chart.svg", persistedHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/docs/guide.pdf", persistedHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_Reports_Offline_Runtime_Dependency_Diagnostics_In_Page_And_Manifest() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerOfflineDiagnosticTests", Guid.NewGuid().ToString("N"));
+        HttpListener listener = new();
+        string rootUrl;
+        {
+            int port = GetFreePort();
+            rootUrl = $"http://localhost:{port}/";
+            listener.Prefixes.Add(rootUrl);
+        }
+        listener.Start();
+
+        _ = Task.Run(async () => {
+            try {
+                while (listener.IsListening) {
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    string key = context.Request.RawUrl ?? "/";
+                    if (!string.Equals(key, "/", StringComparison.Ordinal)) {
+                        context.Response.StatusCode = 404;
+                        context.Response.OutputStream.Close();
+                        continue;
+                    }
+
+                    byte[] data = Encoding.UTF8.GetBytes("""
+                        <html>
+                        <head><title>Offline Diagnostics</title></head>
+                        <body>
+                          <main>
+                            <h1>Offline Diagnostics</h1>
+                            <button onclick="fetch('/api/status').then(r => r.json())">Refresh</button>
+                            <script>
+                              const socket = new WebSocket('wss://example.test/socket');
+                              navigator.serviceWorker.register('/sw.js');
+                            </script>
+                          </main>
+                        </body>
+                        </html>
+                        """);
+                    context.Response.ContentType = "text/html; charset=utf-8";
+                    context.Response.ContentLength64 = data.Length;
+                    await context.Response.OutputStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                    context.Response.OutputStream.Close();
+                }
+            } catch (HttpListenerException) {
+            } catch (ObjectDisposedException) {
+            }
+        });
+
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 5,
+                OutputPath = outputPath
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Contains(page.OfflineDependencyDiagnostics, diagnostic => string.Equals(diagnostic.Kind, "fetch-api", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.OfflineDependencyDiagnostics, diagnostic => string.Equals(diagnostic.Kind, "websocket", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.OfflineDependencyDiagnostics, diagnostic => string.Equals(diagnostic.Kind, "service-worker", StringComparison.OrdinalIgnoreCase));
+            Assert.All(page.OfflineDependencyDiagnostics, diagnostic => Assert.False(string.IsNullOrWhiteSpace(diagnostic.Evidence)));
+            Assert.Equal("live-dependent", page.OfflineReadinessGrade);
+            Assert.Equal("high", page.HighestOfflineRiskSeverity);
+            Assert.Equal(3, page.OfflineDependencyDiagnosticCount);
+            Assert.Equal("fetch-api, service-worker, websocket", page.OfflineDependencyKindsSummary);
+            Assert.True(result.Summary.OfflineRiskPageCount >= 1);
+            Assert.True(result.Summary.OfflineRiskDiagnosticCount >= 3);
+            Assert.True(result.Summary.HighOfflineRiskPageCount >= 1);
+            Assert.Equal("live-dependent", result.Summary.OfflineReadinessGrade);
+            Assert.Contains("fetch-api", result.Summary.OfflineDependencyKinds.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("high", result.Summary.OfflineDependencySeverityCounts.Keys, StringComparer.OrdinalIgnoreCase);
+
+            string report = result.Summary.ToReportText(result.SitemapUrls);
+            Assert.Contains("Offline-risk pages:", report, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("High offline-risk pages:", report, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline readiness grade: live-dependent", report, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline readiness:", report, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline severity", report, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline dependency fetch-api:", report, StringComparison.OrdinalIgnoreCase);
+
+            string indexHtml = File.ReadAllText(Path.Combine(outputPath, "index.html"));
+            Assert.Contains("Offline Readiness", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline Grade", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline-Risk Pages", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("High-Risk Pages", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline readiness grade: <code>live-dependent</code>", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("offline risk:", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("fetch-api", indexHtml, StringComparison.OrdinalIgnoreCase);
+
+            using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(page.ManifestPath!));
+            Assert.Equal("live-dependent", manifest.RootElement.GetProperty("OfflineReadinessGrade").GetString());
+            Assert.Equal("high", manifest.RootElement.GetProperty("HighestOfflineRiskSeverity").GetString());
+            JsonElement diagnostics = manifest.RootElement.GetProperty("OfflineDependencyDiagnostics");
+            Assert.True(diagnostics.ValueKind == JsonValueKind.Array);
+            Assert.Contains(diagnostics.EnumerateArray().Select(item => item.GetProperty("Kind").GetString()), kind => string.Equals(kind, "fetch-api", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(diagnostics.EnumerateArray().Select(item => item.GetProperty("Kind").GetString()), kind => string.Equals(kind, "websocket", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(diagnostics.EnumerateArray().Select(item => item.GetProperty("Kind").GetString()), kind => string.Equals(kind, "service-worker", StringComparison.OrdinalIgnoreCase));
+
+            using JsonDocument pagesJsonl = JsonDocument.Parse(File.ReadAllLines(result.PagesJsonlPath!).Single());
+            Assert.Equal("live-dependent", pagesJsonl.RootElement.GetProperty("OfflineReadinessGrade").GetString());
+            Assert.Equal("high", pagesJsonl.RootElement.GetProperty("HighestOfflineRiskSeverity").GetString());
+            Assert.Equal(3, pagesJsonl.RootElement.GetProperty("OfflineDependencyDiagnosticCount").GetInt32());
+            Assert.Equal("fetch-api, service-worker, websocket", pagesJsonl.RootElement.GetProperty("OfflineDependencyKindsSummary").GetString());
+            Assert.Contains(pagesJsonl.RootElement.GetProperty("OfflineDependencyKinds").EnumerateArray().Select(item => item.GetString()), kind => string.Equals(kind, "fetch-api", StringComparison.OrdinalIgnoreCase));
+
+            string[] csvLines = File.ReadAllLines(result.PagesCsvPath!);
+            Assert.Contains("OfflineReadinessGrade", csvLines[0], StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("HighestOfflineRiskSeverity", csvLines[0], StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("OfflineDependencyKindsSummary", csvLines[0], StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("live-dependent", csvLines[1], StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("high", csvLines[1], StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("fetch-api, service-worker, websocket", csvLines[1], StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            listener.Close();
+            if (Directory.Exists(outputPath)) {
+                Directory.Delete(outputPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void DetectRenderedNetworkDependencyDiagnostics_Reports_Runtime_And_CrossOrigin_Findings() {
+        List<HtmlNetworkEntry> entries = new() {
+            new() {
+                Url = "https://app.example.test/api/status",
+                ResourceType = HtmlNetworkResourceType.Fetch
+            },
+            new() {
+                Url = "https://api.example.test/v1/data",
+                ResourceType = HtmlNetworkResourceType.XHR
+            },
+            new() {
+                Url = "wss://stream.example.test/live",
+                ResourceType = HtmlNetworkResourceType.WebSocket
+            },
+            new() {
+                Url = "https://app.example.test/assets/app.js",
+                ResourceType = HtmlNetworkResourceType.Script
+            }
+        };
+
+        IList<HtmlCrawlOfflineDependencyDiagnostic> diagnostics = HtmlCrawler.DetectRenderedNetworkDependencyDiagnostics(
+            entries,
+            new Uri("https://app.example.test/dashboard"));
+
+        Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Kind, "observed-fetch-api", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(diagnostic.Evidence, "https://app.example.test/api/status", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Kind, "observed-xml-http-request", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(diagnostic.Evidence, "https://api.example.test/v1/data", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Kind, "observed-websocket", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(diagnostic.Evidence, "wss://stream.example.test/live", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(diagnostic.Severity, "high", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Kind, "observed-cross-origin-runtime", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(diagnostic.Evidence)
+            && string.Equals(diagnostic.Severity, "high", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Kind, "observed-fetch-api", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(diagnostic.Severity, "warning", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(diagnostics, diagnostic => string.Equals(diagnostic.Kind, "script", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void HtmlCrawlSummary_OfflineReadinessGrade_IsReadyWithoutDiagnostics() {
+        HtmlCrawlResult result = new() {
+            StartUrl = "https://example.com/",
+            Started = DateTimeOffset.UtcNow.AddSeconds(-1),
+            Finished = DateTimeOffset.UtcNow,
+            Pages = {
+                new HtmlCrawlPage {
+                    Url = "https://example.com/",
+                    Status = HtmlCrawlPageStatus.Success
+                }
+            }
+        };
+
+        HtmlCrawlSummary summary = result.Summary;
+
+        Assert.Equal("ready", summary.OfflineReadinessGrade);
+        Assert.Equal(0, summary.OfflineRiskDiagnosticCount);
+        Assert.Equal(0, summary.HighOfflineRiskPageCount);
+        Assert.Equal("ready", Assert.Single(result.Pages).OfflineReadinessGrade);
+        Assert.Equal("none", Assert.Single(result.Pages).HighestOfflineRiskSeverity);
+    }
+
+    [Fact]
+    public void HtmlCrawlSummary_OfflineReadinessGrade_IsPartialForWarningsOnly() {
+        HtmlCrawlResult result = new() {
+            StartUrl = "https://example.com/",
+            Started = DateTimeOffset.UtcNow.AddSeconds(-1),
+            Finished = DateTimeOffset.UtcNow,
+            Pages = {
+                new HtmlCrawlPage {
+                    Url = "https://example.com/",
+                    Status = HtmlCrawlPageStatus.Success,
+                    OfflineDependencyDiagnostics = {
+                        new HtmlCrawlOfflineDependencyDiagnostic {
+                            Kind = "fetch-api",
+                            Severity = "warning",
+                            Evidence = "fetch('/api/status')"
+                        }
+                    }
+                }
+            }
+        };
+
+        HtmlCrawlSummary summary = result.Summary;
+
+            Assert.Equal("partial", summary.OfflineReadinessGrade);
+            Assert.Equal(1, summary.OfflineRiskDiagnosticCount);
+            Assert.Equal(0, summary.HighOfflineRiskPageCount);
+            Assert.Equal("partial", Assert.Single(result.Pages).OfflineReadinessGrade);
+            Assert.Equal("warning", Assert.Single(result.Pages).HighestOfflineRiskSeverity);
+            Assert.Equal(1, summary.OfflineReadinessCounts["partial"]);
+            Assert.Equal(1, summary.OfflineReadinessCountsByState["Success:partial"]);
+        }
+
+    [Fact]
+    public async Task CrawlAsync_Exports_NotAssessed_OfflineReadiness_For_Skipped_And_Pending_Candidates() {
+        string outputPath = Path.Combine(Path.GetTempPath(), "HtmlCrawlerPendingSkippedOfflineTests", Guid.NewGuid().ToString("N"));
+        Dictionary<string, string> responses = new() {
+            ["/"] = "<html><head><title>Home</title></head><body><a href='/allowed'>Allowed</a><a href='/blocked'>Blocked</a></body></html>",
+            ["/allowed"] = "<html><head><title>Allowed</title></head><body>Allowed</body></html>",
+            ["/blocked"] = "<html><head><title>Blocked</title></head><body>Blocked</body></html>"
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 1,
+                MaxPages = 1,
+                OutputPath = outputPath,
+                ExcludePatterns = { "*blocked" }
+            });
+
+            HtmlCrawlPendingItem pending = Assert.Single(result.PendingPages);
+            Assert.Equal("not-assessed", pending.OfflineReadinessGrade);
+            Assert.Equal("none", pending.HighestOfflineRiskSeverity);
+
+            HtmlCrawlPage skipped = Assert.Single(result.SkippedPages);
+            Assert.Equal(HtmlCrawlSkipReason.ExcludedByPattern, skipped.SkipReason);
+            Assert.Equal("not-assessed", skipped.OfflineReadinessGrade);
+            Assert.Equal("none", skipped.HighestOfflineRiskSeverity);
+
+            HtmlCrawlSummary summary = result.Summary;
+            Assert.Equal(1, summary.OfflineReadinessCounts["ready"]);
+            Assert.Equal(2, summary.OfflineReadinessCounts["not-assessed"]);
+            Assert.Equal(1, summary.OfflineReadinessCountsByState["Success:ready"]);
+            Assert.Equal(1, summary.OfflineReadinessCountsByState["Skipped:not-assessed"]);
+            Assert.Equal(1, summary.OfflineReadinessCountsByState["Pending:not-assessed"]);
+
+            using JsonDocument skippedJsonl = JsonDocument.Parse(File.ReadAllLines(result.SkippedPagesJsonlPath!).Single());
+            Assert.Equal("not-assessed", skippedJsonl.RootElement.GetProperty("OfflineReadinessGrade").GetString());
+            Assert.Equal("none", skippedJsonl.RootElement.GetProperty("HighestOfflineRiskSeverity").GetString());
+            Assert.Equal(0, skippedJsonl.RootElement.GetProperty("OfflineDependencyDiagnosticCount").GetInt32());
+            Assert.Equal(string.Empty, skippedJsonl.RootElement.GetProperty("OfflineDependencyKindsSummary").GetString());
+
+            using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(result.ManifestPath!));
+            JsonElement pendingJson = Assert.Single(manifest.RootElement.GetProperty("PendingPages").EnumerateArray());
+            Assert.Equal("not-assessed", pendingJson.GetProperty("OfflineReadinessGrade").GetString());
+            Assert.Equal("none", pendingJson.GetProperty("HighestOfflineRiskSeverity").GetString());
+            Assert.Equal(0, pendingJson.GetProperty("OfflineDependencyDiagnosticCount").GetInt32());
+            Assert.Equal(string.Empty, pendingJson.GetProperty("OfflineDependencyKindsSummary").GetString());
+
+            string indexHtml = File.ReadAllText(result.IndexHtmlPath!);
+            Assert.Contains("Pending Pages", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Skipped Pages", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not-assessed", indexHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Offline state <code>Pending:not-assessed</code>: 1", indexHtml, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            server.Stop();
+            server.Close();
             if (Directory.Exists(outputPath)) {
                 Directory.Delete(outputPath, recursive: true);
             }

--- a/Sources/HtmlTinkerX/Enums/HtmlEnumParser.cs
+++ b/Sources/HtmlTinkerX/Enums/HtmlEnumParser.cs
@@ -46,4 +46,23 @@ public static class HtmlEnumParser {
         "PATCH" => HtmlHttpMethod.Patch,
         _ => HtmlHttpMethod.Other
     };
+
+    /// <summary>
+    /// Converts a browser resource type string to <see cref="HtmlNetworkResourceType"/>.
+    /// </summary>
+    public static HtmlNetworkResourceType ParseNetworkResourceType(string? resourceType) => resourceType?.ToLowerInvariant() switch {
+        "document" => HtmlNetworkResourceType.Document,
+        "stylesheet" => HtmlNetworkResourceType.Stylesheet,
+        "image" => HtmlNetworkResourceType.Image,
+        "media" => HtmlNetworkResourceType.Media,
+        "font" => HtmlNetworkResourceType.Font,
+        "script" => HtmlNetworkResourceType.Script,
+        "texttrack" => HtmlNetworkResourceType.TextTrack,
+        "xhr" => HtmlNetworkResourceType.XHR,
+        "fetch" => HtmlNetworkResourceType.Fetch,
+        "eventsource" => HtmlNetworkResourceType.EventSource,
+        "websocket" => HtmlNetworkResourceType.WebSocket,
+        "manifest" => HtmlNetworkResourceType.Manifest,
+        _ => HtmlNetworkResourceType.Other
+    };
 }

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -1,5 +1,7 @@
 using AngleSharp.Dom;
 using Microsoft.Playwright;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -70,6 +72,10 @@ public static class HtmlCrawler {
         public string? HtmlPath { get; set; }
         public string? TextPath { get; set; }
         public string? ManifestPath { get; set; }
+        public string OfflineReadinessGrade { get; set; } = "ready";
+        public string HighestOfflineRiskSeverity { get; set; } = "none";
+        public int OfflineDependencyDiagnosticCount { get; set; }
+        public string OfflineDependencyKindsSummary { get; set; } = string.Empty;
         public string Fingerprint { get; set; } = string.Empty;
     }
 
@@ -80,6 +86,10 @@ public static class HtmlCrawler {
         public string Status { get; set; } = string.Empty;
         public string Category { get; set; } = string.Empty;
         public string? SkipReason { get; set; }
+        public string OfflineReadinessGrade { get; set; } = "not-assessed";
+        public string HighestOfflineRiskSeverity { get; set; } = "none";
+        public int OfflineDependencyDiagnosticCount { get; set; }
+        public string OfflineDependencyKindsSummary { get; set; } = string.Empty;
         public int InDegree { get; set; }
         public int OutDegree { get; set; }
         public int InternalOutDegree { get; set; }
@@ -265,6 +275,11 @@ public static class HtmlCrawler {
                     AppliedProfileName = appliedProfile?.Name,
                     AppliedProfileReasonCode = profileDecision.ReasonCode,
                     AppliedProfileReason = profileDecision.Reason,
+                    RenderEnabled = resolvedOptions.Render,
+                    AutoRenderEnabled = resolvedOptions.AutoRender,
+                    HiddenContentMode = resolvedOptions.HiddenContentMode,
+                    MarkdownImageMode = resolvedOptions.MarkdownImageMode,
+                    ListingCardMetadataMode = resolvedOptions.ListingCardMetadataMode,
                     Started = DateTimeOffset.UtcNow
                 };
             }
@@ -281,6 +296,11 @@ public static class HtmlCrawler {
             if (string.IsNullOrWhiteSpace(result.AppliedProfileReason) && !string.IsNullOrWhiteSpace(profileDecision.Reason)) {
                 result.AppliedProfileReason = profileDecision.Reason;
             }
+            result.RenderEnabled = resolvedOptions.Render;
+            result.AutoRenderEnabled = resolvedOptions.AutoRender;
+            result.HiddenContentMode = resolvedOptions.HiddenContentMode;
+            result.MarkdownImageMode = resolvedOptions.MarkdownImageMode;
+            result.ListingCardMetadataMode = resolvedOptions.ListingCardMetadataMode;
 
             Queue<CrawlRequest> pending = new();
             HashSet<string> queued = new(StringComparer.OrdinalIgnoreCase);
@@ -1042,7 +1062,7 @@ public static class HtmlCrawler {
 
         StringBuilder pagesJsonl = new();
         StringBuilder pagesCsv = new();
-        pagesCsv.AppendLine("Url,RequestedUrl,CanonicalUrl,ParentUrl,Depth,Status,StatusCode,ContentType,Title,HtmlPath,TextPath,MarkdownPath,StructuredJsonPath,ManifestPath,ContentFingerprint,DuplicateOfUrl,Rendered,RenderMode,RenderReasonCode,RenderReason,AppliedScenario,AppliedProfileName,AppliedProfileReasonCode,AppliedProfileReason,ContentModeUsed,ContentSelectionReasonCode,ContentSelectionReason,ContentElementTag,ContentElementId,ContentElementClasses,ContentElementSelectorHint,ContentSelectionScore,ReaderCandidateCount,ReaderRootElementSelectorHint,ContentComparisonCount,BestContentComparisonMode,BestContentComparisonReasonCode,BestContentComparisonWordCount,RunnerUpContentComparisonMode,BestContentComparisonWordDelta,ContentComparisonDeltaSummary,ContentComparisonPreviewSummary,Started,Finished,DurationMs,LinkCount,AssetCount,InteractionCount,StructuredTableCount,StructuredListCount,StructuredFormCount,StructuredMicrodataCount,StructuredMetaTagCount,StructuredCodeBlockCount,StructuredCodeSampleCount,StructuredApiEndpointCount,StructuredAuthenticatedApiEndpointCount,StructuredRateLimitedApiEndpointCount,StructuredApiErrorResponseCount,StructuredBreadcrumbCount,StructuredFaqCount,StructuredSpecTableCount,StructuredCalloutCount,StructuredPrimaryActionCount,StructuredHeaderCount,StructuredNavigationCount,StructuredMainCount,StructuredArticleCount,StructuredAsideCount,StructuredFooterCount,Error");
+        pagesCsv.AppendLine("Url,RequestedUrl,CanonicalUrl,ParentUrl,Depth,Status,StatusCode,ContentType,Title,HtmlPath,TextPath,MarkdownPath,StructuredJsonPath,ManifestPath,ContentFingerprint,DuplicateOfUrl,Rendered,RenderMode,RenderReasonCode,RenderReason,AppliedScenario,AppliedProfileName,AppliedProfileReasonCode,AppliedProfileReason,ContentModeUsed,ContentSelectionReasonCode,ContentSelectionReason,ContentElementTag,ContentElementId,ContentElementClasses,ContentElementSelectorHint,ContentSelectionScore,ReaderCandidateCount,ReaderRootElementSelectorHint,ContentComparisonCount,BestContentComparisonMode,BestContentComparisonReasonCode,BestContentComparisonWordCount,RunnerUpContentComparisonMode,BestContentComparisonWordDelta,ContentComparisonDeltaSummary,ContentComparisonPreviewSummary,Started,Finished,DurationMs,LinkCount,AssetCount,InteractionCount,StructuredTableCount,StructuredListCount,StructuredFormCount,StructuredMicrodataCount,StructuredMetaTagCount,StructuredCodeBlockCount,StructuredCodeSampleCount,StructuredApiEndpointCount,StructuredAuthenticatedApiEndpointCount,StructuredRateLimitedApiEndpointCount,StructuredApiErrorResponseCount,StructuredBreadcrumbCount,StructuredFaqCount,StructuredSpecTableCount,StructuredCalloutCount,StructuredPrimaryActionCount,StructuredHeaderCount,StructuredNavigationCount,StructuredMainCount,StructuredArticleCount,StructuredAsideCount,StructuredFooterCount,OfflineReadinessGrade,HighestOfflineRiskSeverity,OfflineDependencyDiagnosticCount,OfflineDependencyKindsSummary,Error");
         foreach (HtmlCrawlPage page in result.Pages) {
             cancellationToken.ThrowIfCancellationRequested();
             pagesJsonl.AppendLine(JsonSerializer.Serialize(new {
@@ -1116,6 +1136,12 @@ public static class HtmlCrawler {
                 StructuredArticleCount = page.StructuredJson?.Layout.ArticleCount ?? 0,
                 StructuredAsideCount = page.StructuredJson?.Layout.AsideCount ?? 0,
                 StructuredFooterCount = page.StructuredJson?.Layout.FooterCount ?? 0,
+                page.OfflineReadinessGrade,
+                page.HighestOfflineRiskSeverity,
+                OfflineDependencyDiagnosticCount = page.OfflineDependencyDiagnosticCount,
+                page.OfflineDependencyKinds,
+                page.OfflineDependencyKindsSummary,
+                OfflineDependencyDiagnostics = page.OfflineDependencyDiagnostics,
                 page.Error
             }));
 
@@ -1190,6 +1216,10 @@ public static class HtmlCrawler {
                 EscapeCsv((page.StructuredJson?.Layout.ArticleCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 EscapeCsv((page.StructuredJson?.Layout.AsideCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 EscapeCsv((page.StructuredJson?.Layout.FooterCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv(page.OfflineReadinessGrade),
+                EscapeCsv(page.HighestOfflineRiskSeverity),
+                EscapeCsv(page.OfflineDependencyDiagnosticCount.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                EscapeCsv(page.OfflineDependencyKindsSummary),
                 EscapeCsv(page.Error)));
         }
 
@@ -1214,6 +1244,10 @@ public static class HtmlCrawler {
                 page.ContentType,
                 page.ContentFingerprint,
                 page.DuplicateOfUrl,
+                page.OfflineReadinessGrade,
+                page.HighestOfflineRiskSeverity,
+                page.OfflineDependencyDiagnosticCount,
+                page.OfflineDependencyKindsSummary,
                 page.Error
             }));
         }
@@ -1232,6 +1266,10 @@ public static class HtmlCrawler {
                 page.ContentType,
                 page.ContentFingerprint,
                 page.DuplicateOfUrl,
+                page.OfflineReadinessGrade,
+                page.HighestOfflineRiskSeverity,
+                page.OfflineDependencyDiagnosticCount,
+                page.OfflineDependencyKindsSummary,
                 page.Error
             }));
         }
@@ -1299,6 +1337,10 @@ public static class HtmlCrawler {
                 HtmlPath = BuildRelativeOptionalPath(artifactPaths.ChunksJsonlPath, chunk.HtmlPath),
                 TextPath = BuildRelativeOptionalPath(artifactPaths.ChunksJsonlPath, chunk.TextPath),
                 ManifestPath = BuildRelativeOptionalPath(artifactPaths.ChunksJsonlPath, chunk.ManifestPath),
+                chunk.OfflineReadinessGrade,
+                chunk.HighestOfflineRiskSeverity,
+                chunk.OfflineDependencyDiagnosticCount,
+                chunk.OfflineDependencyKindsSummary,
                 chunk.Fingerprint
             }));
         }
@@ -1812,6 +1854,14 @@ public static class HtmlCrawler {
                     asset.ContentLength
                 })
                 .ToArray(),
+            page.OfflineReadinessGrade,
+            page.HighestOfflineRiskSeverity,
+            page.OfflineDependencyDiagnosticCount,
+            page.OfflineDependencyKinds,
+            page.OfflineDependencyKindsSummary,
+            OfflineDependencyDiagnostics = page.OfflineDependencyDiagnostics
+                .OrderBy(diagnostic => diagnostic.Kind, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
             page.Error
         };
 
@@ -2208,6 +2258,10 @@ public static class HtmlCrawler {
             Depth = page.Depth,
             Status = page.Status.ToString(),
             Category = "Fetched",
+            OfflineReadinessGrade = page.OfflineReadinessGrade,
+            HighestOfflineRiskSeverity = page.HighestOfflineRiskSeverity,
+            OfflineDependencyDiagnosticCount = page.OfflineDependencyDiagnosticCount,
+            OfflineDependencyKindsSummary = page.OfflineDependencyKindsSummary,
             InDegree = incomingTotal.TryGetValue(page.Url, out int inDegree) ? inDegree : 0,
             OutDegree = outgoingTotal.TryGetValue(page.Url, out int outDegree) ? outDegree : 0,
             InternalOutDegree = outgoingInternal.TryGetValue(page.Url, out int internalOutDegree) ? internalOutDegree : 0,
@@ -2224,6 +2278,10 @@ public static class HtmlCrawler {
                 Status = page.Status.ToString(),
                 Category = "Skipped",
                 SkipReason = page.SkipReason.ToString(),
+                OfflineReadinessGrade = page.OfflineReadinessGrade,
+                HighestOfflineRiskSeverity = page.HighestOfflineRiskSeverity,
+                OfflineDependencyDiagnosticCount = page.OfflineDependencyDiagnosticCount,
+                OfflineDependencyKindsSummary = page.OfflineDependencyKindsSummary,
                 InDegree = incomingTotal.TryGetValue(page.Url, out int inDegree) ? inDegree : 0,
                 OutDegree = 0,
                 InternalOutDegree = 0
@@ -2238,6 +2296,10 @@ public static class HtmlCrawler {
                 Status = page.Status.ToString(),
                 Category = "External",
                 SkipReason = page.SkipReason.ToString(),
+                OfflineReadinessGrade = page.OfflineReadinessGrade,
+                HighestOfflineRiskSeverity = page.HighestOfflineRiskSeverity,
+                OfflineDependencyDiagnosticCount = page.OfflineDependencyDiagnosticCount,
+                OfflineDependencyKindsSummary = page.OfflineDependencyKindsSummary,
                 InDegree = incomingTotal.TryGetValue(page.Url, out int inDegree) ? inDegree : 0,
                 OutDegree = 0,
                 InternalOutDegree = 0
@@ -2256,7 +2318,52 @@ public static class HtmlCrawler {
                 InternalOutDegree = 0
             }));
 
+        int fetchedNodeCount = nodes.Count(node => string.Equals(node.Category, "Fetched", StringComparison.OrdinalIgnoreCase));
+        int skippedNodeCount = nodes.Count(node => string.Equals(node.Category, "Skipped", StringComparison.OrdinalIgnoreCase));
+        int externalNodeCount = nodes.Count(node => string.Equals(node.Category, "External", StringComparison.OrdinalIgnoreCase));
+        Dictionary<string, int> nodeCategories = nodes
+            .GroupBy(node => node.Category, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int> edgeRelations = edges
+            .GroupBy(edge => edge.Relation, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int> skippedNodeReasons = nodes
+            .Where(node => string.Equals(node.Category, "Skipped", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(node.SkipReason))
+            .GroupBy(node => node.SkipReason!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int> offlineReadinessCounts = nodes
+            .GroupBy(node => node.OfflineReadinessGrade, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int> offlineSeverityCounts = nodes
+            .GroupBy(node => node.HighestOfflineRiskSeverity, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int> offlineDependencyKindCounts = nodes
+            .SelectMany(node => string.IsNullOrWhiteSpace(node.OfflineDependencyKindsSummary)
+                ? Array.Empty<string>()
+                : node.OfflineDependencyKindsSummary.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(kind => kind.Trim())
+                    .Where(kind => !string.IsNullOrWhiteSpace(kind)))
+            .GroupBy(kind => kind, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        int offlineRiskNodeCount = nodes.Count(node => node.OfflineDependencyDiagnosticCount > 0);
+        int highOfflineRiskNodeCount = nodes.Count(node => string.Equals(node.HighestOfflineRiskSeverity, "high", StringComparison.OrdinalIgnoreCase));
+
         object graphDocument = new {
+            Summary = new {
+                NodeCount = nodes.Count,
+                EdgeCount = edges.Count,
+                FetchedNodeCount = fetchedNodeCount,
+                SkippedNodeCount = skippedNodeCount,
+                ExternalNodeCount = externalNodeCount,
+                OfflineRiskNodeCount = offlineRiskNodeCount,
+                HighOfflineRiskNodeCount = highOfflineRiskNodeCount,
+                OfflineReadinessCounts = offlineReadinessCounts,
+                OfflineSeverityCounts = offlineSeverityCounts,
+                OfflineDependencyKindCounts = offlineDependencyKindCounts,
+                NodeCategories = nodeCategories,
+                EdgeRelations = edgeRelations,
+                SkippedNodeReasons = skippedNodeReasons
+            },
             Nodes = nodes.OrderBy(node => node.Category, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(node => node.Depth)
                 .ThenBy(node => node.Url, StringComparer.OrdinalIgnoreCase)
@@ -2272,20 +2379,6 @@ public static class HtmlCrawler {
                 })
                 .ToArray()
         };
-
-        int fetchedNodeCount = nodes.Count(node => string.Equals(node.Category, "Fetched", StringComparison.OrdinalIgnoreCase));
-        int skippedNodeCount = nodes.Count(node => string.Equals(node.Category, "Skipped", StringComparison.OrdinalIgnoreCase));
-        int externalNodeCount = nodes.Count(node => string.Equals(node.Category, "External", StringComparison.OrdinalIgnoreCase));
-        Dictionary<string, int> nodeCategories = nodes
-            .GroupBy(node => node.Category, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
-        Dictionary<string, int> edgeRelations = edges
-            .GroupBy(edge => edge.Relation, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
-        Dictionary<string, int> skippedNodeReasons = nodes
-            .Where(node => string.Equals(node.Category, "Skipped", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(node.SkipReason))
-            .GroupBy(node => node.SkipReason!, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
         return (graphDocument, nodes.Count, edges.Count, fetchedNodeCount, skippedNodeCount, externalNodeCount, nodeCategories, edgeRelations, skippedNodeReasons);
     }
 
@@ -2310,20 +2403,24 @@ public static class HtmlCrawler {
                 chunks.Add(new PageChunkRecord {
                     ChunkId = $"chunk-{nextChunkId:D5}",
                     Url = page.Url,
-                    Title = page.Title,
-                    Depth = page.Depth,
-                    ChunkIndex = chunkIndex++,
-                    WordCount = CountWords(chunkText),
-                    CharacterCount = chunkText.Length,
+                Title = page.Title,
+                Depth = page.Depth,
+                ChunkIndex = chunkIndex++,
+                WordCount = CountWords(chunkText),
+                CharacterCount = chunkText.Length,
                     Summary = BuildSummary(chunkText),
                     Headings = searchMetadata.Headings,
                     Keywords = ExtractKeywords(chunkText),
-                    Text = chunkText,
-                    HtmlPath = page.HtmlPath,
-                    TextPath = page.TextPath,
-                    ManifestPath = page.ManifestPath,
-                    Fingerprint = fingerprint
-                });
+                Text = chunkText,
+                HtmlPath = page.HtmlPath,
+                TextPath = page.TextPath,
+                ManifestPath = page.ManifestPath,
+                OfflineReadinessGrade = page.OfflineReadinessGrade,
+                HighestOfflineRiskSeverity = page.HighestOfflineRiskSeverity,
+                OfflineDependencyDiagnosticCount = page.OfflineDependencyDiagnosticCount,
+                OfflineDependencyKindsSummary = page.OfflineDependencyKindsSummary,
+                Fingerprint = fingerprint
+            });
                 nextChunkId++;
             }
         }
@@ -7119,12 +7216,44 @@ public static class HtmlCrawler {
         AppendStatCard(builder, "Skipped Assets", summary.SkippedAssetCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
         AppendStatCard(builder, "Assets", summary.AssetCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
         AppendStatCard(builder, "Chunks", summary.ChunkCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        AppendStatCard(builder, "Offline Grade", summary.OfflineReadinessGrade);
+        AppendStatCard(builder, "Offline-Risk Pages", summary.OfflineRiskPageCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        AppendStatCard(builder, "High-Risk Pages", summary.HighOfflineRiskPageCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        AppendStatCard(builder, "Offline Findings", summary.OfflineRiskDiagnosticCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
         AppendStatCard(builder, "Interactions", summary.InteractionCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
         AppendStatCard(builder, "Graph Edges", summary.GraphEdgeCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
         AppendStatCard(builder, "External Nodes", summary.GraphExternalNodeCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
         AppendStatCard(builder, "Links", summary.TotalDiscoveredLinks.ToString(System.Globalization.CultureInfo.InvariantCulture));
         builder.AppendLine("    </div>");
         builder.AppendLine("  </section>");
+
+        builder.AppendLine("  <section>");
+        builder.AppendLine("    <h2>Extraction Settings</h2>");
+        builder.AppendLine("    <ul>");
+        builder.Append("      <li>Hidden-content mode: <code>")
+            .Append(HtmlEncode(summary.HiddenContentMode.ToString()))
+            .AppendLine("</code></li>");
+        builder.Append("      <li>Markdown image mode: <code>")
+            .Append(HtmlEncode(summary.MarkdownImageMode.ToString()))
+            .AppendLine("</code></li>");
+        builder.Append("      <li>Listing-card metadata mode: <code>")
+            .Append(HtmlEncode(summary.ListingCardMetadataMode.ToString()))
+            .AppendLine("</code></li>");
+        builder.AppendLine("    </ul>");
+        builder.AppendLine("  </section>");
+
+        if (summary.GuidanceNotes.Count > 0) {
+            builder.AppendLine("  <section>");
+            builder.AppendLine("    <h2>Guidance</h2>");
+            builder.AppendLine("    <ul>");
+            foreach (string note in summary.GuidanceNotes.Where(note => !string.IsNullOrWhiteSpace(note))) {
+                builder.Append("      <li>")
+                    .Append(HtmlEncode(note))
+                    .AppendLine("</li>");
+            }
+            builder.AppendLine("    </ul>");
+            builder.AppendLine("  </section>");
+        }
 
         builder.AppendLine("  <section>");
         builder.AppendLine("    <h2>Artifacts</h2>");
@@ -7245,6 +7374,54 @@ public static class HtmlCrawler {
             builder.AppendLine("  </section>");
         }
 
+        if (summary.OfflineReadinessCounts.Count > 0 || summary.OfflineDependencyKinds.Count > 0) {
+            builder.AppendLine("  <section>");
+            builder.AppendLine("    <h2>Offline Readiness</h2>");
+            builder.AppendLine("    <ul>");
+            builder.Append("      <li>Pages with offline-runtime risk signals: ")
+                .Append(HtmlEncode(summary.OfflineRiskPageCount.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                .AppendLine("</li>");
+            builder.Append("      <li>Offline readiness grade: <code>")
+                .Append(HtmlEncode(summary.OfflineReadinessGrade))
+                .AppendLine("</code></li>");
+            builder.Append("      <li>Total offline-runtime diagnostics: ")
+                .Append(HtmlEncode(summary.OfflineRiskDiagnosticCount.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                .AppendLine("</li>");
+            builder.Append("      <li>Pages with high-severity offline-runtime signals: ")
+                .Append(HtmlEncode(summary.HighOfflineRiskPageCount.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                .AppendLine("</li>");
+            foreach (var item in summary.OfflineReadinessCounts.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                builder.Append("      <li>Offline grade <code>")
+                    .Append(HtmlEncode(item.Key))
+                    .Append("</code>: ")
+                    .Append(HtmlEncode(item.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                    .AppendLine("</li>");
+            }
+            foreach (var item in summary.OfflineReadinessCountsByState.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                builder.Append("      <li>Offline state <code>")
+                    .Append(HtmlEncode(item.Key))
+                    .Append("</code>: ")
+                    .Append(HtmlEncode(item.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                    .AppendLine("</li>");
+            }
+            foreach (var item in summary.OfflineDependencySeverityCounts.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                builder.Append("      <li>Offline severity <code>")
+                    .Append(HtmlEncode(item.Key))
+                    .Append("</code>: ")
+                    .Append(HtmlEncode(item.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                    .AppendLine("</li>");
+            }
+            foreach (var item in summary.OfflineDependencyKinds.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                builder.Append("      <li>Offline dependency <code>")
+                    .Append(HtmlEncode(item.Key))
+                    .Append("</code>: ")
+                    .Append(HtmlEncode(item.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                    .AppendLine("</li>");
+            }
+            builder.AppendLine("    </ul>");
+            builder.AppendLine("  </section>");
+        }
+
         if (summary.GraphNodeCategories.Count > 0 || summary.GraphEdgeRelations.Count > 0 || summary.GraphSkippedNodeReasons.Count > 0) {
             builder.AppendLine("  <section>");
             builder.AppendLine("    <h2>Graph Summary</h2>");
@@ -7330,6 +7507,17 @@ public static class HtmlCrawler {
             if (page.AppliedInteractions.Count > 0) {
                 builder.Append("<br>interactions: ")
                     .Append(HtmlEncode(string.Join(" | ", page.AppliedInteractions)));
+            }
+            if (page.OfflineDependencyDiagnostics.Count > 0) {
+                builder.Append("<br>offline risk: ")
+                    .Append(HtmlEncode(page.OfflineDependencyDiagnosticCount.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                    .Append(" <span class=\"muted\">(")
+                    .Append(HtmlEncode(page.OfflineReadinessGrade))
+                    .Append("; ")
+                    .Append(HtmlEncode(page.HighestOfflineRiskSeverity))
+                    .Append("; ")
+                    .Append(HtmlEncode(page.OfflineDependencyKindsSummary))
+                    .Append(")</span>");
             }
             builder.Append("<br>content: ")
                 .Append(HtmlEncode(page.ContentModeUsed.ToString()));
@@ -7483,7 +7671,7 @@ public static class HtmlCrawler {
             builder.AppendLine("  <section>");
             builder.AppendLine("    <h2>Skipped Pages</h2>");
             builder.AppendLine("    <table>");
-            builder.AppendLine("      <thead><tr><th>URL</th><th>Reason</th><th>Depth</th></tr></thead>");
+            builder.AppendLine("      <thead><tr><th>URL</th><th>Reason</th><th>Offline</th><th>Depth</th></tr></thead>");
             builder.AppendLine("      <tbody>");
             foreach (HtmlCrawlPage page in skippedContentPages) {
                 builder.AppendLine("        <tr>");
@@ -7495,6 +7683,11 @@ public static class HtmlCrawler {
                 builder.Append("          <td><code>")
                     .Append(HtmlEncode(page.SkipReason.ToString()))
                     .AppendLine("</code></td>");
+                builder.Append("          <td><code>")
+                    .Append(HtmlEncode(page.OfflineReadinessGrade))
+                    .Append("</code> <span class=\"muted\">(")
+                    .Append(HtmlEncode(page.HighestOfflineRiskSeverity))
+                    .AppendLine(")</span></td>");
                 builder.Append("          <td>")
                     .Append(HtmlEncode(page.Depth.ToString(System.Globalization.CultureInfo.InvariantCulture)))
                     .AppendLine("</td>");
@@ -7510,7 +7703,7 @@ public static class HtmlCrawler {
             builder.AppendLine("    <h2>Skipped Assets</h2>");
             builder.AppendLine("    <p class=\"muted\">These URLs were discovered as asset candidates and intentionally not crawled as content pages.</p>");
             builder.AppendLine("    <table>");
-            builder.AppendLine("      <thead><tr><th>URL</th><th>Reason</th><th>Depth</th></tr></thead>");
+            builder.AppendLine("      <thead><tr><th>URL</th><th>Reason</th><th>Offline</th><th>Depth</th></tr></thead>");
             builder.AppendLine("      <tbody>");
             foreach (HtmlCrawlPage page in skippedAssetPages) {
                 builder.AppendLine("        <tr>");
@@ -7522,6 +7715,50 @@ public static class HtmlCrawler {
                 builder.Append("          <td><code>")
                     .Append(HtmlEncode(page.SkipReason.ToString()))
                     .AppendLine("</code></td>");
+                builder.Append("          <td><code>")
+                    .Append(HtmlEncode(page.OfflineReadinessGrade))
+                    .Append("</code> <span class=\"muted\">(")
+                    .Append(HtmlEncode(page.HighestOfflineRiskSeverity))
+                    .AppendLine(")</span></td>");
+                builder.Append("          <td>")
+                    .Append(HtmlEncode(page.Depth.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+                    .AppendLine("</td>");
+                builder.AppendLine("        </tr>");
+            }
+            builder.AppendLine("      </tbody>");
+            builder.AppendLine("    </table>");
+            builder.AppendLine("  </section>");
+        }
+
+        if (result.PendingPages.Count > 0) {
+            builder.AppendLine("  <section>");
+            builder.AppendLine("    <h2>Pending Pages</h2>");
+            builder.AppendLine("    <table>");
+            builder.AppendLine("      <thead><tr><th>URL</th><th>Parent</th><th>Offline</th><th>Depth</th></tr></thead>");
+            builder.AppendLine("      <tbody>");
+            foreach (HtmlCrawlPendingItem page in result.PendingPages.OrderBy(page => page.Depth).ThenBy(page => page.Url, StringComparer.OrdinalIgnoreCase)) {
+                builder.AppendLine("        <tr>");
+                builder.Append("          <td><a href=\"")
+                    .Append(HtmlEncode(page.Url))
+                    .Append("\">")
+                    .Append(HtmlEncode(page.Url))
+                    .AppendLine("</a></td>");
+                builder.Append("          <td>");
+                if (!string.IsNullOrWhiteSpace(page.ParentUrl)) {
+                    builder.Append("<a href=\"")
+                        .Append(HtmlEncode(page.ParentUrl))
+                        .Append("\">")
+                        .Append(HtmlEncode(page.ParentUrl))
+                        .Append("</a>");
+                } else {
+                    builder.Append("&nbsp;");
+                }
+                builder.AppendLine("</td>");
+                builder.Append("          <td><code>")
+                    .Append(HtmlEncode(page.OfflineReadinessGrade))
+                    .Append("</code> <span class=\"muted\">(")
+                    .Append(HtmlEncode(page.HighestOfflineRiskSeverity))
+                    .AppendLine(")</span></td>");
                 builder.Append("          <td>")
                     .Append(HtmlEncode(page.Depth.ToString(System.Globalization.CultureInfo.InvariantCulture)))
                     .AppendLine("</td>");
@@ -7798,6 +8035,7 @@ public static class HtmlCrawler {
 
         try {
             cancellationToken.ThrowIfCancellationRequested();
+            int networkLogStart = session.NetworkLog.Count();
             IResponse? response = await session.Page.GotoAsync(request.Uri.AbsoluteUri, new PageGotoOptions {
                 Timeout = options.Timeout,
                 WaitUntil = WaitUntilState.NetworkIdle
@@ -7819,6 +8057,10 @@ public static class HtmlCrawler {
                 await AutoScrollPageAsync(session.Page, options, cancellationToken).ConfigureAwait(false);
             }
 
+            if (options.HiddenContentMode == HtmlCrawlHiddenContentMode.RespectHidden) {
+                await MarkRenderedHiddenElementsAsync(session.Page).ConfigureAwait(false);
+            }
+
             string fullHtml = await session.Page.ContentAsync().ConfigureAwait(false);
             page.StatusCode = response?.Status;
             page.ContentType = TryGetResponseContentType(response);
@@ -7835,6 +8077,8 @@ public static class HtmlCrawler {
 
             string? title = await session.Page.TitleAsync().ConfigureAwait(false);
             PopulatePageFromHtml(page, fullHtml, request.Uri, options, structuredSchema, title);
+            Uri runtimeDiagnosticsUri = TryGetAbsoluteUri(session.Page.Url, out Uri? renderedUri) ? renderedUri! : request.Uri;
+            MergeOfflineDependencyDiagnostics(page.OfflineDependencyDiagnostics, DetectRenderedNetworkDependencyDiagnostics(session.NetworkLog.Skip(networkLogStart), runtimeDiagnosticsUri));
             return new FetchedPageData {
                 Page = page,
                 RawHtml = fullHtml
@@ -7932,6 +8176,7 @@ public static class HtmlCrawler {
         page.CanonicalUrl = ExtractCanonicalUrl(html, requestUri, options);
         page.Links = ExtractLinks(html, requestUri, options);
         page.AssetUrls = ExtractAssetUrls(html, requestUri, options);
+        page.OfflineDependencyDiagnostics = DetectOfflineDependencyDiagnostics(html);
         ContentSelectionResult contentSelection = SelectContent(html, options);
         string selectedHtml = ApplyContentCleanup(contentSelection.Html, options);
         page.ContentModeUsed = contentSelection.ModeUsed;
@@ -7961,7 +8206,7 @@ public static class HtmlCrawler {
         string markdownBaseUrl = ResolveMarkdownBaseUrl(html, requestUri);
         string selectedText = HtmlParserToText.ConvertToText(PrepareHtmlForTextExtraction(selectedHtml, options));
         string selectedMarkdown = options.IncludeMarkdown || options.IncludeStructuredJson
-            ? ConvertSelectedHtmlToMarkdown(selectedHtml, markdownBaseUrl)
+            ? ConvertSelectedHtmlToMarkdown(selectedHtml, markdownBaseUrl, options)
             : string.Empty;
         page.Html = options.IncludeHtml ? selectedHtml : string.Empty;
         page.Text = options.IncludeText ? selectedText : string.Empty;
@@ -7978,8 +8223,186 @@ public static class HtmlCrawler {
         return GetDocumentBaseUri(document, requestUri).AbsoluteUri;
     }
 
-    private static string ConvertSelectedHtmlToMarkdown(string html, string? pageUrl) {
-        return HtmlMarkdownConverterAdapter.ConvertToMarkdown(html, pageUrl);
+    private static string ConvertSelectedHtmlToMarkdown(string html, string? pageUrl, HtmlCrawlOptions? options = null) {
+        return HtmlMarkdownConverterAdapter.ConvertToMarkdown(
+            html,
+            pageUrl,
+            options?.MarkdownImageMode ?? MarkdownImageRenderingMode.PortableMarkdown,
+            options?.ListingCardMetadataMode ?? HtmlListingCardMetadataMode.SuppressInRepeatedCards);
+    }
+
+    private static IList<HtmlCrawlOfflineDependencyDiagnostic> DetectOfflineDependencyDiagnostics(string html) {
+        if (string.IsNullOrWhiteSpace(html)) {
+            return new List<HtmlCrawlOfflineDependencyDiagnostic>();
+        }
+
+        IDocument document = HtmlParser.ParseWithAngleSharp(html);
+        List<string> scriptBodies = document.QuerySelectorAll("script")
+            .Where(script => string.IsNullOrWhiteSpace(script.GetAttribute("src")))
+            .Select(script => script.TextContent ?? string.Empty)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .ToList();
+        List<string> handlerBodies = document.QuerySelectorAll("*")
+            .SelectMany(element => element.Attributes
+                .Where(attribute => attribute != null
+                    && attribute.Name.StartsWith("on", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(attribute.Value))
+                .Select(attribute => attribute.Value))
+            .ToList();
+        List<string> sources = new(scriptBodies.Count + handlerBodies.Count);
+        sources.AddRange(scriptBodies);
+        sources.AddRange(handlerBodies);
+        if (sources.Count == 0) {
+            return new List<HtmlCrawlOfflineDependencyDiagnostic>();
+        }
+
+        List<HtmlCrawlOfflineDependencyDiagnostic> diagnostics = new();
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "fetch-api", "Inline JavaScript calls fetch(), so the saved page may still require live API responses.", @"(?<![\w$])fetch\s*\(");
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "xml-http-request", "Inline JavaScript uses XMLHttpRequest, so the saved page may still request live network data.", @"\bXMLHttpRequest\b");
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "axios", "Inline JavaScript references axios, which often means the saved page still depends on live HTTP requests.", @"(?<![\w$])axios(?:\s*\(|\s*\.)");
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "websocket", "Inline JavaScript opens a WebSocket connection, so the saved page may still require a live server session.", @"\bWebSocket\s*\(");
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "event-source", "Inline JavaScript opens an EventSource stream, so the saved page may still require live server-sent events.", @"\bEventSource\s*\(");
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "service-worker", "Inline JavaScript references navigator.serviceWorker, which can keep runtime behavior tied to a live browsing context.", @"navigator\s*\.\s*serviceWorker");
+        AddOfflineDependencyDiagnosticIfMatched(diagnostics, sources, "dynamic-import", "Inline JavaScript uses dynamic import(), which can keep additional modules or routes loaded at runtime.", @"(?<![\w$])import\s*\(");
+        return diagnostics;
+    }
+
+    internal static IList<HtmlCrawlOfflineDependencyDiagnostic> DetectRenderedNetworkDependencyDiagnostics(IEnumerable<HtmlNetworkEntry>? entries, Uri pageUri) {
+        List<HtmlCrawlOfflineDependencyDiagnostic> diagnostics = new();
+        if (entries == null) {
+            return diagnostics;
+        }
+
+        bool observedCrossOriginRuntime = false;
+        foreach (HtmlNetworkEntry entry in entries.Where(static entry => entry != null && !string.IsNullOrWhiteSpace(entry.Url))) {
+            string? kind = entry.ResourceType switch {
+                HtmlNetworkResourceType.Fetch => "observed-fetch-api",
+                HtmlNetworkResourceType.XHR => "observed-xml-http-request",
+                HtmlNetworkResourceType.WebSocket => "observed-websocket",
+                HtmlNetworkResourceType.EventSource => "observed-event-source",
+                _ => null
+            };
+            if (kind == null) {
+                continue;
+            }
+
+            string summary = entry.ResourceType switch {
+                HtmlNetworkResourceType.Fetch => "Rendered browsing observed a fetch() request, so the saved page may still depend on live API responses.",
+                HtmlNetworkResourceType.XHR => "Rendered browsing observed an XMLHttpRequest call, so the saved page may still request live network data.",
+                HtmlNetworkResourceType.WebSocket => "Rendered browsing observed a WebSocket connection, so the saved page may still require a live server session.",
+                HtmlNetworkResourceType.EventSource => "Rendered browsing observed a server-sent events stream, so the saved page may still require a live event feed.",
+                _ => string.Empty
+            };
+            AddOfflineDependencyDiagnosticIfMissing(diagnostics, new HtmlCrawlOfflineDependencyDiagnostic {
+                Kind = kind,
+                Severity = GetOfflineDependencySeverity(kind),
+                Summary = summary,
+                Evidence = entry.Url
+            });
+
+            if (!observedCrossOriginRuntime
+                && TryGetAbsoluteUri(entry.Url, out Uri? resourceUri)
+                && !string.Equals(resourceUri!.Host, pageUri.Host, StringComparison.OrdinalIgnoreCase)) {
+                observedCrossOriginRuntime = true;
+                AddOfflineDependencyDiagnosticIfMissing(diagnostics, new HtmlCrawlOfflineDependencyDiagnostic {
+                    Kind = "observed-cross-origin-runtime",
+                    Severity = GetOfflineDependencySeverity("observed-cross-origin-runtime"),
+                    Summary = "Rendered browsing observed runtime network traffic to another host, so the saved page may still depend on live cross-origin services.",
+                    Evidence = entry.Url
+                });
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static void AddOfflineDependencyDiagnosticIfMatched(
+        ICollection<HtmlCrawlOfflineDependencyDiagnostic> diagnostics,
+        IEnumerable<string> sources,
+        string kind,
+        string summary,
+        string pattern) {
+        Regex regex = new(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        foreach (string source in sources) {
+            Match match = regex.Match(source);
+            if (!match.Success) {
+                continue;
+            }
+
+            diagnostics.Add(new HtmlCrawlOfflineDependencyDiagnostic {
+                Kind = kind,
+                Severity = GetOfflineDependencySeverity(kind),
+                Summary = summary,
+                Evidence = ExtractOfflineDependencyEvidence(source, match)
+            });
+            return;
+        }
+    }
+
+    internal static string GetOfflineDependencySeverity(string? kind) => kind?.ToLowerInvariant() switch {
+        "websocket" => "high",
+        "event-source" => "high",
+        "observed-websocket" => "high",
+        "observed-event-source" => "high",
+        "observed-cross-origin-runtime" => "high",
+        _ => "warning"
+    };
+
+    private static void MergeOfflineDependencyDiagnostics(
+        IList<HtmlCrawlOfflineDependencyDiagnostic> target,
+        IEnumerable<HtmlCrawlOfflineDependencyDiagnostic> additions) {
+        if (target == null) {
+            throw new ArgumentNullException(nameof(target));
+        }
+
+        foreach (HtmlCrawlOfflineDependencyDiagnostic diagnostic in additions ?? Enumerable.Empty<HtmlCrawlOfflineDependencyDiagnostic>()) {
+            AddOfflineDependencyDiagnosticIfMissing(target, diagnostic);
+        }
+    }
+
+    private static void AddOfflineDependencyDiagnosticIfMissing(
+        ICollection<HtmlCrawlOfflineDependencyDiagnostic> diagnostics,
+        HtmlCrawlOfflineDependencyDiagnostic? diagnostic) {
+        if (diagnostics == null) {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        if (diagnostic == null || string.IsNullOrWhiteSpace(diagnostic.Kind)) {
+            return;
+        }
+
+        if (diagnostics.Any(existing =>
+                string.Equals(existing.Kind, diagnostic.Kind, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Evidence, diagnostic.Evidence, StringComparison.OrdinalIgnoreCase))) {
+            return;
+        }
+
+        diagnostics.Add(diagnostic);
+    }
+
+    private static string ExtractOfflineDependencyEvidence(string source, Match match) {
+        if (string.IsNullOrWhiteSpace(source) || match == null || !match.Success) {
+            return string.Empty;
+        }
+
+        int start = Math.Max(0, match.Index - 30);
+        int end = Math.Min(source.Length, match.Index + match.Length + 50);
+        string snippet = source.Substring(start, end - start).Replace("\r", " ").Replace("\n", " ").Trim();
+        return Regex.Replace(snippet, @"\s+", " ");
+    }
+
+    private static bool TryGetAbsoluteUri(string? value, out Uri? uri) {
+        if (Uri.TryCreate(value, UriKind.Absolute, out Uri? absoluteUri)
+            && (absoluteUri.Scheme == Uri.UriSchemeHttp
+                || absoluteUri.Scheme == Uri.UriSchemeHttps
+                || string.Equals(absoluteUri.Scheme, "ws", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(absoluteUri.Scheme, "wss", StringComparison.OrdinalIgnoreCase))) {
+            uri = absoluteUri;
+            return true;
+        }
+
+        uri = null;
+        return false;
     }
 
     private static ProfileSelectionDecision ResolveInitialProfileDecision(
@@ -8888,6 +9311,9 @@ public static class HtmlCrawler {
 
         if (LooksLikeFullHtmlDocument(html)) {
             IDocument document = HtmlParser.ParseWithAngleSharp(html);
+            if (options.HiddenContentMode == HtmlCrawlHiddenContentMode.RespectHidden) {
+                RemoveHiddenElements(document);
+            }
             StripBoilerplateElements(document, options);
             RemoveConfiguredElements(document, options);
             return document.DocumentElement?.OuterHtml ?? html;
@@ -8899,6 +9325,9 @@ public static class HtmlCrawler {
             return html;
         }
 
+        if (options.HiddenContentMode == HtmlCrawlHiddenContentMode.RespectHidden) {
+            RemoveHiddenElements(wrapper);
+        }
         StripBoilerplateElements(wrapper, options);
         RemoveConfiguredElements(wrapper, options);
         return wrapper.InnerHtml;
@@ -8916,6 +9345,9 @@ public static class HtmlCrawler {
 
         if (LooksLikeFullHtmlDocument(html)) {
             IDocument document = HtmlParser.ParseWithAngleSharp(html);
+            if (options.HiddenContentMode == HtmlCrawlHiddenContentMode.RespectHidden) {
+                RemoveHiddenElements(document);
+            }
             if (options.SmartContentCleanup) {
                 StripBoilerplateElements(document, options);
             }
@@ -8929,6 +9361,9 @@ public static class HtmlCrawler {
             return html;
         }
 
+        if (options.HiddenContentMode == HtmlCrawlHiddenContentMode.RespectHidden) {
+            RemoveHiddenElements(wrapper);
+        }
         if (options.SmartContentCleanup) {
             StripBoilerplateElements(wrapper, options);
         }
@@ -8936,10 +9371,103 @@ public static class HtmlCrawler {
         return wrapper.InnerHtml;
     }
 
+    private static void RemoveHiddenElements(IParentNode container) {
+        foreach (IElement element in container.QuerySelectorAll("[hidden],[aria-hidden],[style],input[type='hidden'],[data-htmltinkerx-hidden='true']").ToArray()) {
+            if (ShouldRemoveHiddenElement(element)) {
+                element.Remove();
+            }
+        }
+    }
+
+    private static bool ShouldRemoveHiddenElement(IElement element) {
+        if (element == null) {
+            return false;
+        }
+
+        if (element.HasAttribute("hidden")) {
+            return true;
+        }
+
+        if (string.Equals(element.GetAttribute("data-htmltinkerx-hidden"), "true", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (string.Equals(element.GetAttribute("aria-hidden"), "true", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (element.TagName.Equals("INPUT", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(element.GetAttribute("type"), "hidden", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        string? style = element.GetAttribute("style");
+        if (string.IsNullOrWhiteSpace(style)) {
+            return false;
+        }
+
+        string normalizedStyle = Regex.Replace(style, @"\s+", string.Empty).ToLowerInvariant();
+        return normalizedStyle.Contains("display:none", StringComparison.Ordinal)
+               || normalizedStyle.Contains("visibility:hidden", StringComparison.Ordinal)
+               || normalizedStyle.Contains("content-visibility:hidden", StringComparison.Ordinal);
+    }
+
+    private static Task MarkRenderedHiddenElementsAsync(IPage page) {
+        return page.EvaluateAsync(
+            """
+            () => {
+                const hiddenAttributeName = 'data-htmltinkerx-hidden';
+                for (const element of document.querySelectorAll(`[${hiddenAttributeName}]`)) {
+                    element.removeAttribute(hiddenAttributeName);
+                }
+
+                const shouldMarkHidden = (element) => {
+                    if (!(element instanceof Element)) {
+                        return false;
+                    }
+
+                    const tagName = (element.tagName || '').toLowerCase();
+                    if (tagName === 'html' || tagName === 'head' || tagName === 'body') {
+                        return false;
+                    }
+
+                    if (element.hasAttribute('hidden')) {
+                        return true;
+                    }
+
+                    if ((element.getAttribute('aria-hidden') || '').toLowerCase() === 'true') {
+                        return true;
+                    }
+
+                    if (tagName === 'input' && (element.getAttribute('type') || '').toLowerCase() === 'hidden') {
+                        return true;
+                    }
+
+                    const style = window.getComputedStyle(element);
+                    if (!style) {
+                        return false;
+                    }
+
+                    return style.display === 'none'
+                        || style.visibility === 'hidden'
+                        || style.visibility === 'collapse'
+                        || style.contentVisibility === 'hidden';
+                };
+
+                for (const element of document.querySelectorAll('*')) {
+                    if (shouldMarkHidden(element)) {
+                        element.setAttribute(hiddenAttributeName, 'true');
+                    }
+                }
+            }
+            """);
+    }
+
     private static void StripBoilerplateElements(IParentNode container, HtmlCrawlOptions options) {
         foreach (IElement element in container.QuerySelectorAll(
                      "script,style,noscript,svg,header,nav,footer,aside,[role='banner'],[role='navigation'],[role='contentinfo'],[role='search'],form[role='search'],.wpml-ls,.sharing-popup,.post-footer-sharing,.socials-sharing,.gem-pagination,.menu-toggle,.minisearch,.skip-link,.skip-link-screen-reader-text").ToArray()) {
-            if (ShouldPreserveStructuredContentElement(element)) {
+            if (ShouldPreserveStructuredContentElement(element)
+                || ShouldPreserveOfflineExecutableElement(element, options)) {
                 continue;
             }
 
@@ -8963,20 +9491,22 @@ public static class HtmlCrawler {
         return LooksLikeStructuredCalloutElement(element) || LooksLikeMediaNoscriptFallbackElement(element);
     }
 
-    private static bool LooksLikeMediaNoscriptFallbackElement(IElement element) {
-        if (element == null || !element.TagName.Equals("NOSCRIPT", StringComparison.OrdinalIgnoreCase)) {
+    private static bool ShouldPreserveOfflineExecutableElement(IElement element, HtmlCrawlOptions options) {
+        if (element == null || options == null) {
             return false;
         }
 
-        foreach (string html in EnumerateNoscriptHtmlCandidates(element)) {
-            IDocument document = HtmlParser.ParseWithAngleSharp($"<div id=\"__htmltinkerx_noscript_media\">{html}</div>");
-            IElement? wrapper = document.QuerySelector("#__htmltinkerx_noscript_media");
-            if (wrapper?.QuerySelector("img,picture,source") != null) {
-                return true;
-            }
+        if (!options.DownloadAssets || !options.RewriteAssetReferencesToLocal) {
+            return false;
         }
 
-        return false;
+        return element.TagName.Equals("SCRIPT", StringComparison.OrdinalIgnoreCase)
+               || element.TagName.Equals("STYLE", StringComparison.OrdinalIgnoreCase)
+               || element.TagName.Equals("LINK", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeMediaNoscriptFallbackElement(IElement element) {
+        return TryGetNoscriptFallbackWrapper(element, out _);
     }
 
     private static IEnumerable<string> EnumerateNoscriptHtmlCandidates(IElement element) {
@@ -9184,23 +9714,57 @@ public static class HtmlCrawler {
         Uri effectiveBaseUri = GetDocumentBaseUri(document, baseUri);
         HashSet<string> assets = new(StringComparer.OrdinalIgnoreCase);
 
-        foreach (IElement element in document.QuerySelectorAll("img[src], source[src], video[src], audio[src], link[href], a[href], img[srcset], source[srcset], style, [style]")) {
+        CollectAssetUrlsFromContainer(document, effectiveBaseUri, options, assets);
+        foreach (IElement noscript in document.QuerySelectorAll("noscript")) {
+            if (!TryGetNoscriptFallbackWrapper(noscript, out IElement wrapper)) {
+                continue;
+            }
+
+            CollectAssetUrlsFromContainer(wrapper, effectiveBaseUri, options, assets);
+        }
+
+        return assets.ToList();
+    }
+
+    private static void CollectAssetUrlsFromContainer(
+        IParentNode container,
+        Uri effectiveBaseUri,
+        HtmlCrawlOptions options,
+        ISet<string> assets) {
+        foreach (IElement element in container.QuerySelectorAll("img, source, video, audio, track, script, iframe, embed, object[data], link[href], a[href], style, [style]")) {
             switch (element.TagName.ToUpperInvariant()) {
                 case "IMG":
                 case "SOURCE":
                 case "VIDEO":
                 case "AUDIO":
+                case "TRACK":
+                case "SCRIPT":
+                case "IFRAME":
+                case "EMBED":
                     AddAssetCandidate(element.GetAttribute("src"), effectiveBaseUri, options, assets);
-                    foreach (string srcSetCandidate in ExtractSrcSetUrls(element.GetAttribute("srcset"))) {
+                    AddAssetCandidate(element.GetAttribute("data-src"), effectiveBaseUri, options, assets);
+                    AddAssetCandidate(element.GetAttribute("data-lazy-src"), effectiveBaseUri, options, assets);
+                    AddAssetCandidate(element.GetAttribute("data-original-src"), effectiveBaseUri, options, assets);
+                    if (element.TagName.Equals("VIDEO", StringComparison.OrdinalIgnoreCase)) {
+                        AddAssetCandidate(element.GetAttribute("poster"), effectiveBaseUri, options, assets);
+                    }
+                    foreach (string srcSetCandidate in ExtractSrcSetUrls(
+                                 element.GetAttribute("srcset"),
+                                 element.GetAttribute("data-srcset"),
+                                 element.GetAttribute("data-lazy-srcset"),
+                                 element.GetAttribute("data-original-srcset"))) {
                         AddAssetCandidate(srcSetCandidate, effectiveBaseUri, options, assets);
                     }
                     break;
+                case "OBJECT":
+                    AddAssetCandidate(element.GetAttribute("data"), effectiveBaseUri, options, assets);
+                    break;
                 case "LINK":
-                    string rel = element.GetAttribute("rel") ?? string.Empty;
-                    if (rel.IndexOf("icon", StringComparison.OrdinalIgnoreCase) >= 0
-                        || rel.IndexOf("image", StringComparison.OrdinalIgnoreCase) >= 0
-                        || rel.IndexOf("stylesheet", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    if (ShouldTreatLinkAsOfflineAsset(element)) {
                         AddAssetCandidate(element.GetAttribute("href"), effectiveBaseUri, options, assets);
+                        foreach (string srcSetCandidate in ExtractSrcSetUrls(element.GetAttribute("imagesrcset"))) {
+                            AddAssetCandidate(srcSetCandidate, effectiveBaseUri, options, assets);
+                        }
                     }
                     break;
                 case "A":
@@ -9224,8 +9788,6 @@ public static class HtmlCrawler {
                     break;
             }
         }
-
-        return assets.ToList();
     }
 
     private static Dictionary<string, string> BuildLocalPageMap(IEnumerable<HtmlCrawlPage> pages) {
@@ -9313,20 +9875,31 @@ public static class HtmlCrawler {
         IDictionary<string, string> assetMap,
         IDictionary<string, string> localPageMap,
         HtmlCrawlOptions options) {
-        foreach (IElement element in container.QuerySelectorAll("img[src], source[src], video[src], audio[src], link[href], a[href]")) {
+        foreach (IElement element in container.QuerySelectorAll("img, source, video, audio, track, script, iframe, embed, object[data], link[href], a[href]")) {
             switch (element.TagName.ToUpperInvariant()) {
                 case "IMG":
                 case "SOURCE":
                 case "VIDEO":
                 case "AUDIO":
+                case "TRACK":
+                case "SCRIPT":
+                case "IFRAME":
+                case "EMBED":
                     RewriteAssetAttribute(element, "src", resolutionBaseUri, pageHtmlPath, assetMap, options);
+                    RewriteAssetAttribute(element, "data-src", resolutionBaseUri, pageHtmlPath, assetMap, options);
+                    RewriteAssetAttribute(element, "data-lazy-src", resolutionBaseUri, pageHtmlPath, assetMap, options);
+                    RewriteAssetAttribute(element, "data-original-src", resolutionBaseUri, pageHtmlPath, assetMap, options);
+                    if (element.TagName.Equals("VIDEO", StringComparison.OrdinalIgnoreCase)) {
+                        RewriteAssetAttribute(element, "poster", resolutionBaseUri, pageHtmlPath, assetMap, options);
+                    }
+                    break;
+                case "OBJECT":
+                    RewriteAssetAttribute(element, "data", resolutionBaseUri, pageHtmlPath, assetMap, options);
                     break;
                 case "LINK":
-                    string rel = element.GetAttribute("rel") ?? string.Empty;
-                    if (rel.IndexOf("icon", StringComparison.OrdinalIgnoreCase) >= 0
-                        || rel.IndexOf("image", StringComparison.OrdinalIgnoreCase) >= 0
-                        || rel.IndexOf("stylesheet", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    if (ShouldTreatLinkAsOfflineAsset(element)) {
                         RewriteAssetAttribute(element, "href", resolutionBaseUri, pageHtmlPath, assetMap, options);
+                        RewriteSrcSetAttribute(element, "imagesrcset", resolutionBaseUri, pageHtmlPath, assetMap, options);
                     }
                     break;
                 case "A":
@@ -9361,17 +9934,14 @@ public static class HtmlCrawler {
             }
         }
 
-        foreach (IElement element in container.QuerySelectorAll("img[srcset], source[srcset]")) {
-            string? srcSet = element.GetAttribute("srcset");
-            if (string.IsNullOrWhiteSpace(srcSet)) {
-                continue;
-            }
-
-            string rewritten = RewriteSrcSetToLocal(srcSet!, resolutionBaseUri, pageHtmlPath, assetMap, options);
-            if (!string.Equals(rewritten, srcSet, StringComparison.Ordinal)) {
-                element.SetAttribute("srcset", rewritten);
-            }
+        foreach (IElement element in container.QuerySelectorAll("img, source")) {
+            RewriteSrcSetAttribute(element, "srcset", resolutionBaseUri, pageHtmlPath, assetMap, options);
+            RewriteSrcSetAttribute(element, "data-srcset", resolutionBaseUri, pageHtmlPath, assetMap, options);
+            RewriteSrcSetAttribute(element, "data-lazy-srcset", resolutionBaseUri, pageHtmlPath, assetMap, options);
+            RewriteSrcSetAttribute(element, "data-original-srcset", resolutionBaseUri, pageHtmlPath, assetMap, options);
         }
+
+        RewriteNoscriptFallbackReferences(container, resolutionBaseUri, pageHtmlPath, assetMap, localPageMap, options);
     }
 
     private static Uri GetDocumentBaseUri(IParentNode container, Uri fallbackBaseUri) {
@@ -9388,6 +9958,56 @@ public static class HtmlCrawler {
         foreach (IElement baseElement in container.QuerySelectorAll("base[href]").ToArray()) {
             baseElement.Remove();
         }
+    }
+
+    private static void RewriteNoscriptFallbackReferences(
+        IParentNode container,
+        Uri resolutionBaseUri,
+        string pageHtmlPath,
+        IDictionary<string, string> assetMap,
+        IDictionary<string, string> localPageMap,
+        HtmlCrawlOptions options) {
+        foreach (IElement noscript in container.QuerySelectorAll("noscript")) {
+            if (!TryGetNoscriptFallbackWrapper(noscript, out IElement wrapper)) {
+                continue;
+            }
+
+            RewriteStoredReferencesInContainer(wrapper, resolutionBaseUri, pageHtmlPath, assetMap, localPageMap, options);
+            RemoveBaseElements(wrapper);
+            noscript.InnerHtml = wrapper.InnerHtml;
+        }
+    }
+
+    private static bool TryGetNoscriptFallbackWrapper(IElement element, out IElement wrapper) {
+        wrapper = null!;
+        if (element == null || !element.TagName.Equals("NOSCRIPT", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        foreach (string html in EnumerateNoscriptHtmlCandidates(element)) {
+            IDocument document = HtmlParser.ParseWithAngleSharp($"<div id=\"__htmltinkerx_noscript_media\">{html}</div>");
+            IElement? parsedWrapper = document.QuerySelector("#__htmltinkerx_noscript_media");
+            if (parsedWrapper?.QuerySelector("img,picture,source,video,audio") == null) {
+                continue;
+            }
+
+            wrapper = parsedWrapper;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool ShouldTreatLinkAsOfflineAsset(IElement element) {
+        if (element == null || !element.TagName.Equals("LINK", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        string rel = element.GetAttribute("rel") ?? string.Empty;
+        return rel.IndexOf("icon", StringComparison.OrdinalIgnoreCase) >= 0
+               || rel.IndexOf("image", StringComparison.OrdinalIgnoreCase) >= 0
+               || rel.IndexOf("stylesheet", StringComparison.OrdinalIgnoreCase) >= 0
+               || rel.IndexOf("preload", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static void RewriteAssetAttribute(
@@ -9412,6 +10032,24 @@ public static class HtmlCrawler {
         }
 
         element.SetAttribute(attributeName, BuildRelativePath(pageHtmlPath, localPath));
+    }
+
+    private static void RewriteSrcSetAttribute(
+        IElement element,
+        string attributeName,
+        Uri pageUri,
+        string pageHtmlPath,
+        IDictionary<string, string> assetMap,
+        HtmlCrawlOptions options) {
+        string? value = element.GetAttribute(attributeName);
+        if (string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        string rewritten = RewriteSrcSetToLocal(value!, pageUri, pageHtmlPath, assetMap, options);
+        if (!string.Equals(rewritten, value, StringComparison.Ordinal)) {
+            element.SetAttribute(attributeName, rewritten);
+        }
     }
 
     private static void RewritePageAttribute(
@@ -9553,20 +10191,22 @@ public static class HtmlCrawler {
         return BuildRelativePath(pageHtmlPath, localPath);
     }
 
-    private static IEnumerable<string> ExtractSrcSetUrls(string? srcSet) {
-        if (string.IsNullOrWhiteSpace(srcSet)) {
-            yield break;
-        }
-
-        string normalizedSrcSet = srcSet!;
-        foreach (string entry in normalizedSrcSet.Split(',')) {
-            string trimmed = entry.Trim();
-            if (trimmed.Length == 0) {
+    private static IEnumerable<string> ExtractSrcSetUrls(params string?[] srcSets) {
+        foreach (string? srcSet in srcSets) {
+            if (string.IsNullOrWhiteSpace(srcSet)) {
                 continue;
             }
 
-            int separatorIndex = trimmed.IndexOf(' ');
-            yield return separatorIndex > 0 ? trimmed.Substring(0, separatorIndex) : trimmed;
+            string normalizedSrcSet = srcSet!;
+            foreach (string entry in normalizedSrcSet.Split(',')) {
+                string trimmed = entry.Trim();
+                if (trimmed.Length == 0) {
+                    continue;
+                }
+
+                int separatorIndex = trimmed.IndexOf(' ');
+                yield return separatorIndex > 0 ? trimmed.Substring(0, separatorIndex) : trimmed;
+            }
         }
     }
 

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -9412,7 +9412,7 @@ public static class HtmlCrawler {
                || normalizedStyle.Contains("content-visibility:hidden", StringComparison.Ordinal);
     }
 
-    private static Task MarkRenderedHiddenElementsAsync(IPage page) {
+    internal static Task MarkRenderedHiddenElementsAsync(IPage page) {
         return page.EvaluateAsync(
             """
             () => {

--- a/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
+++ b/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
@@ -5,26 +5,40 @@ using OfficeIMO.Markdown.Html;
 namespace HtmlTinkerX;
 
 internal static class HtmlMarkdownConverterAdapter {
-    public static MarkdownDoc ConvertToMarkdownDocument(string html, string? pageUrl) {
+    public static MarkdownDoc ConvertToMarkdownDocument(
+        string html,
+        string? pageUrl,
+        MarkdownImageRenderingMode imageMode = MarkdownImageRenderingMode.PortableMarkdown,
+        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
         if (string.IsNullOrWhiteSpace(html)) {
             return MarkdownDoc.Create();
         }
 
-        var options = CreateOptions(pageUrl);
+        var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode);
         return html.LoadFromHtml(options);
     }
 
-    public static string ConvertToMarkdown(string html, string? pageUrl) {
+    public static string ConvertToMarkdown(
+        string html,
+        string? pageUrl,
+        MarkdownImageRenderingMode imageMode = MarkdownImageRenderingMode.PortableMarkdown,
+        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
         if (string.IsNullOrWhiteSpace(html)) {
             return string.Empty;
         }
 
-        var options = CreateOptions(pageUrl);
+        var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode);
         return html.LoadFromHtml(options).ToMarkdown(options.MarkdownWriteOptions);
     }
 
-    internal static HtmlToMarkdownOptions CreateOptions(string? pageUrl) {
+    internal static HtmlToMarkdownOptions CreateOptions(
+        string? pageUrl,
+        MarkdownImageRenderingMode imageMode = MarkdownImageRenderingMode.PortableMarkdown,
+        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
         var options = HtmlToMarkdownOptions.CreatePortableProfile();
+        options.MarkdownWriteOptions ??= MarkdownWriteOptions.CreatePortableProfile();
+        options.MarkdownWriteOptions.ImageRenderingMode = imageMode;
+        options.ListingCardMetadataMode = listingCardMetadataMode;
         if (!string.IsNullOrWhiteSpace(pageUrl) && Uri.TryCreate(pageUrl, UriKind.Absolute, out var baseUri)) {
             options.BaseUri = baseUri;
         }

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -11,7 +11,7 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OfficeImoMarkdownHtmlVersion>0.1.3</OfficeImoMarkdownHtmlVersion>
+        <OfficeImoMarkdownHtmlVersion>0.1.4</OfficeImoMarkdownHtmlVersion>
         <OfficeImoRepoCandidate1>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\\..\\..\\OfficeIMO\\'))</OfficeImoRepoCandidate1>
         <OfficeImoRepoCandidate2>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\\..\\..\\..\\OfficeIMO\\'))</OfficeImoRepoCandidate2>
         <OfficeImoMarkdownHtmlProjectCandidate1>$([System.IO.Path]::Combine('$(OfficeImoRepoCandidate1)', 'OfficeIMO.Markdown.Html', 'OfficeIMO.Markdown.Html.csproj'))</OfficeImoMarkdownHtmlProjectCandidate1>

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlHiddenContentMode.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlHiddenContentMode.cs
@@ -1,0 +1,16 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Controls whether extraction keeps or removes obviously hidden DOM content.
+/// </summary>
+public enum HtmlCrawlHiddenContentMode {
+    /// <summary>
+    /// Remove content hidden through explicit DOM attributes or inline styles.
+    /// </summary>
+    RespectHidden = 0,
+
+    /// <summary>
+    /// Keep hidden DOM content in extracted HTML, text, and markdown.
+    /// </summary>
+    IncludeHidden = 1
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlOfflineDependencyDiagnostic.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlOfflineDependencyDiagnostic.cs
@@ -1,0 +1,18 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Records a likely runtime dependency that may keep a saved page from working fully offline.
+/// </summary>
+public sealed class HtmlCrawlOfflineDependencyDiagnostic {
+    /// <summary>Machine-friendly category of the detected runtime dependency.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>Severity label for the diagnostic.</summary>
+    public string Severity { get; set; } = "warning";
+
+    /// <summary>Human-readable explanation of why this page may still depend on live runtime behavior.</summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Short evidence snippet captured from the page markup or inline script.</summary>
+    public string? Evidence { get; set; }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlOptions.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlOptions.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
 
 namespace HtmlTinkerX;
 
@@ -87,6 +89,16 @@ public sealed class HtmlCrawlOptions {
     /// <summary>Stores Markdown converted from the selected page content in the result.</summary>
     public bool IncludeMarkdown { get; set; }
 
+    /// <summary>
+    /// Controls how images are emitted when selected HTML is converted to markdown.
+    /// </summary>
+    public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
+
+    /// <summary>
+    /// Controls whether low-value metadata inside repeated listing cards should be preserved or suppressed in markdown output.
+    /// </summary>
+    public HtmlListingCardMetadataMode ListingCardMetadataMode { get; set; } = HtmlListingCardMetadataMode.SuppressInRepeatedCards;
+
     /// <summary>Stores structured JSON-friendly page data extracted from the crawl.</summary>
     public bool IncludeStructuredJson { get; set; }
 
@@ -125,6 +137,11 @@ public sealed class HtmlCrawlOptions {
 
     /// <summary>When true, applies conservative cleanup heuristics to remove low-value boilerplate inside the selected content area.</summary>
     public bool SmartContentCleanup { get; set; } = true;
+
+    /// <summary>
+    /// Controls whether extraction should respect or include obviously hidden DOM content.
+    /// </summary>
+    public HtmlCrawlHiddenContentMode HiddenContentMode { get; set; } = HtmlCrawlHiddenContentMode.RespectHidden;
 
     /// <summary>Optional selectors to click once on rendered pages before extraction.</summary>
     public IList<string> ClickSelectors { get; set; } = new List<string>();
@@ -309,6 +326,8 @@ public sealed class HtmlCrawlOptions {
             IncludeHtml = IncludeHtml,
             IncludeText = IncludeText,
             IncludeMarkdown = IncludeMarkdown,
+            MarkdownImageMode = MarkdownImageMode,
+            ListingCardMetadataMode = ListingCardMetadataMode,
             IncludeStructuredJson = IncludeStructuredJson,
             StructuredJsonPreset = StructuredJsonPreset,
             StructuredJsonSchema = StructuredJsonSchema,
@@ -322,6 +341,7 @@ public sealed class HtmlCrawlOptions {
             ExcludeClasses = new List<string>(ExcludeClasses),
             ExcludeIds = new List<string>(ExcludeIds),
             SmartContentCleanup = SmartContentCleanup,
+            HiddenContentMode = HiddenContentMode,
             ClickSelectors = new List<string>(ClickSelectors),
             ClickTexts = new List<string>(ClickTexts),
             DismissSelectors = new List<string>(DismissSelectors),

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlPage.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlPage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HtmlTinkerX;
 
@@ -75,6 +76,56 @@ public sealed class HtmlCrawlPage {
 
     /// <summary>Discovered asset URLs referenced from the page.</summary>
     public IList<string> AssetUrls { get; set; } = new List<string>();
+
+    /// <summary>Likely runtime dependencies that may still require live network behavior even after assets are mirrored locally.</summary>
+    public IList<HtmlCrawlOfflineDependencyDiagnostic> OfflineDependencyDiagnostics { get; set; } = new List<HtmlCrawlOfflineDependencyDiagnostic>();
+
+    /// <summary>Count of recorded offline-runtime dependency diagnostics for this page.</summary>
+    public int OfflineDependencyDiagnosticCount => OfflineDependencyDiagnostics.Count;
+
+    /// <summary>Distinct offline-runtime dependency kinds recorded for this page.</summary>
+    public IList<string> OfflineDependencyKinds => OfflineDependencyDiagnostics
+        .Where(diagnostic => !string.IsNullOrWhiteSpace(diagnostic?.Kind))
+        .Select(diagnostic => diagnostic.Kind!.Trim())
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(kind => kind, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    /// <summary>Compact summary of distinct offline-runtime dependency kinds for this page.</summary>
+    public string OfflineDependencyKindsSummary => string.Join(", ", OfflineDependencyKinds);
+
+    /// <summary>Overall offline readiness grade for this page derived from its runtime-risk diagnostics.</summary>
+    public string OfflineReadinessGrade {
+        get {
+            if (Status != HtmlCrawlPageStatus.Success) {
+                return "not-assessed";
+            }
+
+            if (OfflineDependencyDiagnostics.Count == 0) {
+                return "ready";
+            }
+
+            return string.Equals(HighestOfflineRiskSeverity, "high", StringComparison.OrdinalIgnoreCase)
+                ? "live-dependent"
+                : "partial";
+        }
+    }
+
+    /// <summary>Highest offline-runtime risk severity recorded for this page.</summary>
+    public string HighestOfflineRiskSeverity {
+        get {
+            if (Status != HtmlCrawlPageStatus.Success) {
+                return "none";
+            }
+
+            string? highestSeverity = OfflineDependencyDiagnostics
+                .Select(ResolveOfflineSeverity)
+                .OrderByDescending(GetSeverityRank)
+                .ThenBy(severity => severity, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            return string.IsNullOrWhiteSpace(highestSeverity) ? "none" : highestSeverity!;
+        }
+    }
 
     /// <summary>Rendered interactions that were successfully applied before extraction.</summary>
     public IList<string> AppliedInteractions { get; set; } = new List<string>();
@@ -168,4 +219,18 @@ public sealed class HtmlCrawlPage {
 
     /// <summary>Total fetch duration.</summary>
     public TimeSpan Duration => Finished - Started;
+
+    private static string ResolveOfflineSeverity(HtmlCrawlOfflineDependencyDiagnostic diagnostic) {
+        string inferredSeverity = HtmlCrawler.GetOfflineDependencySeverity(diagnostic?.Kind);
+        string explicitSeverity = string.IsNullOrWhiteSpace(diagnostic?.Severity) ? inferredSeverity : diagnostic!.Severity!;
+        return string.Equals(inferredSeverity, "high", StringComparison.OrdinalIgnoreCase)
+            ? "high"
+            : explicitSeverity;
+    }
+
+    private static int GetSeverityRank(string? severity) => severity?.ToLowerInvariant() switch {
+        "high" => 2,
+        "warning" => 1,
+        _ => 0
+    };
 }

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlPendingItem.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlPendingItem.cs
@@ -12,4 +12,16 @@ public sealed class HtmlCrawlPendingItem {
 
     /// <summary>Depth at which the candidate will be crawled.</summary>
     public int Depth { get; set; }
+
+    /// <summary>Offline readiness grade for pending candidates, which have not been assessed yet.</summary>
+    public string OfflineReadinessGrade { get; set; } = "not-assessed";
+
+    /// <summary>Highest offline-runtime risk severity for pending candidates, which have not been assessed yet.</summary>
+    public string HighestOfflineRiskSeverity { get; set; } = "none";
+
+    /// <summary>Count of recorded offline-runtime dependency diagnostics for pending candidates, which have not been assessed yet.</summary>
+    public int OfflineDependencyDiagnosticCount { get; set; }
+
+    /// <summary>Compact summary of distinct offline-runtime dependency kinds for pending candidates, which have not been assessed yet.</summary>
+    public string OfflineDependencyKindsSummary { get; set; } = string.Empty;
 }

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlResult.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
 
 namespace HtmlTinkerX;
 
@@ -43,6 +45,21 @@ public sealed class HtmlCrawlResult {
 
     /// <summary>Explains why the applied crawl profile was selected.</summary>
     public string? AppliedProfileReason { get; set; }
+
+    /// <summary>Whether full browser rendering was enabled for the crawl.</summary>
+    public bool RenderEnabled { get; set; }
+
+    /// <summary>Whether auto-render fallback was enabled for the crawl.</summary>
+    public bool AutoRenderEnabled { get; set; }
+
+    /// <summary>Controls whether extraction respects or includes hidden DOM content.</summary>
+    public HtmlCrawlHiddenContentMode HiddenContentMode { get; set; } = HtmlCrawlHiddenContentMode.RespectHidden;
+
+    /// <summary>Controls how images are emitted when page HTML is converted to markdown.</summary>
+    public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
+
+    /// <summary>Controls whether low-value metadata inside repeated listing cards is preserved or suppressed in markdown output.</summary>
+    public HtmlListingCardMetadataMode ListingCardMetadataMode { get; set; } = HtmlListingCardMetadataMode.SuppressInRepeatedCards;
 
     /// <summary>Manifest path used when crawl artifacts were persisted.</summary>
     public string? ManifestPath { get; set; }

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlSummary.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlSummary.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
 
 namespace HtmlTinkerX;
 
@@ -198,19 +200,82 @@ public sealed class HtmlCrawlSummary {
     /// <summary>Total discovered outbound links across fetched pages.</summary>
     public int TotalDiscoveredLinks { get; set; }
 
+    /// <summary>Number of fetched pages that still show likely offline runtime risk signals.</summary>
+    public int OfflineRiskPageCount { get; set; }
+
+    /// <summary>Total number of offline runtime risk diagnostics recorded across fetched pages.</summary>
+    public int OfflineRiskDiagnosticCount { get; set; }
+
+    /// <summary>Number of fetched pages with at least one high-severity offline runtime risk diagnostic.</summary>
+    public int HighOfflineRiskPageCount { get; set; }
+
+    /// <summary>Counts of offline runtime risk diagnostics by kind.</summary>
+    public IDictionary<string, int> OfflineDependencyKinds { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Counts of offline runtime risk diagnostics by severity.</summary>
+    public IDictionary<string, int> OfflineDependencySeverityCounts { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Overall offline readiness grade derived from the recorded runtime-risk diagnostics.</summary>
+    public string OfflineReadinessGrade { get; set; } = "ready";
+
+    /// <summary>Counts of offline readiness grades across all fetched, skipped, failed, and pending candidates.</summary>
+    public IDictionary<string, int> OfflineReadinessCounts { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Counts of offline readiness grades grouped by candidate state, for example <c>Success:ready</c>.</summary>
+    public IDictionary<string, int> OfflineReadinessCountsByState { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Counts of skipped pages by reason.</summary>
     public IDictionary<string, int> SkipReasons { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Counts of fetched pages by HTTP status code.</summary>
     public IDictionary<string, int> StatusCodes { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Whether full browser rendering was enabled for the crawl.</summary>
+    public bool RenderEnabled { get; set; }
+
+    /// <summary>Whether auto-render fallback was enabled for the crawl.</summary>
+    public bool AutoRenderEnabled { get; set; }
+
+    /// <summary>Controls whether extraction respects or includes hidden DOM content.</summary>
+    public HtmlCrawlHiddenContentMode HiddenContentMode { get; set; } = HtmlCrawlHiddenContentMode.RespectHidden;
+
+    /// <summary>Controls how images are emitted when page HTML is converted to markdown.</summary>
+    public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
+
+    /// <summary>Controls whether low-value metadata inside repeated listing cards is preserved or suppressed in markdown output.</summary>
+    public HtmlListingCardMetadataMode ListingCardMetadataMode { get; set; } = HtmlListingCardMetadataMode.SuppressInRepeatedCards;
+
+    /// <summary>Optional crawl guidance notes derived from the run configuration and observed behavior.</summary>
+    public IList<string> GuidanceNotes { get; set; } = new List<string>();
+
     internal static HtmlCrawlSummary FromResult(HtmlCrawlResult result) {
+        static string ResolveOfflineSeverity(HtmlCrawlOfflineDependencyDiagnostic diagnostic) {
+            string inferredSeverity = HtmlCrawler.GetOfflineDependencySeverity(diagnostic?.Kind);
+            string explicitSeverity = string.IsNullOrWhiteSpace(diagnostic?.Severity) ? inferredSeverity : diagnostic!.Severity!;
+            return string.Equals(inferredSeverity, "high", StringComparison.OrdinalIgnoreCase)
+                ? "high"
+                : explicitSeverity;
+        }
+
+        static void Increment(IDictionary<string, int> counts, string key) {
+            if (counts.TryGetValue(key, out int existing)) {
+                counts[key] = existing + 1;
+            } else {
+                counts[key] = 1;
+            }
+        }
+
         var summary = new HtmlCrawlSummary {
             StartUrl = result.StartUrl,
             AppliedProfileName = result.AppliedProfileName,
             AppliedScenario = result.AppliedScenario,
             AppliedProfileReasonCode = result.AppliedProfileReasonCode,
             AppliedProfileReason = result.AppliedProfileReason,
+            RenderEnabled = result.RenderEnabled,
+            AutoRenderEnabled = result.AutoRenderEnabled,
+            HiddenContentMode = result.HiddenContentMode,
+            MarkdownImageMode = result.MarkdownImageMode,
+            ListingCardMetadataMode = result.ListingCardMetadataMode,
             PageCount = result.Pages.Count,
             SuccessfulPageCount = result.Pages.Count(page => page.Status == HtmlCrawlPageStatus.Success),
             FailedPageCount = result.Pages.Count(page => page.Status == HtmlCrawlPageStatus.Failed),
@@ -249,7 +314,10 @@ public sealed class HtmlCrawlSummary {
             StructuredCalloutCount = result.Pages.Sum(page => page.StructuredJson?.Callouts.Count ?? 0),
             StructuredPrimaryActionCount = result.Pages.Sum(page => page.StructuredJson?.PrimaryActions.Count ?? 0),
             DurationMs = result.Finished > result.Started ? (long)(result.Finished - result.Started).TotalMilliseconds : 0,
-            TotalDiscoveredLinks = result.Pages.Sum(page => page.Links?.Count ?? 0)
+            TotalDiscoveredLinks = result.Pages.Sum(page => page.Links?.Count ?? 0),
+            OfflineRiskPageCount = result.Pages.Count(page => page.OfflineDependencyDiagnostics.Count > 0),
+            OfflineRiskDiagnosticCount = result.Pages.Sum(page => page.OfflineDependencyDiagnostics.Count),
+            HighOfflineRiskPageCount = result.Pages.Count(page => page.OfflineDependencyDiagnostics.Any(diagnostic => string.Equals(ResolveOfflineSeverity(diagnostic), "high", StringComparison.OrdinalIgnoreCase)))
         };
 
         summary.ChunkCount = result.ChunkCount > 0
@@ -312,6 +380,49 @@ public sealed class HtmlCrawlSummary {
 
         foreach (var group in result.Pages.Where(page => page.StatusCode.HasValue).GroupBy(page => page.StatusCode!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparer.OrdinalIgnoreCase)) {
             summary.StatusCodes[group.Key] = group.Count();
+        }
+        foreach (var group in result.Pages
+            .SelectMany(page => page.OfflineDependencyDiagnostics)
+            .Where(diagnostic => !string.IsNullOrWhiteSpace(diagnostic.Kind))
+            .GroupBy(diagnostic => diagnostic.Kind, StringComparer.OrdinalIgnoreCase)) {
+            summary.OfflineDependencyKinds[group.Key] = group.Count();
+        }
+        foreach (var group in result.Pages
+            .SelectMany(page => page.OfflineDependencyDiagnostics)
+            .Select(ResolveOfflineSeverity)
+            .GroupBy(severity => severity, StringComparer.OrdinalIgnoreCase)) {
+            summary.OfflineDependencySeverityCounts[group.Key] = group.Count();
+        }
+        summary.OfflineReadinessGrade = summary.HighOfflineRiskPageCount > 0
+            ? "live-dependent"
+            : summary.OfflineRiskDiagnosticCount > 0
+                ? "partial"
+                : "ready";
+        foreach (HtmlCrawlPage page in result.Pages) {
+            Increment(summary.OfflineReadinessCounts, page.OfflineReadinessGrade);
+            Increment(summary.OfflineReadinessCountsByState, $"{page.Status}:{page.OfflineReadinessGrade}");
+        }
+        foreach (HtmlCrawlPage page in result.SkippedPages) {
+            Increment(summary.OfflineReadinessCounts, page.OfflineReadinessGrade);
+            Increment(summary.OfflineReadinessCountsByState, $"{page.Status}:{page.OfflineReadinessGrade}");
+        }
+        foreach (HtmlCrawlPendingItem page in result.PendingPages) {
+            Increment(summary.OfflineReadinessCounts, page.OfflineReadinessGrade);
+            Increment(summary.OfflineReadinessCountsByState, $"Pending:{page.OfflineReadinessGrade}");
+        }
+
+        if (summary.HiddenContentMode == HtmlCrawlHiddenContentMode.RespectHidden
+            && !summary.RenderEnabled
+            && !summary.AutoRenderEnabled) {
+            summary.GuidanceNotes.Add("Hidden-content filtering ran in static mode. Elements hidden only by external CSS may still require rendering to be excluded.");
+        }
+
+        if (summary.MarkdownImageMode == MarkdownImageRenderingMode.PortableMarkdown) {
+            summary.GuidanceNotes.Add("Markdown images used portable output. Image size hints stay in HTML/manifests unless a richer markdown mode is selected.");
+        }
+
+        if (summary.ListingCardMetadataMode == HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
+            summary.GuidanceNotes.Add("Repeated listing-card chrome like date/time/byline/read-more blocks was suppressed in markdown output. Switch the listing-card metadata mode to Preserve when you want raw teaser metadata retained.");
         }
 
         return summary;
@@ -380,8 +491,21 @@ public sealed class HtmlCrawlSummary {
         report.AppendLine($"Skipped graph nodes: {GraphSkippedNodeCount}");
         report.AppendLine($"External graph nodes: {GraphExternalNodeCount}");
         report.AppendLine($"Discovered links: {TotalDiscoveredLinks}");
+        report.AppendLine($"Offline-risk pages: {OfflineRiskPageCount}");
+        report.AppendLine($"Offline-risk diagnostics: {OfflineRiskDiagnosticCount}");
+        report.AppendLine($"High offline-risk pages: {HighOfflineRiskPageCount}");
+        report.AppendLine($"Offline readiness grade: {OfflineReadinessGrade}");
+        report.AppendLine($"Hidden-content mode: {HiddenContentMode}");
+        report.AppendLine($"Markdown image mode: {MarkdownImageMode}");
+        report.AppendLine($"Listing-card metadata mode: {ListingCardMetadataMode}");
         report.AppendLine($"Pages with interactions: {InteractedPageCount}");
         report.AppendLine($"Applied interactions: {InteractionCount}");
+        if (GuidanceNotes.Count > 0) {
+            report.AppendLine("Guidance:");
+            foreach (string note in GuidanceNotes.Where(note => !string.IsNullOrWhiteSpace(note))) {
+                report.AppendLine($"- {note}");
+            }
+        }
         report.AppendLine($"Duration: {DurationMs} ms");
 
         if (RenderModeCounts.Count > 0 || RenderReasonCounts.Count > 0) {
@@ -420,6 +544,23 @@ public sealed class HtmlCrawlSummary {
             report.AppendLine("Interaction summary:");
             foreach (var item in InteractionCounts.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
                 report.AppendLine($"- {item.Key}: {item.Value}");
+            }
+        }
+
+        if (OfflineDependencyKinds.Count > 0) {
+            report.AppendLine();
+            report.AppendLine("Offline readiness:");
+            foreach (var item in OfflineReadinessCounts.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                report.AppendLine($"- Offline grade {item.Key}: {item.Value}");
+            }
+            foreach (var item in OfflineReadinessCountsByState.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                report.AppendLine($"- Offline state {item.Key}: {item.Value}");
+            }
+            foreach (var item in OfflineDependencySeverityCounts.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                report.AppendLine($"- Offline severity {item.Key}: {item.Value}");
+            }
+            foreach (var item in OfflineDependencyKinds.OrderByDescending(item => item.Value).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
+                report.AppendLine($"- Offline dependency {item.Key}: {item.Value}");
             }
         }
 

--- a/Sources/HtmlTinkerX/Models/HtmlNetworkEntry.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlNetworkEntry.cs
@@ -15,6 +15,9 @@ public sealed class HtmlNetworkEntry {
     /// <summary>Request headers.</summary>
     public IDictionary<string, string> RequestHeaders { get; set; } = new Dictionary<string, string>();
 
+    /// <summary>Browser-reported resource type when available.</summary>
+    public HtmlNetworkResourceType ResourceType { get; set; } = HtmlNetworkResourceType.Other;
+
     /// <summary>Response status code.</summary>
     public System.Net.HttpStatusCode? Status { get; set; }
 

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -123,6 +123,7 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
                 Url = req.Url,
                 Method = HtmlEnumParser.ParseHttpMethod(req.Method),
                 RequestHeaders = new Dictionary<string, string>(req.Headers),
+                ResourceType = HtmlEnumParser.ParseNetworkResourceType(req.ResourceType),
                 Started = System.DateTimeOffset.UtcNow
             };
 
@@ -140,6 +141,7 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
                 Url = r.Url,
                 Method = HtmlEnumParser.ParseHttpMethod(r.Method),
                 RequestHeaders = new Dictionary<string, string>(r.Headers),
+                ResourceType = HtmlEnumParser.ParseNetworkResourceType(r.ResourceType),
                 Started = System.DateTimeOffset.UtcNow
             });
             entry.Status = (System.Net.HttpStatusCode)res.Status;

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserTester.cs
@@ -293,24 +293,7 @@ public static class HtmlBrowserTester {
     }
     
     private static HtmlNetworkResourceType DetermineResourceType(IRequest request) {
-        var url = request.Url.ToLowerInvariant();
-        var resourceType = request.ResourceType.ToLowerInvariant();
-        
-        return resourceType switch {
-            "document" => HtmlNetworkResourceType.Document,
-            "stylesheet" => HtmlNetworkResourceType.Stylesheet,
-            "image" => HtmlNetworkResourceType.Image,
-            "media" => HtmlNetworkResourceType.Media,
-            "font" => HtmlNetworkResourceType.Font,
-            "script" => HtmlNetworkResourceType.Script,
-            "texttrack" => HtmlNetworkResourceType.TextTrack,
-            "xhr" => HtmlNetworkResourceType.XHR,
-            "fetch" => HtmlNetworkResourceType.Fetch,
-            "eventsource" => HtmlNetworkResourceType.EventSource,
-            "websocket" => HtmlNetworkResourceType.WebSocket,
-            "manifest" => HtmlNetworkResourceType.Manifest,
-            _ => HtmlNetworkResourceType.Other
-        };
+        return HtmlEnumParser.ParseNetworkResourceType(request.ResourceType);
     }
     
     private static HtmlNetworkErrorType ParseNetworkError(string? error) {

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlCrawl.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlCrawl.cs
@@ -1,4 +1,6 @@
 using HtmlTinkerX;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
@@ -158,6 +160,10 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
     /// <summary>Disable the built-in cleanup heuristics that remove low-value boilerplate inside extracted content.</summary>
     [Parameter]
     public SwitchParameter DisableSmartContentCleanup { get; set; }
+
+    /// <summary>Controls whether extraction should respect or include hidden DOM content. Static crawls only detect explicit DOM-hidden markers; use Render or AutoRender when you need stylesheet-hidden content filtered by computed visibility.</summary>
+    [Parameter]
+    public HtmlCrawlHiddenContentMode HiddenContentMode { get; set; } = HtmlCrawlHiddenContentMode.RespectHidden;
 
     /// <summary>Optional selectors to click once on rendered pages before extraction.</summary>
     [Parameter]
@@ -331,6 +337,14 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter IncludeMarkdown { get; set; }
 
+    /// <summary>Controls how images are emitted when selected HTML is converted to markdown. Use PortableMarkdown for broad renderer compatibility, RichMarkdown for OfficeIMO-style size suffixes, or Html for exact width and height fidelity.</summary>
+    [Parameter]
+    public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
+
+    /// <summary>Controls whether low-value metadata inside repeated listing cards should be preserved or suppressed in markdown output.</summary>
+    [Parameter]
+    public HtmlListingCardMetadataMode ListingCardMetadataMode { get; set; } = HtmlListingCardMetadataMode.SuppressInRepeatedCards;
+
     /// <summary>Include structured JSON-friendly data extracted from each crawled page.</summary>
     [Parameter]
     public SwitchParameter IncludeStructuredJson { get; set; }
@@ -399,6 +413,8 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
             IncludeHtml = IncludeHtml.IsPresent,
             IncludeText = IncludeText.IsPresent,
             IncludeMarkdown = IncludeMarkdown.IsPresent,
+            MarkdownImageMode = MarkdownImageMode,
+            ListingCardMetadataMode = ListingCardMetadataMode,
             IncludeStructuredJson = IncludeStructuredJson.IsPresent,
             StructuredJsonPreset = StructuredJsonPreset,
             StructuredJsonSchema = StructuredJsonSchema,
@@ -412,6 +428,7 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
             ExcludeClasses = new List<string>(ExcludeClass),
             ExcludeIds = new List<string>(ExcludeId),
             SmartContentCleanup = !DisableSmartContentCleanup.IsPresent,
+            HiddenContentMode = HiddenContentMode,
             ClickSelectors = new List<string>(ClickSelector),
             ClickTexts = new List<string>(ClickText),
             DismissSelectors = new List<string>(DismissSelector),


### PR DESCRIPTION
## Summary
- expose portable, rich, and HTML markdown image modes through crawl options and PowerShell
- add hidden-content modes, computed-hidden filtering for rendered crawls, and summary guidance
- improve offline mirroring and runtime offline-risk diagnostics across crawl exports
- add listing-card metadata controls so repeated date/time/byline/read-more chrome can be suppressed by default in crawl markdown

## Verification
- dotnet test C:/Support/GitHub/PSParseHTML/Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --filter "FullyQualifiedName~HtmlCrawlerMarkdownTests|FullyQualifiedName~HtmlCrawlerTests.CrawlAsync_SummaryAndIndex_ExposeHiddenContentAndMarkdownGuidance|FullyQualifiedName~HtmlCrawlerTests.HtmlCrawlOptions_CloneAndClearSensitiveData_WorkIndependently" -m:1
- Passed 36/36 on net472 and net8.0
- Live evotec.xyz homepage crawl verified repeated card chrome is removed while image, title, and summary content remain

## Upstream
- Converter/library PR: EvotecIT/OfficeIMO (paired PR)