### PR TITLE
Add HTML table selection and link URL metadata

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -150,6 +150,22 @@ public class HtmlTableDataExtensionsTests {
     }
 
     [Fact]
+    public void ParseTablesDetailed_ReverseTableCanIncludeLinkUrlColumns() {
+        const string html = """
+<table>
+  <tr><th>Name</th><td>Example</td></tr>
+  <tr><th>Website</th><td><a href="https://example.com">Open</a></td></tr>
+</table>
+""";
+
+        HtmlTableResult table = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable: true, includeLinkUrls: true).Single();
+
+        Assert.Contains("WebsiteUrl", table.Metadata.Headers);
+        Assert.Equal("Open", table.Data[0]["Website"]);
+        Assert.Equal("https://example.com", table.Data[0]["WebsiteUrl"]);
+    }
+
+    [Fact]
     public void SelectTables_FiltersByIndexIdClassCaptionAndHeader() {
         const string html = """
 <table id="summary" class="report compact"><caption>Summary data</caption><tr><th>Name</th></tr><tr><td>One</td></tr></table>

--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -88,7 +88,7 @@ public class HtmlTableDataExtensionsTests {
 </table>
 """;
 
-        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html, includeLinkUrls: true).Single();
+        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html, null, null, false, false, false, null, HtmlCellTextFormat.Compact, true).Single();
         DataTable dataTable = table.ToDataTable();
 
         Assert.Contains("NameUrl", table.Metadata.Headers);
@@ -107,7 +107,7 @@ public class HtmlTableDataExtensionsTests {
 </table>
 """;
 
-        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html, includeLinkUrls: true).Single();
+        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html, null, null, false, false, false, null, HtmlCellTextFormat.Compact, true).Single();
         DataTable dataTable = table.ToDataTable();
 
         Assert.Contains("NameUrl", table.Metadata.Headers);
@@ -126,12 +126,20 @@ public class HtmlTableDataExtensionsTests {
 </table>
 """;
 
-        HtmlTableResult table = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, includeLinkUrls: true).Single();
+        HtmlTableResult table = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, false, false, false, null, HtmlCellTextFormat.Compact, true).Single();
 
         Assert.Contains("Column1Url", table.Metadata.Headers);
         Assert.Contains("Column2Url", table.Metadata.Headers);
         Assert.Equal("/one", table.Data[0]["Column1Url"]);
         Assert.Equal("/two", table.Data[0]["Column2Url"]);
+
+        DataTable dataTable = table.ToDataTable();
+        Assert.Contains("0", dataTable.Columns.Cast<DataColumn>().Select(column => column.ColumnName));
+        Assert.Contains("1", dataTable.Columns.Cast<DataColumn>().Select(column => column.ColumnName));
+        Assert.Equal("One", dataTable.Rows[0]["0"]);
+        Assert.Equal("Two", dataTable.Rows[0]["1"]);
+        Assert.Equal("/one", dataTable.Rows[0]["Column1Url"]);
+        Assert.Equal("/two", dataTable.Rows[0]["Column2Url"]);
     }
 
     [Fact]
@@ -158,7 +166,7 @@ public class HtmlTableDataExtensionsTests {
 </table>
 """;
 
-        HtmlTableResult table = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable: true, includeLinkUrls: true).Single();
+        HtmlTableResult table = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, true, null, null, false, false, false, null, HtmlCellTextFormat.Compact, true).Single();
 
         Assert.Contains("WebsiteUrl", table.Metadata.Headers);
         Assert.Equal("Open", table.Data[0]["Website"]);
@@ -220,6 +228,36 @@ public class HtmlTableDataExtensionsTests {
         });
 
         Assert.Equal(2, selected.Count);
+    }
+
+    [Fact]
+    public void PublicDetailedParseOverloads_PreservePreviousSignatures() {
+        Type dictionaryType = typeof(System.Collections.Generic.IDictionary<string, string>);
+
+        Assert.NotNull(typeof(HtmlParser).GetMethod(
+            nameof(HtmlParser.ParseTablesWithAngleSharpDetailed),
+            new[] { typeof(string), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParser).GetMethod(
+            nameof(HtmlParser.ParseFileTablesWithAngleSharpDetailed),
+            new[] { typeof(string), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParser).GetMethod(
+            nameof(HtmlParser.ParseStreamTablesWithAngleSharpDetailed),
+            new[] { typeof(Stream), typeof(Encoding), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParser).GetMethod(
+            nameof(HtmlParser.ParseTablesWithHtmlAgilityPackDetailed),
+            new[] { typeof(string), typeof(bool), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParser).GetMethod(
+            nameof(HtmlParser.ParseFileTablesWithHtmlAgilityPackDetailed),
+            new[] { typeof(string), typeof(bool), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParser).GetMethod(
+            nameof(HtmlParser.ParseStreamTablesWithHtmlAgilityPackDetailed),
+            new[] { typeof(Stream), typeof(Encoding), typeof(bool), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParserFromTable).GetMethod(
+            nameof(HtmlParserFromTable.ParseTablesWithAngleSharpDetailed),
+            new[] { typeof(string), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
+        Assert.NotNull(typeof(HtmlParserFromTable).GetMethod(
+            nameof(HtmlParserFromTable.ParseTablesWithHtmlAgilityPackDetailed),
+            new[] { typeof(string), typeof(bool), dictionaryType, dictionaryType, typeof(bool), typeof(bool), typeof(bool), typeof(string), typeof(HtmlCellTextFormat) }));
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -85,6 +85,7 @@ public class HtmlTableDataExtensionsTests {
   <tr><th>Name</th><th>Owner</th></tr>
   <tr><td><a href="https://example.com/a">Alpha</a></td><td>Team A</td></tr>
   <tr><td><a href="/beta">Beta</a><a href="/beta/details">Details</a></td><td>Team B</td></tr>
+  <tr><td><a href="/Docs">Docs</a><a href="/docs">docs</a><a href="/Docs">duplicate</a></td><td>Team C</td></tr>
 </table>
 """;
 
@@ -95,6 +96,10 @@ public class HtmlTableDataExtensionsTests {
         Assert.Equal("Alpha", dataTable.Rows[0]["Name"]);
         Assert.Equal("https://example.com/a", dataTable.Rows[0]["NameUrl"]);
         Assert.Equal("/beta; /beta/details", dataTable.Rows[1]["NameUrl"]);
+        Assert.Equal("/Docs; /docs", dataTable.Rows[2]["NameUrl"]);
+
+        HtmlTableResult agilityTable = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, false, null, null, false, false, false, null, HtmlCellTextFormat.Compact, true).Single();
+        Assert.Equal("/Docs; /docs", agilityTable.Data[2]["NameUrl"]);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -114,6 +114,47 @@ public class HtmlTableDataExtensionsTests {
     }
 
     [Fact]
+    public void SelectTables_RespectsCaseSensitiveMatching() {
+        const string html = """
+<table id="Summary" class="Report"><caption>Summary Data</caption><tr><th>Owner</th></tr><tr><td>Team</td></tr></table>
+""";
+
+        var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html);
+
+        Assert.Single(tables.SelectTables(new HtmlTableSelectionOptions { Id = "summary" }));
+        Assert.Empty(tables.SelectTables(new HtmlTableSelectionOptions { Id = "summary", IgnoreCase = false }));
+        Assert.Empty(tables.SelectTables(new HtmlTableSelectionOptions { ClassName = "report", IgnoreCase = false }));
+        Assert.Empty(tables.SelectTables(new HtmlTableSelectionOptions { CaptionContains = "summary", IgnoreCase = false }));
+        Assert.Empty(tables.SelectTables(new HtmlTableSelectionOptions { Header = "owner", IgnoreCase = false }));
+        Assert.Single(tables.SelectTables(new HtmlTableSelectionOptions { Id = "Summary", ClassName = "Report", CaptionContains = "Summary", Header = "Owner", IgnoreCase = false }));
+    }
+
+    [Fact]
+    public void SelectTables_EmptySelectionOptionsReturnAllTables() {
+        const string html = """
+<table id="one"><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+<table id="two"><tr><th>Name</th></tr><tr><td>Two</td></tr></table>
+""";
+
+        var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(html);
+        var selected = tables.SelectTables(new HtmlTableSelectionOptions {
+            Id = " ",
+            ClassName = "\t",
+            CaptionContains = "\r\n",
+            Header = string.Empty,
+            TableIndexes = { -1 }
+        });
+
+        Assert.Equal(2, selected.Count);
+
+        selected = tables.SelectTables(new HtmlTableSelectionOptions {
+            TableIndexes = null!
+        });
+
+        Assert.Equal(2, selected.Count);
+    }
+
+    [Fact]
     public void ToDataTable_NullTableThrows() {
         Assert.Throws<ArgumentNullException>(() => HtmlTableDataExtensions.ToDataTable(null!));
     }

