### PR TITLE
Enable module-scoped ALC loading

### DIFF
--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -98,6 +98,51 @@ jobs:
         run: .\PSParseHTML.Tests.ps1
         timeout-minutes: 10
 
+  test-windows-packaged-alc:
+    needs: refresh-psd1
+    name: 'Windows Packaged ALC conflict'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install PowerShell modules
+        shell: pwsh
+        run: |
+          Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+          Install-Module -Name TextMate -Repository PSGallery -RequiredVersion 0.2.1 -Force -SkipPublisherCheck -AllowClobber
+          Install-Module -Name PwshSpectreConsole -Repository PSGallery -RequiredVersion 2.6.3 -Force -SkipPublisherCheck -AllowClobber
+
+      - name: Build packaged module
+        shell: pwsh
+        env:
+          RefreshPSD1Only: 'false'
+        run: .\Build\Build-Module.ps1
+        timeout-minutes: 15
+
+      - name: Run packaged ALC conflict smoke test
+        shell: pwsh
+        run: |
+          $config = [PesterConfiguration]::Default
+          $config.Run.Path = 'Tests/AssemblyLoadContext.Conflict.Tests.ps1'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+        timeout-minutes: 5
+
   test-ubuntu:
     needs: refresh-psd1
     name: 'Ubuntu PowerShell 7'

--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Run packaged ALC conflict smoke test
         shell: pwsh
         run: |
