### PR TITLE
Add reusable HTML table data conversions

### DIFF
--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -8,7 +8,7 @@
     Description          = 'Module that allows to manipulate, parse, format and optimize HTML, JavaScript and CSS'
     FunctionsToExport    = @()
     GUID                 = 'f0387960-7034-4918-a1e1-d5847cbf90df'
-    ModuleVersion        = '2.0.10'
+    ModuleVersion        = '2.0.11'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public class HtmlTableDataExtensionsTests {
+    [Fact]
+    public void ToDataTable_UsesMetadataHeadersAndCanInferTypes() {
+        const string html = """
+<table id="sales-report">
+  <thead><tr><th>Name</th><th>Amount</th><th>Active</th></tr></thead>
+  <tbody>
+    <tr><td>North</td><td>12.50</td><td>true</td></tr>
+    <tr><td>South</td><td>7.25</td><td>false</td></tr>
+  </tbody>
+</table>
+""";
+
+        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html).Single();
+        DataTable dataTable = table.ToDataTable(inferTypes: true);
+
+        Assert.Equal("sales_report", dataTable.TableName);
+        Assert.Equal(3, dataTable.Columns.Count);
+        Assert.Equal(typeof(string), dataTable.Columns["Name"]!.DataType);
+        Assert.Equal(typeof(decimal), dataTable.Columns["Amount"]!.DataType);
+        Assert.Equal(typeof(bool), dataTable.Columns["Active"]!.DataType);
+        Assert.Equal(2, dataTable.Rows.Count);
+        Assert.Equal("North", dataTable.Rows[0]["Name"]);
+        Assert.Equal(12.50m, dataTable.Rows[0]["Amount"]);
+        Assert.Equal(false, dataTable.Rows[1]["Active"]);
+    }
+
+    [Fact]
+    public void ToDataSet_CreatesUniqueTablesForAllParsedHtmlTables() {
+        const string html = """
+<table id="dup"><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+<table id="dup"><tr><th>Name</th></tr><tr><td>Two</td></tr></table>
+""";
+
+        DataSet dataSet = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html).ToDataSet();
+
+        Assert.Equal("HtmlTables", dataSet.DataSetName);
+        Assert.Equal(2, dataSet.Tables.Count);
+        Assert.Equal("dup", dataSet.Tables[0]!.TableName);
+        Assert.Equal("dup2", dataSet.Tables[1]!.TableName);
+        Assert.Equal("Two", dataSet.Tables[1]!.Rows[0]["Name"]);
+    }
+
+    [Fact]
+    public void ParseFileAndStreamTables_ReturnDetailedTableModels() {
+        const string html = """
+<table class="inventory">
+  <tr><th>Name</th><th>Count</th></tr>
+  <tr><td>Widget</td><td>4</td></tr>
+</table>
+""";
+
+        string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".html");
+        try {
+            File.WriteAllText(filePath, html, Encoding.UTF8);
+
+            HtmlTableResult fileTable = HtmlParser.ParseFileTablesWithHtmlAgilityPackDetailed(filePath).Single();
+            Assert.Equal("inventory", fileTable.Metadata.Classes);
+            Assert.Equal("Widget", fileTable.Data[0]["Name"]);
+
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            HtmlTableResult streamTable = HtmlParser.ParseStreamTablesWithAngleSharpDetailed(stream).Single();
+            Assert.Equal("inventory", streamTable.Metadata.Classes);
+            Assert.Equal("4", streamTable.Data[0]["Count"]);
+        } finally {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    [Fact]
+    public void ToDataTable_NullTableThrows() {
+        Assert.Throws<ArgumentNullException>(() => HtmlTableDataExtensions.ToDataTable(null!));
+    }
+}

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -3,8 +3,10 @@ using AngleSharp.Html.Parser;
 using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -109,6 +111,58 @@ public static class HtmlParser {
     }
 
     /// <summary>