--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -98,6 +98,58 @@ public class HtmlTableDataExtensionsTests {
     }
 
     [Fact]
+    public void ParseTablesDetailed_NormalizesLinkUrlColumnsAcrossRows() {
+        const string html = """
+<table id="links">
+  <tr><th>Name</th><th>Owner</th></tr>
+  <tr><td>Alpha</td><td>Team A</td></tr>
+  <tr><td><a href="https://example.com/b">Beta</a></td><td>Team B</td></tr>
+</table>
+""";
+
+        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html, includeLinkUrls: true).Single();
+        DataTable dataTable = table.ToDataTable();
+
+        Assert.Contains("NameUrl", table.Metadata.Headers);
+        Assert.True(table.Data[0].ContainsKey("NameUrl"));
+        Assert.Null(table.Data[0]["NameUrl"]);
+        Assert.Equal(DBNull.Value, dataTable.Rows[0]["NameUrl"]);
+        Assert.Equal("https://example.com/b", dataTable.Rows[1]["NameUrl"]);
+    }
+
+    [Fact]
+    public void ParseTablesDetailed_UsesDistinctLinkUrlColumnsForEmptyHeaders() {
+        const string html = """
+<table>
+  <tr><th></th><th></th></tr>
+  <tr><td><a href="/one">One</a></td><td><a href="/two">Two</a></td></tr>
+</table>
+""";
+
+        HtmlTableResult table = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html, includeLinkUrls: true).Single();
+
+        Assert.Contains("Column1Url", table.Metadata.Headers);
+        Assert.Contains("Column2Url", table.Metadata.Headers);
+        Assert.Equal("/one", table.Data[0]["Column1Url"]);
+        Assert.Equal("/two", table.Data[0]["Column2Url"]);
+    }
+
+    [Fact]
+    public void ParseTablesDetailed_UsesOnlyDirectCaptionForNestedTables() {
+        const string html = """
+<table id="outer">
+  <tr><td>
+    <table id="inner"><caption>Nested caption</caption><tr><td>Inside</td></tr></table>
+  </td></tr>
+</table>
+""";
+
+        HtmlTableResult outer = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html).Single(table => table.Metadata.Id == "outer");
+
+        Assert.Equal(string.Empty, outer.Metadata.Caption);
+    }
+
+    [Fact]
     public void SelectTables_FiltersByIndexIdClassCaptionAndHeader() {
         const string html = """
 <table id="summary" class="report compact"><caption>Summary data</caption><tr><th>Name</th></tr><tr><td>One</td></tr></table>

--- a/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlTableDataExtensionsTests.cs
@@ -79,6 +79,41 @@ public class HtmlTableDataExtensionsTests {
     }
 
     [Fact]
+    public void ParseTablesDetailed_CanIncludeLinkUrlColumns() {
+        const string html = """
+<table id="links">
+  <tr><th>Name</th><th>Owner</th></tr>
+  <tr><td><a href="https://example.com/a">Alpha</a></td><td>Team A</td></tr>
+  <tr><td><a href="/beta">Beta</a><a href="/beta/details">Details</a></td><td>Team B</td></tr>
+</table>
+""";
+
+        HtmlTableResult table = HtmlParser.ParseTablesWithAngleSharpDetailed(html, includeLinkUrls: true).Single();
+        DataTable dataTable = table.ToDataTable();
+
+        Assert.Contains("NameUrl", table.Metadata.Headers);
+        Assert.Equal("Alpha", dataTable.Rows[0]["Name"]);
+        Assert.Equal("https://example.com/a", dataTable.Rows[0]["NameUrl"]);
+        Assert.Equal("/beta; /beta/details", dataTable.Rows[1]["NameUrl"]);
+    }
+
+    [Fact]
+    public void SelectTables_FiltersByIndexIdClassCaptionAndHeader() {
+        const string html = """
+<table id="summary" class="report compact"><caption>Summary data</caption><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+<table id="details" class="report wide"><caption>Detailed data</caption><tr><th>Owner</th></tr><tr><td>Team</td></tr></table>
+""";
+
+        var tables = HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(html);
+
+        Assert.Single(tables.SelectTables(new HtmlTableSelectionOptions { TableIndexes = { 1 } }));
+        Assert.Equal("summary", tables.SelectTables(new HtmlTableSelectionOptions { Id = "summary" }).Single().Metadata.Id);
+        Assert.Equal("details", tables.SelectTables(new HtmlTableSelectionOptions { ClassName = "wide" }).Single().Metadata.Id);
+        Assert.Equal("summary", tables.SelectTables(new HtmlTableSelectionOptions { CaptionContains = "summary" }).Single().Metadata.Id);
+        Assert.Equal("details", tables.SelectTables(new HtmlTableSelectionOptions { Header = "Owner" }).Single().Metadata.Id);
+    }
+
+    [Fact]
     public void ToDataTable_NullTableThrows() {
         Assert.Throws<ArgumentNullException>(() => HtmlTableDataExtensions.ToDataTable(null!));
     }

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -97,7 +97,6 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseTablesWithAngleSharpDetailed(
         string html,
@@ -107,8 +106,33 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from HTML markup using AngleSharp with detailed metadata.
+    /// </summary>
+    /// <param name="html">HTML content containing tables.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseTablesWithAngleSharpDetailed(
+        string html,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         return HtmlParserFromTable.ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
@@ -123,7 +147,6 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseFileTablesWithAngleSharpDetailed(
         string filePath,
@@ -133,8 +156,33 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseFileTablesWithAngleSharpDetailed(filePath, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML file using AngleSharp with detailed metadata.
+    /// </summary>
+    /// <param name="filePath">Path to the HTML file.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseFileTablesWithAngleSharpDetailed(
+        string filePath,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         string html = HtmlUtilities.ReadFileChecked(filePath);
         return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
@@ -151,7 +199,6 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseStreamTablesWithAngleSharpDetailed(
         Stream stream,
@@ -162,8 +209,35 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseStreamTablesWithAngleSharpDetailed(stream, encoding, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML stream using AngleSharp with detailed metadata.
+    /// </summary>
+    /// <param name="stream">Stream containing HTML markup.</param>
+    /// <param name="encoding">Optional text encoding. UTF-8 is used when not specified.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseStreamTablesWithAngleSharpDetailed(
+        Stream stream,
+        Encoding? encoding,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         string html = ReadHtmlStream(stream, encoding);
         return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
@@ -216,7 +290,6 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseTablesWithHtmlAgilityPackDetailed(
         string html,
@@ -227,8 +300,35 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from HTML markup using HtmlAgilityPack with detailed metadata.
+    /// </summary>
+    /// <param name="html">HTML content containing tables.</param>
+    /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseTablesWithHtmlAgilityPackDetailed(
+        string html,
+        bool reverseTable,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         return HtmlParserFromTable.ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
@@ -244,7 +344,6 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseFileTablesWithHtmlAgilityPackDetailed(
         string filePath,
@@ -255,8 +354,35 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseFileTablesWithHtmlAgilityPackDetailed(filePath, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML file using HtmlAgilityPack with detailed metadata.
+    /// </summary>
+    /// <param name="filePath">Path to the HTML file.</param>
+    /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseFileTablesWithHtmlAgilityPackDetailed(
+        string filePath,
+        bool reverseTable,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         string html = HtmlUtilities.ReadFileChecked(filePath);
         return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
@@ -274,7 +400,6 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseStreamTablesWithHtmlAgilityPackDetailed(
         Stream stream,
@@ -286,8 +411,37 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseStreamTablesWithHtmlAgilityPackDetailed(stream, encoding, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from an HTML stream using HtmlAgilityPack with detailed metadata.
+    /// </summary>
+    /// <param name="stream">Stream containing HTML markup.</param>
+    /// <param name="encoding">Optional text encoding. UTF-8 is used when not specified.</param>
+    /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells.</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells.</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseStreamTablesWithHtmlAgilityPackDetailed(
+        Stream stream,
+        Encoding? encoding,
+        bool reverseTable,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         string html = ReadHtmlStream(stream, encoding);
         return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -97,6 +97,7 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseTablesWithAngleSharpDetailed(
         string html,
@@ -106,8 +107,9 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
-        return HtmlParserFromTable.ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
+        return HtmlParserFromTable.ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
     /// <summary>
@@ -121,6 +123,7 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseFileTablesWithAngleSharpDetailed(
         string filePath,
@@ -130,9 +133,10 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
         string html = HtmlUtilities.ReadFileChecked(filePath);
-        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
     /// <summary>
@@ -147,6 +151,7 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseStreamTablesWithAngleSharpDetailed(
         Stream stream,
@@ -157,9 +162,10 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
         string html = ReadHtmlStream(stream, encoding);
-        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
     /// <summary>
@@ -210,6 +216,7 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseTablesWithHtmlAgilityPackDetailed(
         string html,
@@ -220,8 +227,9 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
-        return HtmlParserFromTable.ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
+        return HtmlParserFromTable.ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
     /// <summary>
@@ -236,6 +244,7 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseFileTablesWithHtmlAgilityPackDetailed(
         string filePath,
@@ -246,9 +255,10 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
         string html = HtmlUtilities.ReadFileChecked(filePath);
-        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
     /// <summary>
@@ -264,6 +274,7 @@ public static class HtmlParser {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseStreamTablesWithHtmlAgilityPackDetailed(
         Stream stream,
@@ -275,9 +286,10 @@ public static class HtmlParser {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
         string html = ReadHtmlStream(stream, encoding);
-        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat);
+        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls);
     }
 
     /// <summary>

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -1443,7 +1443,7 @@ public static class HtmlParserFromTable {
         var links = cell.QuerySelectorAll("a[href]")
             .Select(link => (link.GetAttribute("href") ?? string.Empty).Trim())
             .Where(href => href.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(StringComparer.Ordinal)
             .ToArray();
         return links.Length == 0 ? null : string.Join("; ", links);
     }
@@ -1452,7 +1452,7 @@ public static class HtmlParserFromTable {
         var links = cell.SelectNodes(".//a[@href]")?
             .Select(link => link.GetAttributeValue("href", string.Empty).Trim())
             .Where(href => href.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(StringComparer.Ordinal)
             .ToArray();
         return links == null || links.Length == 0 ? null : string.Join("; ", links);
     }

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -15,6 +15,9 @@ namespace HtmlTinkerX;
 /// Provides specialized functionality for parsing HTML tables.
 /// </summary>
 public static class HtmlParserFromTable {
+    private const string DefaultColumnNamePrefix = "Column";
+    private const string LinkUrlSuffix = "Url";
+
     /// <summary>
     /// Extracts table data from HTML markup using AngleSharp with detailed metadata.
     /// </summary>
@@ -87,7 +90,7 @@ public static class HtmlParserFromTable {
             TableIndex = tableIndex,
             Id = table.Id,
             Classes = table.ClassName,
-            Caption = HtmlEntity.DeEntitize(table.QuerySelector("caption")?.TextContent ?? string.Empty).Trim()
+            Caption = HtmlEntity.DeEntitize(GetDirectCaptionText(table)).Trim()
         };
 
         foreach (var attr in table.Attributes) {
@@ -190,7 +193,7 @@ public static class HtmlParserFromTable {
         string? emptyValuePlaceholder,
         HtmlCellTextFormat cellTextFormat,
         IDictionary<string, string>? dataValueLookup = null,
-        IReadOnlyDictionary<string, string>? linkHeaderNames = null) {
+        IReadOnlyDictionary<int, string>? linkHeaderNames = null) {
         List<Dictionary<string, string?>> tableRows = new();
         Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
         Dictionary<int, (string? Value, int Remaining)> rowSpanLinks = new();
@@ -215,7 +218,7 @@ public static class HtmlParserFromTable {
                     }
                     if (linkHeaderNames != null && rowSpanLinks.TryGetValue(col, out var linkSpan)) {
                         if (!string.IsNullOrWhiteSpace(linkSpan.Value)) {
-                            linkValues[linkHeaderNames[headers[col]]] = linkSpan.Value;
+                            linkValues[linkHeaderNames[col]] = linkSpan.Value;
                         }
                         if (--linkSpan.Remaining == 0) {
                             rowSpanLinks.Remove(col);
@@ -248,10 +251,9 @@ public static class HtmlParserFromTable {
                         rowspan = rs;
                     }
                     for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
-                        string header = headers[col];
                         rowValues[col] = FillFromDataAttributes(headers[col], value, row, dataValueLookup);
                         if (linkHeaderNames != null && !string.IsNullOrWhiteSpace(linkUrl)) {
-                            linkValues[linkHeaderNames[header]] = linkUrl;
+                            linkValues[linkHeaderNames[col]] = linkUrl;
                         }
                         if (rowspan > 1) {
                             rowSpans[col] = (rowValues[col], rowspan - 1);
@@ -571,7 +573,7 @@ public static class HtmlParserFromTable {
             metadata.TableIndex = tableIndex;
             metadata.Id = table.GetAttributeValue("id", string.Empty);
             metadata.Classes = table.GetAttributeValue("class", string.Empty);
-            metadata.Caption = HtmlEntity.DeEntitize(table.SelectSingleNode(".//caption")?.InnerText ?? string.Empty).Trim();
+            metadata.Caption = HtmlEntity.DeEntitize(GetDirectCaptionText(table)).Trim();
 
             // Extract all attributes
             foreach (var attr in table.Attributes) {
@@ -730,7 +732,7 @@ public static class HtmlParserFromTable {
                         }
                         if (linkHeaderNames != null && rowSpanLinks.TryGetValue(col, out var linkSpan)) {
                             if (!string.IsNullOrWhiteSpace(linkSpan.Value)) {
-                                linkValues[linkHeaderNames[headers[col]]] = linkSpan.Value;
+                                linkValues[linkHeaderNames[col]] = linkSpan.Value;
                             }
                             if (--linkSpan.Remaining == 0) {
                                 rowSpanLinks.Remove(col);
@@ -763,10 +765,9 @@ public static class HtmlParserFromTable {
                             rowspan = rs2;
                         }
                         for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
-                            string header = headers[col];
                             rowValues[col] = FillFromDataAttributes(headers[col], value, row, dataValueLookup);
                             if (linkHeaderNames != null && !string.IsNullOrWhiteSpace(linkUrl)) {
-                                linkValues[linkHeaderNames[header]] = linkUrl;
+                                linkValues[linkHeaderNames[col]] = linkUrl;
                             }
                             if (rowspan > 1) {
                                 rowSpans[col] = (rowValues[col], rowspan - 1);
@@ -1313,11 +1314,14 @@ public static class HtmlParserFromTable {
         return HtmlEntity.DeEntitize(cleaned);
     }
 
-    private static Dictionary<string, string> BuildLinkHeaderNames(IReadOnlyList<string> headers) {
+    private static Dictionary<int, string> BuildLinkHeaderNames(IReadOnlyList<string> headers) {
         var used = new HashSet<string>(headers, StringComparer.OrdinalIgnoreCase);
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (string header in headers) {
-            string baseName = string.IsNullOrWhiteSpace(header) ? "ColumnUrl" : header + "Url";
+        var result = new Dictionary<int, string>();
+        for (int i = 0; i < headers.Count; i++) {
+            string header = headers[i];
+            string baseName = string.IsNullOrWhiteSpace(header)
+                ? DefaultColumnNamePrefix + (i + 1).ToString(CultureInfo.InvariantCulture) + LinkUrlSuffix
+                : header + LinkUrlSuffix;
             string candidate = baseName;
             int suffix = 2;
             while (!used.Add(candidate)) {
@@ -1325,7 +1329,7 @@ public static class HtmlParserFromTable {
                 suffix++;
             }
 
-            result[header] = candidate;
+            result[i] = candidate;
         }
 
         return result;
@@ -1334,20 +1338,38 @@ public static class HtmlParserFromTable {
     private static void AppendUsedLinkHeaders(
         IList<string> headers,
         IEnumerable<Dictionary<string, string?>> rows,
-        IReadOnlyDictionary<string, string>? linkHeaderNames) {
+        IReadOnlyDictionary<int, string>? linkHeaderNames) {
         if (linkHeaderNames == null) {
             return;
         }
 
+        var rowList = rows as IList<Dictionary<string, string?>> ?? rows.ToList();
         foreach (string linkHeader in linkHeaderNames.Values) {
             if (headers.Contains(linkHeader, StringComparer.OrdinalIgnoreCase)) {
                 continue;
             }
 
-            if (rows.Any(row => row.TryGetValue(linkHeader, out string? value) && !string.IsNullOrWhiteSpace(value))) {
+            if (rowList.Any(row => row.TryGetValue(linkHeader, out string? value) && !string.IsNullOrWhiteSpace(value))) {
                 headers.Add(linkHeader);
+                foreach (Dictionary<string, string?> row in rowList) {
+                    if (!row.ContainsKey(linkHeader)) {
+                        row[linkHeader] = null;
+                    }
+                }
             }
         }
+    }
+
+    private static string GetDirectCaptionText(IElement table) {
+        return table.Children
+            .FirstOrDefault(child => child.TagName.Equals("caption", StringComparison.OrdinalIgnoreCase))
+            ?.TextContent ?? string.Empty;
+    }
+
+    private static string GetDirectCaptionText(HtmlNode table) {
+        return table.ChildNodes
+            .FirstOrDefault(child => child.Name.Equals("caption", StringComparison.OrdinalIgnoreCase))
+            ?.InnerText ?? string.Empty;
     }
 
     private static string? ExtractLinkUrls(IElement cell) {

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -26,6 +26,7 @@ public static class HtmlParserFromTable {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     /// <example>
     /// <code>
@@ -40,7 +41,8 @@ public static class HtmlParserFromTable {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -61,8 +63,11 @@ public static class HtmlParserFromTable {
                 continue;
             }
 
-            var tableRows = ParseTableRows(rows, startIndex, metadata.Headers, replaceContent, allProperties, emptyValuePlaceholder, cellTextFormat, dataValueLookup);
+            var linkHeaderNames = includeLinkUrls ? BuildLinkHeaderNames(metadata.Headers) : null;
+            var tableRows = ParseTableRows(rows, startIndex, metadata.Headers, replaceContent, allProperties, emptyValuePlaceholder, cellTextFormat, dataValueLookup, linkHeaderNames);
             if (tableRows.Count > 0) {
+                AppendUsedLinkHeaders(metadata.Headers, tableRows, linkHeaderNames);
+                metadata.ColumnCount = metadata.Headers.Count;
                 result.Metadata = metadata;
                 result.Data = tableRows;
                 results.Add(result);
@@ -81,7 +86,8 @@ public static class HtmlParserFromTable {
         var metadata = new HtmlTableMetadata {
             TableIndex = tableIndex,
             Id = table.Id,
-            Classes = table.ClassName
+            Classes = table.ClassName,
+            Caption = HtmlEntity.DeEntitize(table.QuerySelector("caption")?.TextContent ?? string.Empty).Trim()
         };
 
         foreach (var attr in table.Attributes) {
@@ -183,9 +189,11 @@ public static class HtmlParserFromTable {
         bool allProperties,
         string? emptyValuePlaceholder,
         HtmlCellTextFormat cellTextFormat,
-        IDictionary<string, string>? dataValueLookup = null) {
+        IDictionary<string, string>? dataValueLookup = null,
+        IReadOnlyDictionary<string, string>? linkHeaderNames = null) {
         List<Dictionary<string, string?>> tableRows = new();
         Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
+        Dictionary<int, (string? Value, int Remaining)> rowSpanLinks = new();
         int categoryIndex = headers.FindIndex(h => h.Equals("Category", StringComparison.OrdinalIgnoreCase));
         int severityIndex = headers.FindIndex(h => h.Equals("Severity", StringComparison.OrdinalIgnoreCase));
         foreach (var row in OrderDataRows(rows, startIndex)) {
@@ -194,6 +202,7 @@ public static class HtmlParserFromTable {
             }
             var cells = row.QuerySelectorAll("th,td");
             string?[] rowValues = new string?[headers.Count];
+            Dictionary<string, string?> linkValues = new(StringComparer.OrdinalIgnoreCase);
             int col = 0;
             int cellIndex = 0;
             while (col < headers.Count) {
@@ -204,6 +213,16 @@ public static class HtmlParserFromTable {
                     } else {
                         rowSpans[col] = span;
                     }
+                    if (linkHeaderNames != null && rowSpanLinks.TryGetValue(col, out var linkSpan)) {
+                        if (!string.IsNullOrWhiteSpace(linkSpan.Value)) {
+                            linkValues[linkHeaderNames[headers[col]]] = linkSpan.Value;
+                        }
+                        if (--linkSpan.Remaining == 0) {
+                            rowSpanLinks.Remove(col);
+                        } else {
+                            rowSpanLinks[col] = linkSpan;
+                        }
+                    }
                     col++;
                     continue;
                 }
@@ -211,6 +230,7 @@ public static class HtmlParserFromTable {
                 if (cellIndex < cells.Length) {
                     var cell = cells[cellIndex++];
                     string? value = FormatCellText(cell, cellTextFormat);
+                    string? linkUrl = linkHeaderNames != null ? ExtractLinkUrls(cell) : null;
                     if (replaceContent != null) {
                         foreach (var kv in replaceContent) {
                             value = ReplaceCaseInsensitive(value, kv.Key, kv.Value);
@@ -228,9 +248,16 @@ public static class HtmlParserFromTable {
                         rowspan = rs;
                     }
                     for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
+                        string header = headers[col];
                         rowValues[col] = FillFromDataAttributes(headers[col], value, row, dataValueLookup);
+                        if (linkHeaderNames != null && !string.IsNullOrWhiteSpace(linkUrl)) {
+                            linkValues[linkHeaderNames[header]] = linkUrl;
+                        }
                         if (rowspan > 1) {
                             rowSpans[col] = (rowValues[col], rowspan - 1);
+                            if (linkHeaderNames != null) {
+                                rowSpanLinks[col] = (linkUrl, rowspan - 1);
+                            }
                         }
                     }
                 } else {
@@ -245,6 +272,9 @@ public static class HtmlParserFromTable {
             for (int i = 0; i < headers.Count; i++) {
                 string header = headers[i];
                 dict[string.IsNullOrEmpty(header) ? i.ToString() : header] = rowValues[i];
+            }
+            foreach (var linkValue in linkValues) {
+                dict[linkValue.Key] = linkValue.Value;
             }
             // Override Category/Severity from row-level data attributes when present.
             if (categoryIndex >= 0) {
@@ -504,6 +534,7 @@ public static class HtmlParserFromTable {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseTablesWithHtmlAgilityPackDetailed(
         string html,
@@ -514,7 +545,8 @@ public static class HtmlParserFromTable {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
+        bool includeLinkUrls = false) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -539,6 +571,7 @@ public static class HtmlParserFromTable {
             metadata.TableIndex = tableIndex;
             metadata.Id = table.GetAttributeValue("id", string.Empty);
             metadata.Classes = table.GetAttributeValue("class", string.Empty);
+            metadata.Caption = HtmlEntity.DeEntitize(table.SelectSingleNode(".//caption")?.InnerText ?? string.Empty).Trim();
 
             // Extract all attributes
             foreach (var attr in table.Attributes) {
@@ -671,6 +704,8 @@ public static class HtmlParserFromTable {
             int startIndex = hasHeader ? headerRowIndex + 1 : 0;
             List<Dictionary<string, string?>> tableRows = new();
             Dictionary<int, (string? Value, int Remaining)> rowSpans = new();
+            Dictionary<int, (string? Value, int Remaining)> rowSpanLinks = new();
+            var linkHeaderNames = includeLinkUrls ? BuildLinkHeaderNames(headers) : null;
             int categoryIndex = headers.FindIndex(h => h.Equals("Category", StringComparison.OrdinalIgnoreCase));
             int severityIndex = headers.FindIndex(h => h.Equals("Severity", StringComparison.OrdinalIgnoreCase));
             foreach (var row in OrderDataRows(rows, startIndex)) {
@@ -682,6 +717,7 @@ public static class HtmlParserFromTable {
                     continue;
                 }
                 string?[] rowValues = new string?[headers.Count];
+                Dictionary<string, string?> linkValues = new(StringComparer.OrdinalIgnoreCase);
                 int col = 0;
                 int cellIndex = 0;
                 while (col < headers.Count) {
@@ -692,6 +728,16 @@ public static class HtmlParserFromTable {
                         } else {
                             rowSpans[col] = span;
                         }
+                        if (linkHeaderNames != null && rowSpanLinks.TryGetValue(col, out var linkSpan)) {
+                            if (!string.IsNullOrWhiteSpace(linkSpan.Value)) {
+                                linkValues[linkHeaderNames[headers[col]]] = linkSpan.Value;
+                            }
+                            if (--linkSpan.Remaining == 0) {
+                                rowSpanLinks.Remove(col);
+                            } else {
+                                rowSpanLinks[col] = linkSpan;
+                            }
+                        }
                         col++;
                         continue;
                     }
@@ -699,6 +745,7 @@ public static class HtmlParserFromTable {
                     if (cellIndex < cells.Count) {
                         var cell = cells[cellIndex++];
                         string value = FormatCellText(cell, cellTextFormat);
+                        string? linkUrl = linkHeaderNames != null ? ExtractLinkUrls(cell) : null;
                         if (replaceContent != null) {
                             foreach (var kv in replaceContent) {
                                 value = ReplaceCaseInsensitive(value, kv.Key, kv.Value);
@@ -716,9 +763,16 @@ public static class HtmlParserFromTable {
                             rowspan = rs2;
                         }
                         for (int c = 0; c < colspan && col < headers.Count; c++, col++) {
+                            string header = headers[col];
                             rowValues[col] = FillFromDataAttributes(headers[col], value, row, dataValueLookup);
+                            if (linkHeaderNames != null && !string.IsNullOrWhiteSpace(linkUrl)) {
+                                linkValues[linkHeaderNames[header]] = linkUrl;
+                            }
                             if (rowspan > 1) {
                                 rowSpans[col] = (rowValues[col], rowspan - 1);
+                                if (linkHeaderNames != null) {
+                                    rowSpanLinks[col] = (linkUrl, rowspan - 1);
+                                }
                             }
                         }
                     } else {
@@ -733,6 +787,9 @@ public static class HtmlParserFromTable {
                 for (int i = 0; i < headers.Count; i++) {
                     string header = headers[i];
                     dict[string.IsNullOrEmpty(header) ? i.ToString() : header] = rowValues[i];
+                }
+                foreach (var linkValue in linkValues) {
+                    dict[linkValue.Key] = linkValue.Value;
                 }
                 if (categoryIndex >= 0) {
                     string key = row.GetAttributeValue("data-category", string.Empty).Trim();
@@ -766,6 +823,8 @@ public static class HtmlParserFromTable {
             }
 
             if (tableRows.Count > 0) {
+                AppendUsedLinkHeaders(metadata.Headers, tableRows, linkHeaderNames);
+                metadata.ColumnCount = metadata.Headers.Count;
                 result.Data = tableRows;
                 results.Add(result);
             }
@@ -1252,6 +1311,61 @@ public static class HtmlParserFromTable {
         AppendNodeText(cell, sb);
         var cleaned = CleanupText(sb.ToString(), format);
         return HtmlEntity.DeEntitize(cleaned);
+    }
+
+    private static Dictionary<string, string> BuildLinkHeaderNames(IReadOnlyList<string> headers) {
+        var used = new HashSet<string>(headers, StringComparer.OrdinalIgnoreCase);
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string header in headers) {
+            string baseName = string.IsNullOrWhiteSpace(header) ? "ColumnUrl" : header + "Url";
+            string candidate = baseName;
+            int suffix = 2;
+            while (!used.Add(candidate)) {
+                candidate = baseName + suffix.ToString(CultureInfo.InvariantCulture);
+                suffix++;
+            }
+
+            result[header] = candidate;
+        }
+
+        return result;
+    }
+
+    private static void AppendUsedLinkHeaders(
+        IList<string> headers,
+        IEnumerable<Dictionary<string, string?>> rows,
+        IReadOnlyDictionary<string, string>? linkHeaderNames) {
+        if (linkHeaderNames == null) {
+            return;
+        }
+
+        foreach (string linkHeader in linkHeaderNames.Values) {
+            if (headers.Contains(linkHeader, StringComparer.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (rows.Any(row => row.TryGetValue(linkHeader, out string? value) && !string.IsNullOrWhiteSpace(value))) {
+                headers.Add(linkHeader);
+            }
+        }
+    }
+
+    private static string? ExtractLinkUrls(IElement cell) {
+        var links = cell.QuerySelectorAll("a[href]")
+            .Select(link => (link.GetAttribute("href") ?? string.Empty).Trim())
+            .Where(href => href.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return links.Length == 0 ? null : string.Join("; ", links);
+    }
+
+    private static string? ExtractLinkUrls(HtmlNode cell) {
+        var links = cell.SelectNodes(".//a[@href]")?
+            .Select(link => link.GetAttributeValue("href", string.Empty).Trim())
+            .Where(href => href.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return links == null || links.Length == 0 ? null : string.Join("; ", links);
     }
 
     private static readonly HashSet<string> BlockTags = new(StringComparer.OrdinalIgnoreCase) { "p", "div", "section", "article", "header", "footer", "ul", "ol" };

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -597,6 +597,7 @@ public static class HtmlParserFromTable {
 
             if (reverseTable) {
                 Dictionary<string, string?> obj = new();
+                Dictionary<string, string?> linkValues = new(StringComparer.OrdinalIgnoreCase);
                 int index = 0;
                 foreach (var row in rows) {
                     if (row == null) {
@@ -622,9 +623,21 @@ public static class HtmlParserFromTable {
                         header = (++index).ToString();
                     }
                     obj[header] = value;
+                    if (includeLinkUrls && cells.Count > 1) {
+                        string? linkUrl = ExtractLinkUrls(cells[1]);
+                        if (!string.IsNullOrWhiteSpace(linkUrl)) {
+                            var used = new HashSet<string>(obj.Keys.Concat(linkValues.Keys), StringComparer.OrdinalIgnoreCase);
+                            string linkHeader = CreateUniqueLinkHeaderName(header, index, used);
+                            linkValues[linkHeader] = linkUrl;
+                        }
+                    }
                 }
 
                 if (obj.Count > 0) {
+                    foreach (var linkValue in linkValues) {
+                        obj[linkValue.Key] = linkValue.Value;
+                    }
+
                     result.Data = new List<Dictionary<string, string?>> { obj };
                     metadata.Headers = obj.Keys.ToList();
                     metadata.ColumnCount = obj.Count;
@@ -1319,20 +1332,24 @@ public static class HtmlParserFromTable {
         var result = new Dictionary<int, string>();
         for (int i = 0; i < headers.Count; i++) {
             string header = headers[i];
-            string baseName = string.IsNullOrWhiteSpace(header)
-                ? DefaultColumnNamePrefix + (i + 1).ToString(CultureInfo.InvariantCulture) + LinkUrlSuffix
-                : header + LinkUrlSuffix;
-            string candidate = baseName;
-            int suffix = 2;
-            while (!used.Add(candidate)) {
-                candidate = baseName + suffix.ToString(CultureInfo.InvariantCulture);
-                suffix++;
-            }
-
-            result[i] = candidate;
+            result[i] = CreateUniqueLinkHeaderName(header, i + 1, used);
         }
 
         return result;
+    }
+
+    private static string CreateUniqueLinkHeaderName(string header, int columnIndex, ISet<string> used) {
+        string baseName = string.IsNullOrWhiteSpace(header)
+            ? DefaultColumnNamePrefix + columnIndex.ToString(CultureInfo.InvariantCulture) + LinkUrlSuffix
+            : header + LinkUrlSuffix;
+        string candidate = baseName;
+        int suffix = 2;
+        while (!used.Add(candidate)) {
+            candidate = baseName + suffix.ToString(CultureInfo.InvariantCulture);
+            suffix++;
+        }
+
+        return candidate;
     }
 
     private static void AppendUsedLinkHeaders(

--- a/Sources/HtmlTinkerX/HtmlParserFromTable.cs
+++ b/Sources/HtmlTinkerX/HtmlParserFromTable.cs
@@ -29,7 +29,6 @@ public static class HtmlParserFromTable {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     /// <example>
     /// <code>
@@ -44,8 +43,33 @@ public static class HtmlParserFromTable {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseTablesWithAngleSharpDetailed(html, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from HTML markup using AngleSharp with detailed metadata.
+    /// </summary>
+    /// <param name="html">HTML content containing tables.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells (case-insensitive).</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells (case-insensitive).</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseTablesWithAngleSharpDetailed(
+        string html,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
@@ -536,7 +560,6 @@ public static class HtmlParserFromTable {
     /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
     /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
     /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
-    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
     /// <returns>List of table parse results with metadata.</returns>
     public static List<HtmlTableResult> ParseTablesWithHtmlAgilityPackDetailed(
         string html,
@@ -547,8 +570,35 @@ public static class HtmlParserFromTable {
         bool skipFooter = false,
         bool cleanHeaders = false,
         string? emptyValuePlaceholder = null,
-        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact,
-        bool includeLinkUrls = false) {
+        HtmlCellTextFormat cellTextFormat = HtmlCellTextFormat.Compact) {
+        return ParseTablesWithHtmlAgilityPackDetailed(html, reverseTable, replaceContent, replaceHeaders, allProperties, skipFooter, cleanHeaders, emptyValuePlaceholder, cellTextFormat, includeLinkUrls: false);
+    }
+
+    /// <summary>
+    /// Extracts table data from HTML markup using HtmlAgilityPack with detailed metadata.
+    /// </summary>
+    /// <param name="html">HTML content containing tables.</param>
+    /// <param name="reverseTable">Whether to treat rows as key/value pairs.</param>
+    /// <param name="replaceContent">Dictionary of text replacements for table cells (case-insensitive).</param>
+    /// <param name="replaceHeaders">Dictionary of text replacements for header cells (case-insensitive).</param>
+    /// <param name="allProperties">Whether to pad rows with missing cells.</param>
+    /// <param name="skipFooter">Whether to skip HTML table footer elements.</param>
+    /// <param name="cleanHeaders">Whether to automatically clean special characters from header names.</param>
+    /// <param name="emptyValuePlaceholder">Value to use for empty cells.</param>
+    /// <param name="cellTextFormat">Controls how cell text is flattened (compact, lines, markdown).</param>
+    /// <param name="includeLinkUrls">Whether to add companion URL columns for linked cells.</param>
+    /// <returns>List of table parse results with metadata.</returns>
+    public static List<HtmlTableResult> ParseTablesWithHtmlAgilityPackDetailed(
+        string html,
+        bool reverseTable,
+        IDictionary<string, string>? replaceContent,
+        IDictionary<string, string>? replaceHeaders,
+        bool allProperties,
+        bool skipFooter,
+        bool cleanHeaders,
+        string? emptyValuePlaceholder,
+        HtmlCellTextFormat cellTextFormat,
+        bool includeLinkUrls) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }

--- a/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
+++ b/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
@@ -11,6 +11,9 @@ namespace HtmlTinkerX;
 /// Converts parsed HTML table models into common .NET tabular shapes.
 /// </summary>
 public static class HtmlTableDataExtensions {
+    private const string DefaultColumnNamePrefix = "Column";
+    private const string DefaultDataSetName = "HtmlTables";
+
     /// <summary>
     /// Converts a parsed HTML table into a <see cref="DataTable"/>.
     /// </summary>
@@ -62,7 +65,7 @@ public static class HtmlTableDataExtensions {
             throw new ArgumentNullException(nameof(tables));
         }
 
-        var dataSet = new DataSet(string.IsNullOrWhiteSpace(dataSetName) ? "HtmlTables" : dataSetName);
+        var dataSet = new DataSet(string.IsNullOrWhiteSpace(dataSetName) ? DefaultDataSetName : dataSetName);
         var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         int index = 1;
         foreach (HtmlTableResult table in tables) {
@@ -94,9 +97,13 @@ public static class HtmlTableDataExtensions {
         }
 
         var comparison = options.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        var indexSet = options.TableIndexes.Count > 0
+        var indexSet = options.TableIndexes?.Count > 0
             ? new HashSet<int>(options.TableIndexes.Where(index => index >= 0))
             : null;
+
+        if (!HasSelectionCriteria(options, indexSet)) {
+            return tables.Where(table => table != null).ToList();
+        }
 
         return tables
             .Where(table => table != null)
@@ -120,12 +127,12 @@ public static class HtmlTableDataExtensions {
         }
 
         if (headers.Count == 0) {
-            headers.Add("Column1");
+            headers.Add(DefaultColumnNamePrefix + "1");
         }
 
         for (int i = 0; i < headers.Count; i++) {
             if (string.IsNullOrWhiteSpace(headers[i])) {
-                headers[i] = "Column" + (i + 1).ToString(CultureInfo.InvariantCulture);
+                headers[i] = DefaultColumnNamePrefix + (i + 1).ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -251,6 +258,14 @@ public static class HtmlTableDataExtensions {
         }
 
         return sanitized;
+    }
+
+    private static bool HasSelectionCriteria(HtmlTableSelectionOptions options, ISet<int>? indexSet) {
+        return indexSet?.Count > 0 ||
+               !string.IsNullOrWhiteSpace(options.Id) ||
+               !string.IsNullOrWhiteSpace(options.ClassName) ||
+               !string.IsNullOrWhiteSpace(options.CaptionContains) ||
+               !string.IsNullOrWhiteSpace(options.Header);
     }
 
     private static bool MatchesSelection(

--- a/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
+++ b/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
@@ -112,9 +112,19 @@ public static class HtmlTableDataExtensions {
     }
 
     private static List<string> GetSourceHeaders(HtmlTableResult table) {
-        var headers = table.Metadata.Headers
-            .Where(header => !string.IsNullOrWhiteSpace(header))
-            .ToList();
+        var headers = new List<string>();
+        for (int i = 0; i < table.Metadata.Headers.Count; i++) {
+            string header = table.Metadata.Headers[i];
+            if (!string.IsNullOrWhiteSpace(header)) {
+                headers.Add(header);
+                continue;
+            }
+
+            string positionalHeader = i.ToString(CultureInfo.InvariantCulture);
+            if (table.Data.Any(row => row.ContainsKey(positionalHeader))) {
+                headers.Add(positionalHeader);
+            }
+        }
 
         if (headers.Count == 0) {
             foreach (Dictionary<string, string?> row in table.Data) {

--- a/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
+++ b/Sources/HtmlTinkerX/HtmlTableDataExtensions.cs
@@ -79,6 +79,31 @@ public static class HtmlTableDataExtensions {
         return dataSet;
     }
 
+    /// <summary>
+    /// Selects parsed HTML tables by index, id, class, caption text, or header.
+    /// </summary>
+    /// <param name="tables">Parsed tables.</param>
+    /// <param name="options">Selection options. Empty options return all tables.</param>
+    public static List<HtmlTableResult> SelectTables(this IEnumerable<HtmlTableResult> tables, HtmlTableSelectionOptions? options) {
+        if (tables == null) {
+            throw new ArgumentNullException(nameof(tables));
+        }
+
+        if (options == null) {
+            return tables.Where(table => table != null).ToList();
+        }
+
+        var comparison = options.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var indexSet = options.TableIndexes.Count > 0
+            ? new HashSet<int>(options.TableIndexes.Where(index => index >= 0))
+            : null;
+
+        return tables
+            .Where(table => table != null)
+            .Where(table => MatchesSelection(table, options, indexSet, comparison))
+            .ToList();
+    }
+
     private static List<string> GetSourceHeaders(HtmlTableResult table) {
         var headers = table.Metadata.Headers
             .Where(header => !string.IsNullOrWhiteSpace(header))
@@ -226,5 +251,47 @@ public static class HtmlTableDataExtensions {
         }
 
         return sanitized;
+    }
+
+    private static bool MatchesSelection(
+        HtmlTableResult table,
+        HtmlTableSelectionOptions options,
+        ISet<int>? indexSet,
+        StringComparison comparison) {
+        var metadata = table.Metadata;
+        if (indexSet != null && !indexSet.Contains(metadata.TableIndex)) {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Id) &&
+            !string.Equals(metadata.Id, options.Id, comparison)) {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ClassName) &&
+            !HasClassToken(metadata.Classes, options.ClassName!, comparison)) {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.CaptionContains) &&
+            (metadata.Caption == null || metadata.Caption.IndexOf(options.CaptionContains!, comparison) < 0)) {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Header) &&
+            !metadata.Headers.Any(header => string.Equals(header, options.Header, comparison))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasClassToken(string? classes, string className, StringComparison comparison) {
+        if (string.IsNullOrWhiteSpace(classes)) {
+            return false;
+        }
+
+        return classes.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(token => string.Equals(token, className, comparison));
     }
 }

--- a/Sources/HtmlTinkerX/Models/HtmlTableMetadata.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlTableMetadata.cs
@@ -33,6 +33,11 @@ public class HtmlTableMetadata {
     public string? Classes { get; set; }
 
     /// <summary>
+    /// Text from the table caption element, when present.
+    /// </summary>
+    public string? Caption { get; set; }
+
+    /// <summary>
     /// Additional attributes found on the table element.
     /// </summary>
     public Dictionary<string, string> Attributes { get; set; } = new();

--- a/Sources/HtmlTinkerX/Models/HtmlTableSelectionOptions.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlTableSelectionOptions.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Options for selecting parsed HTML tables by common metadata.
+/// </summary>
+public sealed class HtmlTableSelectionOptions {
+    /// <summary>Zero-based table indexes to include.</summary>
+    public IList<int> TableIndexes { get; set; } = new List<int>();
+
+    /// <summary>Table id to match.</summary>
+    public string? Id { get; set; }
+
+    /// <summary>CSS class token to match.</summary>
+    public string? ClassName { get; set; }
+
+    /// <summary>Caption text fragment to match.</summary>
+    public string? CaptionContains { get; set; }
+
+    /// <summary>Header text to match.</summary>
+    public string? Header { get; set; }
+
+    /// <summary>Use case-insensitive comparisons.</summary>
+    public bool IgnoreCase { get; set; } = true;
+}

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -153,7 +153,7 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
         }
 
         var detailedTables = SelectTables(await GetTablesDetailedAsync().ConfigureAwait(false));
-        if (detailedTables.Count == 0 && HasTableSelection()) {
+        if (detailedTables.Count == 0 && HasTableSelection() && !AsDataSet.IsPresent) {
             return;
         }
 

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -83,6 +83,31 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter InferTypes { get; set; }
 
+    /// <summary>Add companion URL columns for linked table cells.</summary>
+    [Parameter]
+    public SwitchParameter IncludeLinkUrls { get; set; }
+
+    /// <summary>Zero-based table indexes to include.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int[]? TableIndex { get; set; }
+
+    /// <summary>Table id to include.</summary>
+    [Parameter]
+    public string? TableId { get; set; }
+
+    /// <summary>CSS class token to include.</summary>
+    [Parameter]
+    public string? TableClass { get; set; }
+
+    /// <summary>Caption text fragment to include.</summary>
+    [Parameter]
+    public string? Caption { get; set; }
+
+    /// <summary>Header name to include.</summary>
+    [Parameter]
+    public string? Header { get; set; }
+
     /// <summary>Pad rows with missing cells.</summary>
     [Parameter]
     public SwitchParameter AllProperties { get; set; }
@@ -127,7 +152,7 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
             throw new PSArgumentException("-IncludeMetadata cannot be combined with -AsDataTable or -AsDataSet.");
         }
 
-        var detailedTables = await GetTablesDetailedAsync();
+        var detailedTables = SelectTables(await GetTablesDetailedAsync().ConfigureAwait(false));
 
         if (AsDataSet.IsPresent) {
             WriteObject(detailedTables.ToDataSet(DataSetName, InferTypes.IsPresent), false);
@@ -174,26 +199,26 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);
             if (Engine == HtmlParserEngine.AngleSharp && !ReverseTable.IsPresent) {
                 string content = (await HtmlParser.ParseUrlWithAngleSharpAsync(Url.ToString(), client).ConfigureAwait(false)).DocumentElement.OuterHtml;
-                return HtmlParser.ParseTablesWithAngleSharpDetailed(content, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+                return HtmlParser.ParseTablesWithAngleSharpDetailed(content, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
             }
 
             var doc = await HtmlParser.ParseUrlWithHtmlAgilityPackAsync(Url.ToString(), client).ConfigureAwait(false);
-            return HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(doc.DocumentNode.OuterHtml, ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+            return HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(doc.DocumentNode.OuterHtml, ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
         }
 
         if (ParameterSetName == ParameterSetFile) {
             if (Engine == HtmlParserEngine.AngleSharp && !ReverseTable.IsPresent) {
-                return HtmlParser.ParseFileTablesWithAngleSharpDetailed(Path.ToFullPath(), Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+                return HtmlParser.ParseFileTablesWithAngleSharpDetailed(Path.ToFullPath(), Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
             }
 
-            return HtmlParser.ParseFileTablesWithHtmlAgilityPackDetailed(Path.ToFullPath(), ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+            return HtmlParser.ParseFileTablesWithHtmlAgilityPackDetailed(Path.ToFullPath(), ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
         }
 
         if (Engine == HtmlParserEngine.AngleSharp && !ReverseTable.IsPresent) {
-            return HtmlParser.ParseTablesWithAngleSharpDetailed(Content, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+            return HtmlParser.ParseTablesWithAngleSharpDetailed(Content, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
         }
 
-        return HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(Content, ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat());
+        return HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(Content, ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
     }
 
     private HtmlCellTextFormat GetCellTextFormat() =>
@@ -218,6 +243,7 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
         tableObject.Properties.Add(new PSNoteProperty("TableIndex", tableResult.Metadata.TableIndex));
         tableObject.Properties.Add(new PSNoteProperty("TableId", tableResult.Metadata.Id ?? string.Empty));
         tableObject.Properties.Add(new PSNoteProperty("TableClasses", tableResult.Metadata.Classes ?? string.Empty));
+        tableObject.Properties.Add(new PSNoteProperty("Caption", tableResult.Metadata.Caption ?? string.Empty));
         tableObject.Properties.Add(new PSNoteProperty("TableAttributes", tableResult.Metadata.Attributes));
         tableObject.Properties.Add(new PSNoteProperty("RowCount", tableResult.Metadata.RowCount));
         tableObject.Properties.Add(new PSNoteProperty("ColumnCount", tableResult.Metadata.ColumnCount));
@@ -225,6 +251,31 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
         tableObject.Properties.Add(new PSNoteProperty("IsVisible", tableResult.Metadata.IsVisible));
 
         return tableObject;
+    }
+
+    private List<HtmlTableResult> SelectTables(List<HtmlTableResult> tables) {
+        if ((TableIndex == null || TableIndex.Length == 0) &&
+            string.IsNullOrWhiteSpace(TableId) &&
+            string.IsNullOrWhiteSpace(TableClass) &&
+            string.IsNullOrWhiteSpace(Caption) &&
+            string.IsNullOrWhiteSpace(Header)) {
+            return tables;
+        }
+
+        var options = new HtmlTableSelectionOptions {
+            Id = TableId,
+            ClassName = TableClass,
+            CaptionContains = Caption,
+            Header = Header
+        };
+
+        if (TableIndex != null) {
+            foreach (int index in TableIndex) {
+                options.TableIndexes.Add(index);
+            }
+        }
+
+        return tables.SelectTables(options);
     }
 
     /// <summary>

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlTable.cs
@@ -153,6 +153,9 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
         }
 
         var detailedTables = SelectTables(await GetTablesDetailedAsync().ConfigureAwait(false));
+        if (detailedTables.Count == 0 && HasTableSelection()) {
+            return;
+        }
 
         if (AsDataSet.IsPresent) {
             WriteObject(detailedTables.ToDataSet(DataSetName, InferTypes.IsPresent), false);
@@ -220,6 +223,13 @@ public sealed class CmdletConvertFromHtmlTable : AsyncPSCmdlet {
 
         return HtmlParser.ParseTablesWithHtmlAgilityPackDetailed(Content, ReverseTable.IsPresent, Cast(ReplaceContent), Cast(ReplaceHeaders), AllProperties.IsPresent, SkipFooter.IsPresent, CleanHeaders.IsPresent, EmptyValuePlaceholder, GetCellTextFormat(), IncludeLinkUrls.IsPresent);
     }
+
+    private bool HasTableSelection() =>
+        TableIndex != null ||
+        !string.IsNullOrWhiteSpace(TableId) ||
+        !string.IsNullOrWhiteSpace(TableClass) ||
+        !string.IsNullOrWhiteSpace(Caption) ||
+        !string.IsNullOrWhiteSpace(Header);
 
     private HtmlCellTextFormat GetCellTextFormat() =>
         Enum.TryParse<HtmlCellTextFormat>(CellTextFormat, true, out var fmt) ? fmt : HtmlCellTextFormat.Compact;

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -258,6 +258,17 @@ $($ignoredTables -join "`n")
         $Rows.Count | Should -Be 0
     }
 
+    It 'Returns an empty DataSet when table selection matches nothing with AsDataSet' {
+        $Html = @"
+<table id="summary"><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+"@
+
+        $DataSet = ConvertFrom-HtmlTable -Content $Html -TableId 'missing' -AsDataSet
+
+        $DataSet.GetType().FullName | Should -Be 'System.Data.DataSet'
+        $DataSet.Tables.Count | Should -Be 0
+    }
+
     It 'Returns parsed tables from file path as a DataTable' {
         $Path = Join-Path $TestDrive 'table.html'
         @"

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -248,6 +248,16 @@ $($ignoredTables -join "`n")
         $DataTable.Rows[0]['NameUrl'] | Should -Be 'https://example.com/report'
     }
 
+    It 'Returns no output when table selection matches nothing' {
+        $Html = @"
+<table id="summary"><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+"@
+
+        $Rows = @(ConvertFrom-HtmlTable -Content $Html -TableId 'missing')
+
+        $Rows.Count | Should -Be 0
+    }
+
     It 'Returns parsed tables from file path as a DataTable' {
         $Path = Join-Path $TestDrive 'table.html'
         @"

--- a/Tests/ConvertFrom-HtmlTable.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlTable.Tests.ps1
@@ -222,6 +222,32 @@ $($ignoredTables -join "`n")
         $DataSet.Tables[1].Rows[0]['Name'] | Should -Be 'Two'
     }
 
+    It 'Selects tables and includes link URL metadata when requested' {
+        $Html = @"
+<table id="summary" class="report compact"><caption>Summary data</caption><tr><th>Name</th></tr><tr><td>One</td></tr></table>
+<table id="details" class="report wide">
+    <caption>Detailed data</caption>
+    <tr><th>Name</th><th>Owner</th></tr>
+    <tr><td><a href="https://example.com/report">Report</a></td><td>Team A</td></tr>
+</table>
+"@
+
+        $Rows = ConvertFrom-HtmlTable -Content $Html -TableId 'details' -IncludeLinkUrls
+
+        $Rows.Count | Should -Be 1
+        $Rows[0].Name | Should -Be 'Report'
+        $Rows[0].NameUrl | Should -Be 'https://example.com/report'
+
+        $Metadata = ConvertFrom-HtmlTable -Content $Html -TableClass 'compact' -Caption 'summary' -Header 'Name' -IncludeMetadata
+        $Metadata.TableId | Should -Be 'summary'
+        $Metadata.Caption | Should -Be 'Summary data'
+
+        $DataTable = ConvertFrom-HtmlTable -Content $Html -TableIndex 1 -AsDataTable -IncludeLinkUrls
+        $DataTable.GetType().FullName | Should -Be 'System.Data.DataTable'
+        $DataTable.Columns['NameUrl'].ColumnName | Should -Be 'NameUrl'
+        $DataTable.Rows[0]['NameUrl'] | Should -Be 'https://example.com/report'
+    }
+
     It 'Returns parsed tables from file path as a DataTable' {
         $Path = Join-Path $TestDrive 'table.html'
         @"


### PR DESCRIPTION
Summary: add reusable HtmlTinkerX table selection options, capture captions, and optionally emit companion URL columns for linked cells; expose the selection and IncludeLinkUrls switches through ConvertFrom-HtmlTable. Tests: dotnet build PSParseHTML.PowerShell net8.0; HtmlTinkerX HtmlTableDataExtensionsTests net8.0; ConvertFrom-HtmlTable Pester tests.