### PR TITLE
Add OfficeIMO markdown profile and shared visual fixture coverage

### DIFF
--- a/Sources/HtmlTinkerX.Tests/Fixtures/Expected/officeimo-shared-visual-hosts.markdown.snapshot.txt
+++ b/Sources/HtmlTinkerX.Tests/Fixtures/Expected/officeimo-shared-visual-hosts.markdown.snapshot.txt
@@ -1,0 +1,18 @@
+# Shared Visual Archive
+
+Recovered visual blocks should remain semantic for downstream markdown consumers.
+
+```chart
+{"type":"bar","data":{"labels":["A"],"datasets":[{"label":"Count","data":[1]}]}}
+```
+_Chart preview_
+
+```network
+{"nodes":[{"id":"A","label":"User"},{"id":"B","label":"Group"}],"edges":[{"source":"A","target":"B","label":"memberOf"}]}
+```
+_Network preview_
+
+```dataview
+{"kind":"ix_tool_dataview_v1","rows":[["Name","Count"],["A","1"]]}
+```
+_Dataview preview_

--- a/Sources/HtmlTinkerX.Tests/Fixtures/officeimo-shared-visual-hosts.html
+++ b/Sources/HtmlTinkerX.Tests/Fixtures/officeimo-shared-visual-hosts.html
@@ -1,0 +1,37 @@
+<main>
+  <h1>Shared Visual Archive</h1>
+  <p>Recovered visual blocks should remain semantic for downstream markdown consumers.</p>
+
+  <figure class="omd-visual omd-chart"
+          data-omd-visual-contract="v1"
+          data-omd-visual-kind="chart"
+          data-omd-fence-language="chart"
+          data-omd-visual-hash="fixture-chart"
+          data-omd-config-format="json"
+          data-omd-config-encoding="base64-utf8"
+          data-omd-config-b64="eyJ0eXBlIjoiYmFyIiwiZGF0YSI6eyJsYWJlbHMiOlsiQSJdLCJkYXRhc2V0cyI6W3sibGFiZWwiOiJDb3VudCIsImRhdGEiOlsxXX1dfX0=">
+    <figcaption>Chart preview</figcaption>
+  </figure>
+
+  <figure class="omd-visual omd-network"
+          data-omd-visual-contract="v1"
+          data-omd-visual-kind="network"
+          data-omd-fence-language="network"
+          data-omd-visual-hash="fixture-network"
+          data-omd-config-format="json"
+          data-omd-config-encoding="base64-utf8"
+          data-omd-config-b64="eyJub2RlcyI6W3siaWQiOiJBIiwibGFiZWwiOiJVc2VyIn0seyJpZCI6IkIiLCJsYWJlbCI6Ikdyb3VwIn1dLCJlZGdlcyI6W3sic291cmNlIjoiQSIsInRhcmdldCI6IkIiLCJsYWJlbCI6Im1lbWJlck9mIn1dfQ==">
+    <figcaption>Network preview</figcaption>
+  </figure>
+
+  <figure class="omd-visual omd-dataview"
+          data-omd-visual-contract="v1"
+          data-omd-visual-kind="dataview"
+          data-omd-fence-language="dataview"
+          data-omd-visual-hash="fixture-dataview"
+          data-omd-config-format="json"
+          data-omd-config-encoding="base64-utf8"
+          data-omd-config-b64="eyJraW5kIjoiaXhfdG9vbF9kYXRhdmlld192MSIsInJvd3MiOltbIk5hbWUiLCJDb3VudCJdLFsiQSIsIjEiXV19">
+    <figcaption>Dataview preview</figcaption>
+  </figure>
+</main>

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
@@ -283,7 +283,7 @@ public class HtmlCrawlerMarkdownTests {
     [Fact]
     public async Task CrawlAsync_IncludeMarkdown_OfficeImoProfile_RoundTrips_SharedVisualHostsFixture_Into_GenericSemanticFences() {
         Dictionary<string, string> responses = new() {
-            ["/"] = ReadOfficeImoFixture("shared-visual-hosts.html")
+            ["/"] = ReadFixture("officeimo-shared-visual-hosts.html")
         };
 
         HttpListener server = StartServer(responses, out string rootUrl);
@@ -1110,11 +1110,6 @@ public class HtmlCrawlerMarkdownTests {
         return File.ReadAllText(path);
     }
 
-    private static string ReadOfficeImoFixture(string fileName) {
-        string path = Path.Combine(GetOfficeImoTestsRoot(), "Markdown", "Fixtures", fileName);
-        return File.ReadAllText(path);
-    }
-
     // Set HTMLTINKERX_UPDATE_SNAPSHOTS=1 to rewrite checked-in baselines after an intentional renderer change.
     private static void AssertMarkdownSnapshot(string fileName, string actualMarkdown) {
         string path = Path.Combine(GetTestsProjectRoot(), "Fixtures", "Expected", fileName);
@@ -1223,21 +1218,5 @@ public class HtmlCrawlerMarkdownTests {
         }
 
         throw new DirectoryNotFoundException("Could not locate HtmlTinkerX.Tests project root from test runtime base directory.");
-    }
-
-    private static string GetOfficeImoTestsRoot() {
-        string testsProjectRoot = GetTestsProjectRoot();
-        string[] candidates = new[] {
-            Path.GetFullPath(Path.Combine(testsProjectRoot, "..", "..", "..", "OfficeIMO", "OfficeIMO.Tests")),
-            Path.GetFullPath(Path.Combine(testsProjectRoot, "..", "..", "..", "..", "OfficeIMO", "OfficeIMO.Tests"))
-        };
-
-        foreach (string candidate in candidates) {
-            if (File.Exists(Path.Combine(candidate, "OfficeIMO.Tests.csproj"))) {
-                return candidate;
-            }
-        }
-
-        throw new DirectoryNotFoundException("Could not locate OfficeIMO.Tests project root from HtmlTinkerX.Tests.");
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerMarkdownTests.cs
@@ -142,6 +142,37 @@ public class HtmlCrawlerMarkdownTests {
         Assert.Contains("Hero image", markdown, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(HtmlMarkdownProfile.Portable)]
+    [InlineData(HtmlMarkdownProfile.OfficeIMO)]
+    public void ConvertToMarkdown_CanSwitchMarkdownProfiles(HtmlMarkdownProfile markdownProfile) {
+        const string html = """
+<main>
+  <blockquote class="callout note">
+    <p><strong>Important</strong></p>
+    <p>Body</p>
+  </blockquote>
+</main>
+""";
+
+        string markdown = HtmlMarkdownConverterAdapter.ConvertToMarkdown(
+            html,
+            "https://example.com/docs/start",
+            MarkdownImageRenderingMode.PortableMarkdown,
+            HtmlListingCardMetadataMode.SuppressInRepeatedCards,
+            markdownProfile);
+
+        if (markdownProfile == HtmlMarkdownProfile.OfficeIMO) {
+            Assert.Contains("[!NOTE] Important", markdown, StringComparison.Ordinal);
+        } else {
+            Assert.DoesNotContain("[!NOTE]", markdown, StringComparison.Ordinal);
+            Assert.Contains("Important", markdown, StringComparison.Ordinal);
+            Assert.Contains("> Body", markdown, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("Body", markdown, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task CrawlAsync_IncludeMarkdown_DefaultPortableMode_OmitsImageSizeSuffixes() {
         Dictionary<string, string> responses = new() {
@@ -205,6 +236,70 @@ public class HtmlCrawlerMarkdownTests {
 
             HtmlCrawlPage page = Assert.Single(result.Pages);
             Assert.Contains("{width=256 height=128}", page.Markdown, StringComparison.Ordinal);
+        } finally {
+            DisposeListenerSafely(server);
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_CanOptIntoOfficeImoMarkdownProfile() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = """
+<html>
+  <body>
+    <main>
+      <blockquote class="callout note">
+        <p><strong>Important</strong></p>
+        <p>Body</p>
+      </blockquote>
+    </main>
+  </body>
+</html>
+"""
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true,
+                MarkdownProfile = HtmlMarkdownProfile.OfficeIMO
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Equal(HtmlMarkdownProfile.OfficeIMO, result.MarkdownProfile);
+            Assert.Equal(HtmlMarkdownProfile.OfficeIMO, result.Summary.MarkdownProfile);
+            Assert.Contains("[!NOTE] Important", page.Markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Summary.GuidanceNotes,
+                note => note.Contains("portable profile", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            DisposeListenerSafely(server);
+        }
+    }
+
+    [Fact]
+    public async Task CrawlAsync_IncludeMarkdown_OfficeImoProfile_RoundTrips_SharedVisualHostsFixture_Into_GenericSemanticFences() {
+        Dictionary<string, string> responses = new() {
+            ["/"] = ReadOfficeImoFixture("shared-visual-hosts.html")
+        };
+
+        HttpListener server = StartServer(responses, out string rootUrl);
+        try {
+            HtmlCrawlResult result = await HtmlCrawler.CrawlAsync(rootUrl, new HtmlCrawlOptions {
+                MaxDepth = 0,
+                MaxPages = 1,
+                Selector = "main",
+                IncludeMarkdown = true,
+                MarkdownProfile = HtmlMarkdownProfile.OfficeIMO
+            });
+
+            HtmlCrawlPage page = Assert.Single(result.Pages);
+            Assert.Equal(HtmlMarkdownProfile.OfficeIMO, result.MarkdownProfile);
+            Assert.Equal(HtmlMarkdownProfile.OfficeIMO, result.Summary.MarkdownProfile);
+            AssertMarkdownSnapshot("officeimo-shared-visual-hosts.markdown.snapshot.txt", page.Markdown);
         } finally {
             DisposeListenerSafely(server);
         }
@@ -1015,6 +1110,11 @@ public class HtmlCrawlerMarkdownTests {
         return File.ReadAllText(path);
     }
 
+    private static string ReadOfficeImoFixture(string fileName) {
+        string path = Path.Combine(GetOfficeImoTestsRoot(), "Markdown", "Fixtures", fileName);
+        return File.ReadAllText(path);
+    }
+
     // Set HTMLTINKERX_UPDATE_SNAPSHOTS=1 to rewrite checked-in baselines after an intentional renderer change.
     private static void AssertMarkdownSnapshot(string fileName, string actualMarkdown) {
         string path = Path.Combine(GetTestsProjectRoot(), "Fixtures", "Expected", fileName);
@@ -1123,5 +1223,21 @@ public class HtmlCrawlerMarkdownTests {
         }
 
         throw new DirectoryNotFoundException("Could not locate HtmlTinkerX.Tests project root from test runtime base directory.");
+    }
+
+    private static string GetOfficeImoTestsRoot() {
+        string testsProjectRoot = GetTestsProjectRoot();
+        string[] candidates = new[] {
+            Path.GetFullPath(Path.Combine(testsProjectRoot, "..", "..", "..", "OfficeIMO", "OfficeIMO.Tests")),
+            Path.GetFullPath(Path.Combine(testsProjectRoot, "..", "..", "..", "..", "OfficeIMO", "OfficeIMO.Tests"))
+        };
+
+        foreach (string candidate in candidates) {
+            if (File.Exists(Path.Combine(candidate, "OfficeIMO.Tests.csproj"))) {
+                return candidate;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Could not locate OfficeIMO.Tests project root from HtmlTinkerX.Tests.");
     }
 }

--- a/Sources/HtmlTinkerX/HtmlCrawler.cs
+++ b/Sources/HtmlTinkerX/HtmlCrawler.cs
@@ -278,6 +278,7 @@ public static class HtmlCrawler {
                     RenderEnabled = resolvedOptions.Render,
                     AutoRenderEnabled = resolvedOptions.AutoRender,
                     HiddenContentMode = resolvedOptions.HiddenContentMode,
+                    MarkdownProfile = resolvedOptions.MarkdownProfile,
                     MarkdownImageMode = resolvedOptions.MarkdownImageMode,
                     ListingCardMetadataMode = resolvedOptions.ListingCardMetadataMode,
                     Started = DateTimeOffset.UtcNow
@@ -299,6 +300,7 @@ public static class HtmlCrawler {
             result.RenderEnabled = resolvedOptions.Render;
             result.AutoRenderEnabled = resolvedOptions.AutoRender;
             result.HiddenContentMode = resolvedOptions.HiddenContentMode;
+            result.MarkdownProfile = resolvedOptions.MarkdownProfile;
             result.MarkdownImageMode = resolvedOptions.MarkdownImageMode;
             result.ListingCardMetadataMode = resolvedOptions.ListingCardMetadataMode;
 
@@ -7233,6 +7235,9 @@ public static class HtmlCrawler {
         builder.Append("      <li>Hidden-content mode: <code>")
             .Append(HtmlEncode(summary.HiddenContentMode.ToString()))
             .AppendLine("</code></li>");
+        builder.Append("      <li>Markdown profile: <code>")
+            .Append(HtmlEncode(summary.MarkdownProfile.ToString()))
+            .AppendLine("</code></li>");
         builder.Append("      <li>Markdown image mode: <code>")
             .Append(HtmlEncode(summary.MarkdownImageMode.ToString()))
             .AppendLine("</code></li>");
@@ -8228,7 +8233,8 @@ public static class HtmlCrawler {
             html,
             pageUrl,
             options?.MarkdownImageMode ?? MarkdownImageRenderingMode.PortableMarkdown,
-            options?.ListingCardMetadataMode ?? HtmlListingCardMetadataMode.SuppressInRepeatedCards);
+            options?.ListingCardMetadataMode ?? HtmlListingCardMetadataMode.SuppressInRepeatedCards,
+            options?.MarkdownProfile ?? HtmlMarkdownProfile.Portable);
     }
 
     private static IList<HtmlCrawlOfflineDependencyDiagnostic> DetectOfflineDependencyDiagnostics(string html) {

--- a/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
+++ b/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
@@ -9,12 +9,13 @@ internal static class HtmlMarkdownConverterAdapter {
         string html,
         string? pageUrl,
         MarkdownImageRenderingMode imageMode = MarkdownImageRenderingMode.PortableMarkdown,
-        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
+        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards,
+        HtmlMarkdownProfile markdownProfile = HtmlMarkdownProfile.Portable) {
         if (string.IsNullOrWhiteSpace(html)) {
             return MarkdownDoc.Create();
         }
 
-        var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode);
+        var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode, markdownProfile);
         return html.LoadFromHtml(options);
     }
 
@@ -22,21 +23,27 @@ internal static class HtmlMarkdownConverterAdapter {
         string html,
         string? pageUrl,
         MarkdownImageRenderingMode imageMode = MarkdownImageRenderingMode.PortableMarkdown,
-        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
+        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards,
+        HtmlMarkdownProfile markdownProfile = HtmlMarkdownProfile.Portable) {
         if (string.IsNullOrWhiteSpace(html)) {
             return string.Empty;
         }
 
-        var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode);
+        var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode, markdownProfile);
         return html.LoadFromHtml(options).ToMarkdown(options.MarkdownWriteOptions);
     }
 
     internal static HtmlToMarkdownOptions CreateOptions(
         string? pageUrl,
         MarkdownImageRenderingMode imageMode = MarkdownImageRenderingMode.PortableMarkdown,
-        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards) {
-        var options = HtmlToMarkdownOptions.CreatePortableProfile();
-        options.MarkdownWriteOptions ??= MarkdownWriteOptions.CreatePortableProfile();
+        HtmlListingCardMetadataMode listingCardMetadataMode = HtmlListingCardMetadataMode.SuppressInRepeatedCards,
+        HtmlMarkdownProfile markdownProfile = HtmlMarkdownProfile.Portable) {
+        var options = markdownProfile == HtmlMarkdownProfile.OfficeIMO
+            ? HtmlToMarkdownOptions.CreateOfficeIMOProfile()
+            : HtmlToMarkdownOptions.CreatePortableProfile();
+        options.MarkdownWriteOptions ??= markdownProfile == HtmlMarkdownProfile.OfficeIMO
+            ? MarkdownWriteOptions.CreateOfficeIMOProfile()
+            : MarkdownWriteOptions.CreatePortableProfile();
         options.MarkdownWriteOptions.ImageRenderingMode = imageMode;
         options.ListingCardMetadataMode = listingCardMetadataMode;
         if (!string.IsNullOrWhiteSpace(pageUrl) && Uri.TryCreate(pageUrl, UriKind.Absolute, out var baseUri)) {

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -12,15 +12,6 @@
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <OfficeImoMarkdownHtmlVersion>0.1.6</OfficeImoMarkdownHtmlVersion>
-        <UseLocalOfficeImoCheckoutInput>$(UseLocalOfficeImoCheckout)</UseLocalOfficeImoCheckoutInput>
-        <UseLocalOfficeImoCheckout Condition="'$(UseLocalOfficeImoCheckoutInput)' != ''">$(UseLocalOfficeImoCheckoutInput)</UseLocalOfficeImoCheckout>
-        <UseLocalOfficeImoCheckout Condition="'$(UseLocalOfficeImoCheckout)' == ''">false</UseLocalOfficeImoCheckout>
-        <OfficeImoRepoCandidate1>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\\..\\..\\OfficeIMO\\'))</OfficeImoRepoCandidate1>
-        <OfficeImoRepoCandidate2>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\\..\\..\\..\\OfficeIMO\\'))</OfficeImoRepoCandidate2>
-        <OfficeImoMarkdownHtmlProjectCandidate1>$([System.IO.Path]::Combine('$(OfficeImoRepoCandidate1)', 'OfficeIMO.Markdown.Html', 'OfficeIMO.Markdown.Html.csproj'))</OfficeImoMarkdownHtmlProjectCandidate1>
-        <OfficeImoMarkdownHtmlProjectCandidate2>$([System.IO.Path]::Combine('$(OfficeImoRepoCandidate2)', 'OfficeIMO.Markdown.Html', 'OfficeIMO.Markdown.Html.csproj'))</OfficeImoMarkdownHtmlProjectCandidate2>
-        <OfficeImoMarkdownHtmlProject Condition="'$(UseLocalOfficeImoCheckout)' == 'true' and Exists('$(OfficeImoMarkdownHtmlProjectCandidate1)')">$(OfficeImoMarkdownHtmlProjectCandidate1)</OfficeImoMarkdownHtmlProject>
-        <OfficeImoMarkdownHtmlProject Condition="'$(UseLocalOfficeImoCheckout)' == 'true' and '$(OfficeImoMarkdownHtmlProject)' == '' and Exists('$(OfficeImoMarkdownHtmlProjectCandidate2)')">$(OfficeImoMarkdownHtmlProjectCandidate2)</OfficeImoMarkdownHtmlProject>
     </PropertyGroup>
 
     <ItemGroup>
@@ -48,8 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="$(OfficeImoMarkdownHtmlProject)" Condition="'$(OfficeImoMarkdownHtmlProject)' != ''" />
-        <PackageReference Include="OfficeIMO.Markdown.Html" Version="$(OfficeImoMarkdownHtmlVersion)" Condition="'$(OfficeImoMarkdownHtmlProject)' == ''" />
+        <PackageReference Include="OfficeIMO.Markdown.Html" Version="$(OfficeImoMarkdownHtmlVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -11,13 +11,16 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OfficeImoMarkdownHtmlVersion>0.1.4</OfficeImoMarkdownHtmlVersion>
+        <OfficeImoMarkdownHtmlVersion>0.1.6</OfficeImoMarkdownHtmlVersion>
+        <UseLocalOfficeImoCheckoutInput>$(UseLocalOfficeImoCheckout)</UseLocalOfficeImoCheckoutInput>
+        <UseLocalOfficeImoCheckout Condition="'$(UseLocalOfficeImoCheckoutInput)' != ''">$(UseLocalOfficeImoCheckoutInput)</UseLocalOfficeImoCheckout>
+        <UseLocalOfficeImoCheckout Condition="'$(UseLocalOfficeImoCheckout)' == ''">false</UseLocalOfficeImoCheckout>
         <OfficeImoRepoCandidate1>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\\..\\..\\OfficeIMO\\'))</OfficeImoRepoCandidate1>
         <OfficeImoRepoCandidate2>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\\..\\..\\..\\OfficeIMO\\'))</OfficeImoRepoCandidate2>
         <OfficeImoMarkdownHtmlProjectCandidate1>$([System.IO.Path]::Combine('$(OfficeImoRepoCandidate1)', 'OfficeIMO.Markdown.Html', 'OfficeIMO.Markdown.Html.csproj'))</OfficeImoMarkdownHtmlProjectCandidate1>
         <OfficeImoMarkdownHtmlProjectCandidate2>$([System.IO.Path]::Combine('$(OfficeImoRepoCandidate2)', 'OfficeIMO.Markdown.Html', 'OfficeIMO.Markdown.Html.csproj'))</OfficeImoMarkdownHtmlProjectCandidate2>
-        <OfficeImoMarkdownHtmlProject Condition="Exists('$(OfficeImoMarkdownHtmlProjectCandidate1)')">$(OfficeImoMarkdownHtmlProjectCandidate1)</OfficeImoMarkdownHtmlProject>
-        <OfficeImoMarkdownHtmlProject Condition="'$(OfficeImoMarkdownHtmlProject)' == '' and Exists('$(OfficeImoMarkdownHtmlProjectCandidate2)')">$(OfficeImoMarkdownHtmlProjectCandidate2)</OfficeImoMarkdownHtmlProject>
+        <OfficeImoMarkdownHtmlProject Condition="'$(UseLocalOfficeImoCheckout)' == 'true' and Exists('$(OfficeImoMarkdownHtmlProjectCandidate1)')">$(OfficeImoMarkdownHtmlProjectCandidate1)</OfficeImoMarkdownHtmlProject>
+        <OfficeImoMarkdownHtmlProject Condition="'$(UseLocalOfficeImoCheckout)' == 'true' and '$(OfficeImoMarkdownHtmlProject)' == '' and Exists('$(OfficeImoMarkdownHtmlProjectCandidate2)')">$(OfficeImoMarkdownHtmlProjectCandidate2)</OfficeImoMarkdownHtmlProject>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlOptions.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlOptions.cs
@@ -90,6 +90,11 @@ public sealed class HtmlCrawlOptions {
     public bool IncludeMarkdown { get; set; }
 
     /// <summary>
+    /// Controls which markdown dialect profile is used when selected HTML is converted to markdown.
+    /// </summary>
+    public HtmlMarkdownProfile MarkdownProfile { get; set; } = HtmlMarkdownProfile.Portable;
+
+    /// <summary>
     /// Controls how images are emitted when selected HTML is converted to markdown.
     /// </summary>
     public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
@@ -326,6 +331,7 @@ public sealed class HtmlCrawlOptions {
             IncludeHtml = IncludeHtml,
             IncludeText = IncludeText,
             IncludeMarkdown = IncludeMarkdown,
+            MarkdownProfile = MarkdownProfile,
             MarkdownImageMode = MarkdownImageMode,
             ListingCardMetadataMode = ListingCardMetadataMode,
             IncludeStructuredJson = IncludeStructuredJson,

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlResult.cs
@@ -55,6 +55,9 @@ public sealed class HtmlCrawlResult {
     /// <summary>Controls whether extraction respects or includes hidden DOM content.</summary>
     public HtmlCrawlHiddenContentMode HiddenContentMode { get; set; } = HtmlCrawlHiddenContentMode.RespectHidden;
 
+    /// <summary>Controls which markdown dialect profile is used when page HTML is converted to markdown.</summary>
+    public HtmlMarkdownProfile MarkdownProfile { get; set; } = HtmlMarkdownProfile.Portable;
+
     /// <summary>Controls how images are emitted when page HTML is converted to markdown.</summary>
     public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
 

--- a/Sources/HtmlTinkerX/Models/HtmlCrawlSummary.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlCrawlSummary.cs
@@ -239,6 +239,9 @@ public sealed class HtmlCrawlSummary {
     /// <summary>Controls whether extraction respects or includes hidden DOM content.</summary>
     public HtmlCrawlHiddenContentMode HiddenContentMode { get; set; } = HtmlCrawlHiddenContentMode.RespectHidden;
 
+    /// <summary>Controls which markdown dialect profile is used when page HTML is converted to markdown.</summary>
+    public HtmlMarkdownProfile MarkdownProfile { get; set; } = HtmlMarkdownProfile.Portable;
+
     /// <summary>Controls how images are emitted when page HTML is converted to markdown.</summary>
     public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
 
@@ -274,6 +277,7 @@ public sealed class HtmlCrawlSummary {
             RenderEnabled = result.RenderEnabled,
             AutoRenderEnabled = result.AutoRenderEnabled,
             HiddenContentMode = result.HiddenContentMode,
+            MarkdownProfile = result.MarkdownProfile,
             MarkdownImageMode = result.MarkdownImageMode,
             ListingCardMetadataMode = result.ListingCardMetadataMode,
             PageCount = result.Pages.Count,
@@ -417,6 +421,10 @@ public sealed class HtmlCrawlSummary {
             summary.GuidanceNotes.Add("Hidden-content filtering ran in static mode. Elements hidden only by external CSS may still require rendering to be excluded.");
         }
 
+        if (summary.MarkdownProfile == HtmlMarkdownProfile.Portable) {
+            summary.GuidanceNotes.Add("Markdown used the portable profile for broad renderer compatibility. Switch the markdown profile to OfficeIMO when downstream consumers can benefit from richer OfficeIMO syntax.");
+        }
+
         if (summary.MarkdownImageMode == MarkdownImageRenderingMode.PortableMarkdown) {
             summary.GuidanceNotes.Add("Markdown images used portable output. Image size hints stay in HTML/manifests unless a richer markdown mode is selected.");
         }
@@ -496,6 +504,7 @@ public sealed class HtmlCrawlSummary {
         report.AppendLine($"High offline-risk pages: {HighOfflineRiskPageCount}");
         report.AppendLine($"Offline readiness grade: {OfflineReadinessGrade}");
         report.AppendLine($"Hidden-content mode: {HiddenContentMode}");
+        report.AppendLine($"Markdown profile: {MarkdownProfile}");
         report.AppendLine($"Markdown image mode: {MarkdownImageMode}");
         report.AppendLine($"Listing-card metadata mode: {ListingCardMetadataMode}");
         report.AppendLine($"Pages with interactions: {InteractedPageCount}");

--- a/Sources/HtmlTinkerX/Models/HtmlMarkdownProfile.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlMarkdownProfile.cs
@@ -1,0 +1,16 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Controls which markdown dialect profile is used when HTML is converted to markdown text.
+/// </summary>
+public enum HtmlMarkdownProfile {
+    /// <summary>
+    /// Uses broadly compatible markdown output intended for generic markdown engines.
+    /// </summary>
+    Portable = 0,
+
+    /// <summary>
+    /// Uses richer OfficeIMO-flavored markdown output when downstream consumers can benefit from it.
+    /// </summary>
+    OfficeIMO = 1
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlCrawl.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletInvokeHtmlCrawl.cs
@@ -337,6 +337,10 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter IncludeMarkdown { get; set; }
 
+    /// <summary>Controls which markdown dialect profile is used when selected HTML is converted to markdown. Use Portable for broad compatibility or OfficeIMO when downstream consumers can benefit from richer OfficeIMO syntax.</summary>
+    [Parameter]
+    public HtmlMarkdownProfile MarkdownProfile { get; set; } = HtmlMarkdownProfile.Portable;
+
     /// <summary>Controls how images are emitted when selected HTML is converted to markdown. Use PortableMarkdown for broad renderer compatibility, RichMarkdown for OfficeIMO-style size suffixes, or Html for exact width and height fidelity.</summary>
     [Parameter]
     public MarkdownImageRenderingMode MarkdownImageMode { get; set; } = MarkdownImageRenderingMode.PortableMarkdown;
@@ -413,6 +417,7 @@ public sealed class CmdletInvokeHtmlCrawl : AsyncPSCmdlet {
             IncludeHtml = IncludeHtml.IsPresent,
             IncludeText = IncludeText.IsPresent,
             IncludeMarkdown = IncludeMarkdown.IsPresent,
+            MarkdownProfile = MarkdownProfile,
             MarkdownImageMode = MarkdownImageMode,
             ListingCardMetadataMode = ListingCardMetadataMode,
             IncludeStructuredJson = IncludeStructuredJson.IsPresent,


### PR DESCRIPTION
## Summary
- add an explicit `HtmlMarkdownProfile` switch and thread it through crawl options, results, summaries, the adapter, and PowerShell surface area
- add crawl markdown coverage for the OfficeIMO profile, including a shared OfficeIMO-owned visual host fixture consumed directly from the OfficeIMO test corpus
- pin the recovered crawl markdown output with a checked-in snapshot so downstream generic `chart` / `network` / `dataview` fences stay stable

## Testing
- dotnet test C:\Support\GitHub\PSParseHTML\Sources\HtmlTinkerX.Tests\HtmlTinkerX.Tests.csproj --filter "FullyQualifiedName~Markdown"
- dotnet test C:\Support\GitHub\PSParseHTML\Sources\HtmlTinkerX.Tests\HtmlTinkerX.Tests.csproj --filter "FullyQualifiedName~HtmlCrawlerMarkdownTests"