+    /// Extracts table data from an HTML file using AngleSharp with detailed metadata.
+    /// </summary>
+    /// <param name="filePath">Path to an HTML file.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseFileTablesWithAngleSharpDetailed(
+        string filePath,
+        IDictionary<string, string>? replaceContent = null,
+        IDictionary<string, string>? replaceHeaders = null,
+        bool allProperties = false,
+        bool skipFooter = false,
+        bool cleanHeaders = false,
+        string? emptyValuePlaceholder = null,
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        string html = HtmlUtilities.ReadFileChecked(filePath);
+        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML stream using AngleSharp with detailed metadata.
+    /// </summary>
+    /// <param name="stream">Readable stream containing HTML.</param>
+    /// <param name="encoding">Optional text encoding. UTF-8 is used when omitted.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseStreamTablesWithAngleSharpDetailed(
+        Stream stream,
+        Encoding? encoding = null,
+        IDictionary<string, string>? replaceContent = null,
+        IDictionary<string, string>? replaceHeaders = null,
+        bool allProperties = false,
+        bool skipFooter = false,
+        bool cleanHeaders = false,
+        string? emptyValuePlaceholder = null,
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        string html = ReadHtmlStream(stream, encoding);
+        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+    }
+
+    /// <summary>
     /// Extracts table data from HTML markup using AngleSharp.
     /// </summary>
     /// <param name="html">HTML content containing tables.</param>
@@ -168,6 +222,62 @@ public static class HtmlParser {
         string? emptyValuePlaceholder = null,
         HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
         return HtmlParserFromTable.ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML file using HtmlAgilityPack with detailed metadata.
+    /// </summary>
+    /// <param name="filePath">Path to an HTML file.</param>
+    /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseFileTablesWithHtmlAgilityPackDetailed(
+        string filePath,
+        bool reverseTable = false,
+        IDictionary<string, string>? replaceContent = null,
+        IDictionary<string, string>? replaceHeaders = null,
+        bool allProperties = false,
+        bool skipFooter = false,
+        bool cleanHeaders = false,
+        string? emptyValuePlaceholder = null,
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        string html = HtmlUtilities.ReadFileChecked(filePath);
+        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML stream using HtmlAgilityPack with detailed metadata.
+    /// </summary>
+    /// <param name="stream">Readable stream containing HTML.</param>
+    /// <param name="encoding">Optional text encoding. UTF-8 is used when omitted.</param>
+    /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseStreamTablesWithHtmlAgilityPackDetailed(
+        Stream stream,
+        Encoding? encoding = null,
+        bool reverseTable = false,
+        IDictionary<string, string>? replaceContent = null,
+        IDictionary<string, string>? replaceHeaders = null,
+        bool allProperties = false,
+        bool skipFooter = false,
+        bool cleanHeaders = false,
+        string? emptyValuePlaceholder = null,
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        string html = ReadHtmlStream(stream, encoding);
+        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
     }
 
     /// <summary>
@@ -478,5 +588,18 @@ public static class HtmlParser {
                 counters[name] = 0;
             }
         }
+    }
+
+    private static string ReadHtmlStream(Stream stream, Encoding? encoding) {
+        if (stream == null) {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        if (!stream.CanRead) {
+            throw new ArgumentException("Stream must be readable.", nameof(stream));
+        }
+
+        using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+        return reader.ReadToEnd();
     }
 }