+          Import-Module Pester -Force
           $config = [PesterConfiguration]::Default
           $config.Run.Path = 'Tests/AssemblyLoadContext.Conflict.Tests.ps1'
           $config.Run.Exit = $true

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -83,9 +83,23 @@ Build-Module -ModuleName 'PSParseHTML' {
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
     $refreshPSD1Only = $false
-    if ($Env:RefreshPSD1Only) {
-        $refreshPSD1Only = [System.Convert]::ToBoolean($Env:RefreshPSD1Only)
+    if (-not [string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) {
+        switch -Regex ($Env:RefreshPSD1Only.Trim()) {
+            '^(1|true|yes|on)$' {
+                $refreshPSD1Only = $true
+                break
+            }
+            '^(0|false|no|off)$' {
+                $refreshPSD1Only = $false
+                break
+            }
+            default {
+                throw "RefreshPSD1Only must be a boolean value or numeric flag, but received '$Env:RefreshPSD1Only'."
+            }
+        }
     }
+
+    $netProjectPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj')).Path
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
@@ -97,16 +111,19 @@ Build-Module -ModuleName 'PSParseHTML' {
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSParseHTML.PowerShell'
         NETProjectName                    = 'PSParseHTML.PowerShell'
-        NETProjectPath                    = 'Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj'
+        NETProjectPath                    = $netProjectPath
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
-        NETAssemblyLoadContext            = $true
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
         RefreshPSD1Only                   = $refreshPSD1Only
         NETBinaryModuleDocumentation      = $true
+    }
+
+    if (-not $refreshPSD1Only) {
+        $newConfigurationBuildSplat.NETAssemblyLoadContext = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -82,6 +82,11 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
+    $refreshPSD1Only = $false
+    if ($Env:RefreshPSD1Only) {
+        $refreshPSD1Only = [System.Convert]::ToBoolean($Env:RefreshPSD1Only)
+    }
+
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         # lets sign module only on my machine for now
@@ -92,13 +97,15 @@ Build-Module -ModuleName 'PSParseHTML' {
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSParseHTML.PowerShell'
         NETProjectName                    = 'PSParseHTML.PowerShell'
+        NETProjectPath                    = 'Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj'
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
+        NETAssemblyLoadContext            = $true
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = $refreshPSD1Only
         NETBinaryModuleDocumentation      = $true
     }
 

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -99,8 +99,6 @@ Build-Module -ModuleName 'PSParseHTML' {
         }
     }
 
-    $netProjectPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj')).Path
-
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         # lets sign module only on my machine for now
@@ -111,7 +109,6 @@ Build-Module -ModuleName 'PSParseHTML' {
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSParseHTML.PowerShell'
         NETProjectName                    = 'PSParseHTML.PowerShell'
-        NETProjectPath                    = $netProjectPath
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
@@ -123,6 +120,7 @@ Build-Module -ModuleName 'PSParseHTML' {
     }
 
     if (-not $refreshPSD1Only) {
+        $newConfigurationBuildSplat.NETProjectPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj')).Path
         $newConfigurationBuildSplat.NETAssemblyLoadContext = $true
     }
 

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,4 +1,4 @@
-Import-Module PSPublishModule -MinimumVersion 3.0.4 -Force -ErrorAction Stop
+Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'PSParseHTML' {
     # Usual defaults as per standard module
@@ -82,7 +82,7 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
-    $refreshPSD1Only = $false
+    $refreshPSD1Only = $true
     if (-not [string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) {
         switch -Regex ($Env:RefreshPSD1Only.Trim()) {
             '^(1|true|yes|on)$' {

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,4 +1,4 @@
-Import-Module PSPublishModule -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.4 -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'PSParseHTML' {
     # Usual defaults as per standard module

--- a/Sources/HtmlTinkerX.Tests/EncodingDebugTest.cs
+++ b/Sources/HtmlTinkerX.Tests/EncodingDebugTest.cs
@@ -20,8 +20,9 @@ public class EncodingDebugTest
     [Fact]
     public async Task DebugPolishEncodingIssue()
     {
-        var url = "https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm";
-        using var client = new HttpClient();
+        using var server = PolishEncodingFixture.CreateServer();
+        using var client = PolishEncodingFixture.CreateClient(server);
+        var url = "/polish";
         
         // Test with GetStringWithProperEncodingAsync
         var content = await HtmlUtilities.GetStringWithProperEncodingAsync(client, url);

--- a/Sources/HtmlTinkerX.Tests/HtmlAgilityPackEncodingTest.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlAgilityPackEncodingTest.cs
@@ -18,8 +18,9 @@ public class HtmlAgilityPackEncodingTest
     [Fact]
     public async Task TestHtmlAgilityPackEncodingIssue()
     {
-        var url = "https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm";
-        using var client = new HttpClient();
+        using var server = PolishEncodingFixture.CreateServer();
+        using var client = PolishEncodingFixture.CreateClient(server);
+        var url = "/polish";
         
         // Download with proper encoding
         var content = await HtmlUtilities.GetStringWithProperEncodingAsync(client, url);

--- a/Sources/HtmlTinkerX.Tests/HtmlParserTableAdvancedTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlParserTableAdvancedTests.cs
@@ -105,10 +105,11 @@ public class HtmlParserTableAdvancedTests {
 //         // The test relies on external URL encoding detection which behaves differently in .NET Framework
 //         return;
 // #else
-        // This test validates our encoding fix for URL downloads
-        var url = "https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm";
+        // This test validates our encoding fix for URL downloads without depending on an external site.
+        using var server = PolishEncodingFixture.CreateServer();
+        using var client = PolishEncodingFixture.CreateClient(server);
+        var url = "/polish";
 
-        using var client = new HttpClient();
         var doc = await HtmlParser.ParseUrlWithHtmlAgilityPackAsync(url, client);
         var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(doc.DocumentNode.OuterHtml, false, null, null, false, false, false, null);
 

--- a/Sources/HtmlTinkerX.Tests/PolishEncodingFixture.cs
+++ b/Sources/HtmlTinkerX.Tests/PolishEncodingFixture.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.TestHost;
+using System;
+using System.Net.Http;
+using System.Text;
+
+namespace HtmlTinkerX.Tests;
+
+internal static class PolishEncodingFixture {
+    private const string Html = @"<!doctype html>
+<html>
+<head>
+    <meta http-equiv=""Content-Type"" content=""text/html; charset=iso-8859-2"">
+    <title>Polish table encoding fixture</title>
+</head>
+<body>
+    <table><tr><td>Ignored 0</td></tr></table>
+    <table><tr><td>Ignored 1</td></tr></table>
+    <table><tr><td>Ignored 2</td></tr></table>
+    <table><tr><td>Ignored 3</td></tr></table>
+    <table><tr><td>Ignored 4</td></tr></table>
+    <table><tr><td>Ignored 5</td></tr></table>
+    <table><tr><td>Ignored 6</td></tr></table>
+    <table><tr><td>Ignored 7</td></tr></table>
+    <table><tr><td>Ignored 8</td></tr></table>
+    <table><tr><td>Ignored 9</td></tr></table>
+    <table><tr><td>Ignored 10</td></tr></table>
+    <table><tr><td>Ignored 11</td></tr></table>
+    <table>
+        <tr><td>Komórka a1</td><td>Komórka a2</td></tr>
+        <tr><td>Komórka a3</td><td>Komórka a4</td></tr>
+    </table>
+</body>
+</html>";
+
+    public static TestServer CreateServer() {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var bytes = Encoding.GetEncoding("iso-8859-2").GetBytes(Html);
+        return TestServerCompat.CreateTestServer(async context => {
+            context.Response.ContentType = "text/html; charset=iso-8859-2";
+            await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+        }, "/polish", "GET");
+    }
+
+    public static HttpClient CreateClient(TestServer server) {
+        var client = server.CreateClient();
+        client.BaseAddress = new Uri("http://localhost");
+        return client;
+    }
+}

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -24,6 +24,7 @@
         <PackageReference Include="PreMailer.Net" Version="2.7.2" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" Condition=" '$(TargetFramework)' != 'net472' " />
         <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
         <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />

--- a/Sources/HtmlTinkerX/HtmlUtilities.cs
+++ b/Sources/HtmlTinkerX/HtmlUtilities.cs
@@ -12,6 +12,13 @@ namespace HtmlTinkerX;
 public static class HtmlUtilities {
     private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex TagWhitespaceRegex = new(@">\s+<", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    static HtmlUtilities() {
+#if !NETFRAMEWORK
+        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+#endif
+    }
+
     /// <summary>
     /// Resolves the provided path to an absolute file system path.
     /// Environment variables are expanded and relative paths are

--- a/Sources/HtmlTinkerX/HtmlUtilities.cs
+++ b/Sources/HtmlTinkerX/HtmlUtilities.cs
@@ -12,12 +12,9 @@ namespace HtmlTinkerX;
 public static class HtmlUtilities {
     private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex TagWhitespaceRegex = new(@">\s+<", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    static HtmlUtilities() {
 #if !NETFRAMEWORK
-        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+    private static int CodePagesEncodingProviderRegistered;
 #endif
-    }
 
     /// <summary>
     /// Resolves the provided path to an absolute file system path.
@@ -112,7 +109,7 @@ public static class HtmlUtilities {
         if (contentType?.CharSet != null) {
             try {
                 string charset = contentType.CharSet.Trim().Trim('"').Trim('\'');
-                var encoding = System.Text.Encoding.GetEncoding(charset);
+                var encoding = GetEncodingWithCodePagesFallback(charset);
                 return encoding.GetString(bytes);
             } catch {
                 // If the specified encoding is not supported, fall through to detection
@@ -139,7 +136,7 @@ public static class HtmlUtilities {
 
         if (metaMatch.Success) {
             try {
-                var encoding = System.Text.Encoding.GetEncoding(metaMatch.Groups["charset"].Value);
+                var encoding = GetEncodingWithCodePagesFallback(metaMatch.Groups["charset"].Value);
                 return encoding.GetString(bytes);
             } catch {
                 // If the detected encoding is not supported, fall through to UTF-8
@@ -148,6 +145,23 @@ public static class HtmlUtilities {
 
         // Default to UTF-8 if no encoding could be determined
         return System.Text.Encoding.UTF8.GetString(bytes);
+    }
+
+    private static System.Text.Encoding GetEncodingWithCodePagesFallback(string charset) {
+        try {
+            return System.Text.Encoding.GetEncoding(charset);
+        } catch (ArgumentException) {
+            EnsureCodePagesEncodingProvider();
+            return System.Text.Encoding.GetEncoding(charset);
+        }
+    }
+
+    private static void EnsureCodePagesEncodingProvider() {
+#if !NETFRAMEWORK
+        if (Interlocked.Exchange(ref CodePagesEncodingProviderRegistered, 1) == 0) {
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+        }
+#endif
     }
 
     /// <summary>

--- a/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
+++ b/Sources/PSParseHTML.PowerShell/OnImportAndRemove.cs
@@ -22,7 +22,9 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         }
 #if NET5_0_OR_GREATER
         else {
-            AssemblyLoadContext.Default.Resolving += ResolveAlc;
+            if (IsLoadedInDefaultContext()) {
+                AssemblyLoadContext.Default.Resolving += ResolveAlc;
+            }
         }
 #endif
     }
@@ -37,7 +39,9 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         }
 #if NET5_0_OR_GREATER
         else {
-            AssemblyLoadContext.Default.Resolving -= ResolveAlc;
+            if (IsLoadedInDefaultContext()) {
+                AssemblyLoadContext.Default.Resolving -= ResolveAlc;
+            }
         }
 #endif
     }
@@ -99,6 +103,10 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location)!;
 
     private static readonly LoadContext _alc = new LoadContext(_assemblyDir);
+
+    private static bool IsLoadedInDefaultContext() {
+        return AssemblyLoadContext.GetLoadContext(typeof(OnModuleImportAndRemove).Assembly) == AssemblyLoadContext.Default;
+    }
 
     private static Assembly? ResolveAlc(AssemblyLoadContext defaultAlc, AssemblyName assemblyToResolve) {
         string asmPath = Path.Join(_assemblyDir, $"{assemblyToResolve.Name}.dll");

--- a/Tests/AssemblyLoadContext.Conflict.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Conflict.Tests.ps1
@@ -1,0 +1,85 @@
+Describe 'Packaged AssemblyLoadContext conflict isolation' {
+    It 'loads after TextMate and PwshSpectreConsole without sharing the default ALC' {
+        $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Modules'
+        $packagedModule = Join-Path $packagedModuleRoot 'PSParseHTML'
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\PSParseHTML.ModuleLoadContext.dll'
+        $hasConflictModules = (Get-Module -ListAvailable -Name TextMate | Where-Object Version -eq '0.2.1') -and
+            (Get-Module -ListAvailable -Name PwshSpectreConsole | Where-Object Version -eq '2.6.3')
+        if ($PSVersionTable.PSEdition -ne 'Core' -or -not (Test-Path -LiteralPath $packagedLoader) -or -not $hasConflictModules) {
+            Set-ItResult -Skipped -Because 'packaged Core artifact and conflict modules are required'
+            return
+        }
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$moduleRoot = '$moduleRootLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + `$env:PSModulePath
+
+Import-Module TextMate -RequiredVersion 0.2.1 -Force
+Import-Module PwshSpectreConsole -RequiredVersion 2.6.3 -Force
+`$textMateBefore = (Get-Command Get-TextMateGrammar -ErrorAction Stop).Count
+`$spectreBefore = (Get-Command Get-SpectreColors -ErrorAction Stop).Count
+
+Import-Module PSParseHTML -Force
+`$table = ConvertFrom-HtmlTable -Content '<table><tr><th>Name</th></tr><tr><td>42</td></tr></table>' -Engine AngleSharp
+`$command = Get-Command ConvertFrom-HtmlTable -ErrorAction Stop
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
+    ForEach-Object {
+        `$alc = `$_
+        foreach (`$assembly in `$alc.Assemblies) {
+            if (`$assembly.GetName().Name -in @('PSParseHTML.PowerShell', 'HtmlTinkerX', 'SixLabors.ImageSharp', 'Spectre.Console')) {
+                [pscustomobject]@{
+                    Assembly = `$assembly.GetName().Name
+                    Version = `$assembly.GetName().Version.ToString()
+                    ALC = `$alc.Name
+                    IsDefault = [object]::ReferenceEquals(`$alc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+                }
+            }
+        }
+    }
+
+[pscustomobject]@{
+    TextMateCommandBefore = `$textMateBefore
+    SpectreCommandBefore = `$spectreBefore
+    TextMateCommandAfter = (Get-Command Get-TextMateGrammar -ErrorAction Stop).Count
+    SpectreCommandAfter = (Get-Command Get-SpectreColors -ErrorAction Stop).Count
+    TableValue = `$table.Name
+    ConvertFromHtmlTableAssembly = `$commandAssembly.Location
+    ConvertFromHtmlTableALC = `$commandAlc.Name
+    ConvertFromHtmlTableALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    LoadedAssemblies = @(`$loadedAssemblies)
+} | ConvertTo-Json -Depth 6 -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.TextMateCommandBefore | Should -BeGreaterOrEqual 1
+        $result.SpectreCommandBefore | Should -BeGreaterOrEqual 1
+        $result.TextMateCommandAfter | Should -BeGreaterOrEqual 1
+        $result.SpectreCommandAfter | Should -BeGreaterOrEqual 1
+        $result.TableValue | Should -Be '42'
+        $result.ConvertFromHtmlTableAssembly | Should -BeLike '*\Artefacts\Unpacked\Modules\PSParseHTML\Lib\Core\PSParseHTML.PowerShell.dll'
+        $result.ConvertFromHtmlTableALC | Should -Be 'PSParseHTML'
+        $result.ConvertFromHtmlTableALCIsDefault | Should -BeFalse
+
+        $loadedAssemblies = @($result.LoadedAssemblies)
+        $psParseHtmlAssembly = $loadedAssemblies | Where-Object Assembly -eq 'PSParseHTML.PowerShell' | Select-Object -First 1
+        $htmlTinkerXAssembly = $loadedAssemblies | Where-Object Assembly -eq 'HtmlTinkerX' | Select-Object -First 1
+        $spectreAssembly = $loadedAssemblies | Where-Object Assembly -eq 'Spectre.Console' | Select-Object -First 1
+
+        $psParseHtmlAssembly.ALC | Should -Be 'PSParseHTML'
+        $psParseHtmlAssembly.IsDefault | Should -BeFalse
+        $htmlTinkerXAssembly.ALC | Should -Be 'PSParseHTML'
+        $htmlTinkerXAssembly.IsDefault | Should -BeFalse
+        $spectreAssembly.IsDefault | Should -BeTrue
+    }
+}

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -1,8 +1,30 @@
 ﻿Describe -Name 'ConvertFrom-HtmlTable' {
-    It 'Given a HTML table online with polish chars - Should convert it to a PowerShell object' {
-        $Url = 'https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm'
+    BeforeAll {
+        function New-PolishTableHtml {
+            $ignoredTables = for ($i = 0; $i -lt 12; $i++) {
+                "<table><tr><td>Ignored $i</td></tr></table>"
+            }
 
-        $AllTables = ConvertFrom-HtmlTable -Url $Url -Engine AgilityPack
+            @"
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Polish table encoding fixture</title></head>
+<body>
+$($ignoredTables -join "`n")
+<table>
+    <tr><td>Komórka a1</td><td>Komórka a2</td></tr>
+    <tr><td>Komórka a3</td><td>Komórka a4</td></tr>
+</table>
+</body>
+</html>
+"@
+        }
+
+    }
+
+    It 'Given a HTML table fixture with polish chars - Should convert it to a PowerShell object' {
+        $AllTables = ConvertFrom-HtmlTable -Content (New-PolishTableHtml) -Engine AgilityPack
+
         $AllTables.Count | Should -BeGreaterThan 0
     }
 
@@ -34,42 +56,36 @@
         $Table[1].Column2 | Should -Be 'Komórka a4'
     }
 
-    It 'Parses URL with Polish characters correctly - AgilityPack' {
-        $Url = 'https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm'
+    It 'Parses generated HTML with Polish characters correctly - AgilityPack' {
+        $AllTables = ConvertFrom-HtmlTable -Content (New-PolishTableHtml) -Engine AgilityPack
 
-        $AllTables = ConvertFrom-HtmlTable -Url $Url -Engine AgilityPack
         $AllTables.Count | Should -BeGreaterThan 0
 
         # Find the specific table we're testing (should be table index 12)
-        if ($AllTables.Count -gt 12) {
-            $Table = $AllTables[12]
-            $Table.Count | Should -BeGreaterOrEqual 2
+        $Table = $AllTables[12]
+        $Table.Count | Should -BeGreaterOrEqual 2
 
-            # Check that Polish characters are preserved correctly
-            $Table[0].Column1 | Should -Be 'Komórka a1'
-            $Table[0].Column2 | Should -Be 'Komórka a2'
-            $Table[1].Column1 | Should -Be 'Komórka a3'
-            $Table[1].Column2 | Should -Be 'Komórka a4'
-        }
+        # Check that Polish characters are preserved correctly
+        $Table[0].Column1 | Should -Be 'Komórka a1'
+        $Table[0].Column2 | Should -Be 'Komórka a2'
+        $Table[1].Column1 | Should -Be 'Komórka a3'
+        $Table[1].Column2 | Should -Be 'Komórka a4'
     }
 
-    It 'Parses URL with Polish characters correctly - AngleSharp' {
-        $Url = 'https://ifj.edu.pl/private/krawczyk/kurshtml/tabele/tabele.htm'
+    It 'Parses generated HTML with Polish characters correctly - AngleSharp' {
+        $AllTables = ConvertFrom-HtmlTable -Content (New-PolishTableHtml) -Engine AngleSharp
 
-        $AllTables = ConvertFrom-HtmlTable -Url $Url -Engine AngleSharp
         $AllTables.Count | Should -BeGreaterThan 0
 
         # Find the specific table we're testing (should be table index 12)
-        if ($AllTables.Count -gt 12) {
-            $Table = $AllTables[12]
-            $Table.Count | Should -BeGreaterOrEqual 2
+        $Table = $AllTables[12]
+        $Table.Count | Should -BeGreaterOrEqual 2
 
-            # Check that Polish characters are preserved correctly
-            $Table[0].Column1 | Should -Be 'Komórka a1'
-            $Table[0].Column2 | Should -Be 'Komórka a2'
-            $Table[1].Column1 | Should -Be 'Komórka a3'
-            $Table[1].Column2 | Should -Be 'Komórka a4'
-        }
+        # Check that Polish characters are preserved correctly
+        $Table[0].Column1 | Should -Be 'Komórka a1'
+        $Table[0].Column2 | Should -Be 'Komórka a2'
+        $Table[1].Column1 | Should -Be 'Komórka a3'
+        $Table[1].Column2 | Should -Be 'Komórka a4'
     }
     It 'Given a HTML Page with Tables' {
         $AllTables = ConvertFrom-HtmlTable -Url 'https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/licensing-service-plan-reference'


### PR DESCRIPTION
## Summary
- enables the PSPublishModule `NETAssemblyLoadContext` option for PSParseHTML production builds
- resolves the production .NET project path from the build script root so full module builds are independent of the caller working directory
- keeps manifest-only refresh runs compatible with existing CI by skipping ALC generation when `RefreshPSD1Only` is enabled
- prevents the legacy default-context resolver from attaching when the binary module is already loaded through a custom ALC
- replaces external Polish encoding tests with local fixtures and registers code-page encodings for non-UTF HTML responses

## Dependency
- Depends on EvotecIT/PSPublishModule#354 for module-scoped ALC bootstrapper generation. Production/full builds expect a PSPublishModule version that supports `NETAssemblyLoadContext`.

## Validation
- `pwsh -NoProfile -ExecutionPolicy Bypass -Command '$env:RefreshPSD1Only = "1"; & "C:\Support\GitHub\PSParseHTML\Build\Build-Module.ps1"'`
- `dotnet test .\Sources\HtmlTinkerX.Tests\HtmlTinkerX.Tests.csproj -c Release -f net8.0 --filter "TestHtmlAgilityPackEncodingIssue|DebugPolishEncodingIssue|ConvertFromHtmlTable_FromUrlWithPolishCharacters_PreservesEncoding" --no-restore`
- `dotnet test .\Sources\HtmlTinkerX.Tests\HtmlTinkerX.Tests.csproj -c Release -f net8.0 --no-build --verbosity minimal`
- `dotnet build .\Sources\HtmlTinkerX.sln -c Release -p:SkipPostBuild=true --no-restore -m:1 -nr:false`
- focused Pester: `Tests\ConvertFrom-HtmlTable.Tests.ps1`
- `git diff --check`
- local production artifact smoke-tested with `PSParseHTML.ModuleLoadContext.dll` under `Lib\Core`
- Spectre/ImageSharp co-load verified with `PwshSpectreConsole` and PSParseHTML using separate `SixLabors.ImageSharp` versions in separate load contexts
- Windows PowerShell 5.1 import smoke tested