--- a/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
+++ b/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Converts parsed HTML table models into common .NET tabular shapes.
+/// </summary>
+public static class HtmlTableDataExtensions {
+    /// <summary>
+    /// Converts a parsed HTML table into a <see cref="DataTable"/>.
+    /// </summary>
+    /// <param name="table">Parsed table.</param>
+    /// <param name="tableName">Optional table name. When omitted, a stable name is derived from table metadata.</param>
+    /// <param name="inferTypes">When true, columns with consistently typed text are converted to simple .NET types.</param>
+    public static DataTable ToDataTable(this HtmlTableResult table, string? tableName = null, bool inferTypes = false) {
+        if (table == null) {
+            throw new ArgumentNullException(nameof(table));
+        }
+
+        List<string> sourceHeaders = GetSourceHeaders(table);
+        List<string> outputHeaders = sourceHeaders.ToList();
+        HtmlParser.EnsureUniqueNames(outputHeaders);
+
+        Type[] columnTypes = inferTypes
+            ? sourceHeaders.Select(header => InferColumnType(table.Data, header)).ToArray()
+            : sourceHeaders.Select(_ => typeof(string)).ToArray();
+
+        var dataTable = new DataTable(SanitizeTableName(tableName ?? GetDefaultTableName(table.Metadata, 1)));
+        for (int i = 0; i < outputHeaders.Count; i++) {
+            var column = new DataColumn(outputHeaders[i], columnTypes[i]) {
+                AllowDBNull = true
+            };
+            dataTable.Columns.Add(column);
+        }
+
+        foreach (Dictionary<string, string?> sourceRow in table.Data) {
+            DataRow row = dataTable.NewRow();
+            for (int i = 0; i < sourceHeaders.Count; i++) {
+                string? value = TryGetValue(sourceRow, sourceHeaders[i]);
+                row[i] = ConvertValue(value, columnTypes[i]);
+            }
+
+            dataTable.Rows.Add(row);
+        }
+
+        return dataTable;
+    }
+
+    /// <summary>
+    /// Converts parsed HTML tables into a <see cref="DataSet"/> with one table per parsed HTML table.
+    /// </summary>
+    /// <param name="tables">Parsed tables.</param>
+    /// <param name="dataSetName">Optional DataSet name.</param>
+    /// <param name="inferTypes">When true, columns with consistently typed text are converted to simple .NET types.</param>
+    public static DataSet ToDataSet(this IEnumerable<HtmlTableResult> tables, string? dataSetName = null, bool inferTypes = false) {
+        if (tables == null) {
+            throw new ArgumentNullException(nameof(tables));
+        }
+
+        var dataSet = new DataSet(string.IsNullOrWhiteSpace(dataSetName) ? "HtmlTables" : dataSetName);
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int index = 1;
+        foreach (HtmlTableResult table in tables) {
+            if (table == null) {
+                continue;
+            }
+
+            string tableName = EnsureUniqueTableName(GetDefaultTableName(table.Metadata, index), usedNames);
+            DataTable dataTable = table.ToDataTable(tableName, inferTypes);
+            dataSet.Tables.Add(dataTable);
+            index++;
+        }
+
+        return dataSet;
+    }
+
+    private static List<string> GetSourceHeaders(HtmlTableResult table) {
+        var headers = table.Metadata.Headers
+            .Where(header => !string.IsNullOrWhiteSpace(header))
+            .ToList();
+
+        if (headers.Count == 0) {
+            foreach (Dictionary<string, string?> row in table.Data) {
+                foreach (string key in row.Keys) {
+                    if (!headers.Contains(key, StringComparer.OrdinalIgnoreCase)) {
+                        headers.Add(key);
+                    }
+                }
+            }
+        }
+
+        if (headers.Count == 0) {
+            headers.Add("Column1");
+        }
+
+        for (int i = 0; i < headers.Count; i++) {
+            if (string.IsNullOrWhiteSpace(headers[i])) {
+                headers[i] = "Column" + (i + 1).ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        return headers;
+    }
+
+    private static string? TryGetValue(Dictionary<string, string?> row, string header) {
+        if (row.TryGetValue(header, out string? value)) {
+            return value;
+        }
+
+        foreach (KeyValuePair<string, string?> pair in row) {
+            if (string.Equals(pair.Key, header, StringComparison.OrdinalIgnoreCase)) {
+                return pair.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static Type InferColumnType(IEnumerable<Dictionary<string, string?>> rows, string header) {
+        List<string> values = rows
+            .Select(row => TryGetValue(row, header))
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .ToList();
+
+        if (values.Count == 0) {
+            return typeof(string);
+        }
+
+        if (values.All(value => bool.TryParse(value, out _))) {
+            return typeof(bool);
+        }
+
+        if (values.All(value => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))) {
+            return typeof(long);
+        }
+
+        if (values.All(value => decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out _))) {
+            return typeof(decimal);
+        }
+
+        if (values.All(value => DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out _))) {
+            return typeof(DateTime);
+        }
+
+        return typeof(string);
+    }
+
+    private static object ConvertValue(string? value, Type targetType) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return DBNull.Value;
+        }
+
+        string text = value!.Trim();
+        if (targetType == typeof(bool) && bool.TryParse(text, out bool boolValue)) {
+            return boolValue;
+        }
+
+        if (targetType == typeof(long) && long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue)) {
+            return longValue;
+        }
+
+        if (targetType == typeof(decimal) && decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out decimal decimalValue)) {
+            return decimalValue;
+        }
+
+        if (targetType == typeof(DateTime) && DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out DateTime dateValue)) {
+            return dateValue;
+        }
+
+        return value;
+    }
+
+    private static string GetDefaultTableName(HtmlTableMetadata metadata, int fallbackIndex) {
+        if (!string.IsNullOrWhiteSpace(metadata.Id)) {
+            return metadata.Id!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(metadata.Classes)) {
+            string className = metadata.Classes!
+                .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault() ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(className)) {
+                return className;
+            }
+        }
+
+        int tableIndex = metadata.TableIndex >= 0 ? metadata.TableIndex + 1 : fallbackIndex;
+        return "Table" + tableIndex.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string EnsureUniqueTableName(string requestedName, ISet<string> usedNames) {
+        string baseName = SanitizeTableName(requestedName);
+        string candidate = baseName;
+        int suffix = 2;
+        while (!usedNames.Add(candidate)) {
+            candidate = baseName + suffix.ToString(CultureInfo.InvariantCulture);
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private static string SanitizeTableName(string name) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            return "Table";
+        }
+
+        var builder = new StringBuilder(name.Length);
+        foreach (char ch in name.Trim()) {
+            builder.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        }
+
+        string sanitized = builder.ToString().Trim('_');
+        if (sanitized.Length == 0) {
+            sanitized = "Table";
+        }
+
+        if (char.IsDigit(sanitized[0])) {
+            sanitized = "_" + sanitized;
+        }
+
+        return sanitized;
+    }
+}

--- a/Sources/HtmlTinkerX/Models/HtmlTableResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlTableResult.cs
@@ -1,10 +1,5 @@
-﻿using AngleSharp.Dom;
-using HtmlAgilityPack;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
+using System.Data;
 
 namespace HtmlTinkerX;
 
@@ -21,4 +16,12 @@ public class HtmlTableResult {
     /// Table rows with values indexed by header name.
     /// </summary>
     public List<Dictionary<string, string?>> Data { get; set; } = new();
+
+    /// <summary>
+    /// Converts this parsed HTML table into a <see cref="DataTable"/>.
+    /// </summary>
+    /// <param name="tableName">Optional table name. When omitted, a stable name is derived from table metadata.</param>
+    /// <param name="inferTypes">When true, columns with consistently typed text are converted to simple .NET types.</param>
+    public DataTable ToDataTable(string? tableName = null, bool inferTypes = false) =>
+        HtmlTableDataExtensions.ToDataTable(this, tableName, inferTypes);
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -2,6 +2,7 @@ using HtmlTinkerX;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Management.Automation;
 using System.Net.Http;
@@ -23,14 +24,19 @@ namespace PSParseHTML.PowerShell;
 ///   <code>ConvertFrom-HtmlTable -Url https://example.com -Proxy http://proxy:8080</code>
 /// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlTable", DefaultParameterSetName = ParameterSetContent)]
-[OutputType(typeof(PSObject[]))]
+[OutputType(typeof(PSObject[]), typeof(DataTable), typeof(DataSet))]
 public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
+    private const string ParameterSetFile = "File";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML content containing tables.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public string Content { get; set; } = string.Empty;
+
+    /// <summary>Path to an HTML file containing tables.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetFile, ValueFromPipelineByPropertyName = true)]
+    public string Path { get; set; } = string.Empty;
 
     /// <summary>URL of a page with tables.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -56,6 +62,26 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
     /// <summary>Include table metadata information.</summary>
     [Parameter]
     public SwitchParameter IncludeMetadata { get; set; }
+
+    /// <summary>Return each parsed HTML table as a DataTable.</summary>
+    [Parameter]
+    public SwitchParameter AsDataTable { get; set; }
+
+    /// <summary>Return all parsed HTML tables as a DataSet.</summary>
+    [Parameter]
+    public SwitchParameter AsDataSet { get; set; }
+
+    /// <summary>Name to use when returning a single DataTable.</summary>
+    [Parameter]
+    public string? TableName { get; set; }
+
+    /// <summary>Name to use when returning a DataSet.</summary>
+    [Parameter]
+    public string? DataSetName { get; set; }
+
+    /// <summary>Infer simple .NET column types when returning DataTable/DataSet output.</summary>
+    [Parameter]
+    public SwitchParameter InferTypes { get; set; }
 
     /// <summary>Pad rows with missing cells.</summary>
     [Parameter]
@@ -93,7 +119,32 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         ValidateProxy(Proxy, ProxyCredential);
+        if (AsDataTable.IsPresent && AsDataSet.IsPresent) {
+            throw new PSArgumentException("Specify either -AsDataTable or -AsDataSet, but not both.");
+        }
+
+        if (IncludeMetadata.IsPresent && (AsDataTable.IsPresent || AsDataSet.IsPresent)) {
+            throw new PSArgumentException("-IncludeMetadata cannot be combined with -AsDataTable or -AsDataSet.");
+        }
+
         var detailedTables = await GetTablesDetailedAsync();
+
+        if (AsDataSet.IsPresent) {
+            WriteObject(detailedTables.ToDataSet(DataSetName, InferTypes.IsPresent), false);
+            return;
+        }
+
+        if (AsDataTable.IsPresent) {
+            if (detailedTables.Count > 1) {
+                WriteWarning($"{detailedTables.Count} tables found. Returning one DataTable per parsed table.");
+            }
+
+            bool useRequestedName = detailedTables.Count == 1 && !string.IsNullOrWhiteSpace(TableName);
+            foreach (var tableResult in detailedTables) {
+                WriteObject(tableResult.ToDataTable(useRequestedName ? TableName : null, InferTypes.IsPresent), false);
+            }
+            return;
+        }
 
         if (IncludeMetadata.IsPresent) {
             foreach (var tableResult in detailedTables) {
@@ -128,6 +179,14 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
 
             var doc = await HtmlParser.ParseUrlWithHtmlAgilityPackAsync(Url.ToString(), client).ConfigureAwait(false);
             return HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(doc.DocumentNode.OuterHtml, ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+        }
+
+        if (ParameterSetName == ParameterSetFile) {
+            if (Engine == HtmlParserEngine.AngleSharp && !ReverseTable.IsPresent) {
+                return HtmlParser.ParseFileTablesWithAngleSharpDetailed(Path.ToFullPath(), Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+            }
+
+            return HtmlParser.ParseFileTablesWithHtmlAgilityPackDetailed(Path.ToFullPath(), ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
         }
 
         if (Engine == HtmlParserEngine.AngleSharp && !ReverseTable.IsPresent) {

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -188,6 +188,57 @@ $($ignoredTables -join "`n")
         $Result[0].Age | Should -Be '30'
     }
 
+    It 'Returns parsed table as DataTable when requested' {
+        $Html = @"
+<table id="sales-report">
+    <tr><th>Name</th><th>Amount</th><th>Active</th></tr>
+    <tr><td>North</td><td>12.50</td><td>true</td></tr>
+    <tr><td>South</td><td>7.25</td><td>false</td></tr>
+</table>
+"@
+
+        $Table = ConvertFrom-HtmlTable -Content $Html -AsDataTable -InferTypes
+
+        $Table.GetType().FullName | Should -Be 'System.Data.DataTable'
+        $Table.TableName | Should -Be 'sales_report'
+        $Table.Columns['Amount'].DataType.FullName | Should -Be 'System.Decimal'
+        $Table.Rows.Count | Should -Be 2
+        $Table.Rows[0]['Name'] | Should -Be 'North'
+        $Table.Rows[0]['Amount'] | Should -Be ([decimal]'12.50')
+    }
+
+    It 'Returns all parsed tables as a DataSet when requested' {
+        $Html = @"
+<table id="dup"><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+<table id="dup"><tr><th>Name</th></tr><tr><td>Two</td></tr></table>
+"@
+
+        $DataSet = ConvertFrom-HtmlTable -Content $Html -AsDataSet
+
+        $DataSet.GetType().FullName | Should -Be 'System.Data.DataSet'
+        $DataSet.Tables.Count | Should -Be 2
+        $DataSet.Tables[0].TableName | Should -Be 'dup'
+        $DataSet.Tables[1].TableName | Should -Be 'dup2'
+        $DataSet.Tables[1].Rows[0]['Name'] | Should -Be 'Two'
+    }
+
+    It 'Returns parsed tables from file path as a DataTable' {
+        $Path = Join-Path $TestDrive 'table.html'
+        @"
+<table id="from-file">
+    <tr><th>Name</th><th>Amount</th></tr>
+    <tr><td>North</td><td>12.50</td></tr>
+</table>
+"@ | Set-Content -LiteralPath $Path
+
+        $Table = ConvertFrom-HtmlTable -Path $Path -AsDataTable -InferTypes
+
+        $Table.GetType().FullName | Should -Be 'System.Data.DataTable'
+        $Table.TableName | Should -Be 'from_file'
+        $Table.Columns['Amount'].DataType.FullName | Should -Be 'System.Decimal'
+        $Table.Rows[0]['Name'] | Should -Be 'North'
+    }
+
     It 'Parses Wikipedia escape sequence table with correct columns' {
         [HtmlTinkerX.HtmlHttpClientFactory]::DefaultHeaders['User-Agent'] = 'HtmlTinkerX.Tests'
         try {


### PR DESCRIPTION
## Summary
- add reusable HtmlTinkerX conversions from parsed HTML tables to DataTable/DataSet
- add file and stream table parsing helpers for C# callers
- expose ConvertFrom-HtmlTable -Path as a thin PowerShell wrapper

## Validation
- dotnet test Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~HtmlTableDataExtensionsTests"
- dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj --framework net8.0
- dotnet build Sources/HtmlTinkerX/HtmlTinkerX.csproj --framework net472
- pwsh -NoProfile -Command "Import-Module ./PSParseHTML.psd1 -Force; Invoke-Pester -Path ./Tests/ConvertFrom-HtmlTable.Tests.ps1 -Output Detailed"
- git diff --check
