### PR TITLE
Replace screenshot image stack with ChartForgeX

### DIFF
--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -1,18 +1,16 @@
 # Dependency Policy
 
-## SixLabors packages
+## Screenshot image processing
 
-Keep the SixLabors image stack on the 2.x-compatible package line:
+HtmlTinkerX uses ChartForgeX for dependency-free screenshot post-processing:
 
-- `SixLabors.ImageSharp` `2.1.13`
-- `SixLabors.ImageSharp.Drawing` `1.0.0`
-- `SixLabors.Fonts` `1.0.1`
+- decoding Playwright PNG/JPEG screenshot bytes for overlays and format conversion
+- drawing selector highlight rectangles and overlay text
+- encoding PNG, JPEG, BMP, and GIF screenshot output
 
-Do not upgrade `SixLabors.ImageSharp` to 3.x or `SixLabors.ImageSharp.Drawing` to 2.x as part of routine dependency cleanup. Those versions move the dependency graph onto the newer SixLabors license model. A future upgrade should be a deliberate project decision with an explicit license review, not an automatic package bump.
+The package reference lives in `Sources/HtmlTinkerX/HtmlTinkerX.csproj` and applies to every target framework, including `net472`, `net8.0`, and `net10.0`. Local development can pass `-p:ChartForgeXProjectPath=...` to validate against a sibling ChartForgeX checkout before a package is published.
 
-This means `dotnet list package --outdated` is expected to report these packages as outdated. Treat that as an intentional pin unless the license decision changes.
-
-The package references live in `Sources/HtmlTinkerX/HtmlTinkerX.csproj` and apply to every target framework, including `net472`, `net8.0`, and `net10.0`.
+Keep screenshot overlays thin and route reusable raster behavior through ChartForgeX instead of adding a second image-processing stack.
 
 ## JavaScript parser packages
 

--- a/README.MD
+++ b/README.MD
@@ -18,7 +18,7 @@ HtmlTinkerX is available as NuGet from the Nuget Gallery and PSParseHTML PowerSh
 [![top language](https://img.shields.io/github/languages/top/evotecit/HtmlTinkerX.svg)](https://github.com/EvotecIT/HtmlTinkerX)
 [![codecov](https://codecov.io/gh/EvotecIT/HtmlTinkerX/branch/v2-speedygonzales/graph/badge.svg)](https://codecov.io/gh/EvotecIT/HtmlTinkerX)
 
-Dependency guardrails, including the intentional SixLabors 2.x-compatible pin, are documented in [Docs/Dependencies.md](Docs/Dependencies.md).
+Dependency guardrails, including the ChartForgeX-backed screenshot image-processing path, are documented in [Docs/Dependencies.md](Docs/Dependencies.md).
 
 ## 👨‍💻 Author & Social
 [![Twitter Follow](https://img.shields.io/twitter/follow/PrzemyslawKlys.svg?label=Twitter%20%40PrzemyslawKlys&style=social)](https://twitter.com/PrzemyslawKlys)
@@ -1811,11 +1811,9 @@ HtmlTinkerX utilizes several high-quality open-source libraries:
 
 ### 🌐 Browser Automation
 - **[Microsoft.Playwright](https://github.com/microsoft/playwright-dotnet)** - Apache 2.0 License - Browser automation
-- **[SixLabors.ImageSharp](https://github.com/SixLabors/ImageSharp)** - Apache 2.0 License - Image processing
-- **[SixLabors.ImageSharp.Drawing](https://github.com/SixLabors/ImageSharp.Drawing)** - Apache 2.0 License - Image drawing
-- **[SixLabors.Fonts](https://github.com/SixLabors/Fonts)** - Apache 2.0 License - Font handling
+- **[ChartForgeX](https://github.com/EvotecIT/ChartForgeX)** - MIT License - Dependency-free screenshot image composition
 
-SixLabors packages are intentionally pinned to the 2.x-compatible line. See [Docs/Dependencies.md](Docs/Dependencies.md) before changing those versions.
+Screenshot image post-processing is routed through ChartForgeX. See [Docs/Dependencies.md](Docs/Dependencies.md) before changing that dependency path.
 
 ### 🔧 System Libraries
 - **[System.Net.Http](https://learn.microsoft.com/dotnet/api/system.net.http)** - MIT License - HTTP client

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
@@ -118,6 +118,31 @@ public class HtmlBrowserScreenshotTests {
         Directory.Delete(dir);
     }
 
+    [Fact]
+    public async Task CaptureScreenshotAsync_SavesRequestedGifFormat() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string file = Path.Combine(dir, "test.gif");
+        var page = new Mock<IPage>();
+        page.Setup(p => p.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()))
+            .ReturnsAsync(CreatePngImage());
+
+        await HtmlBrowser.CaptureScreenshotAsync(
+            page.Object,
+            file,
+            new ScreenshotOptions { Format = ImageFormat.Gif });
+
+        Assert.True(File.Exists(file));
+        byte[] saved = File.ReadAllBytes(file);
+        Assert.True(saved.Length > 16);
+        Assert.Equal((byte)'G', saved[0]);
+        Assert.Equal((byte)'I', saved[1]);
+        Assert.Equal((byte)'F', saved[2]);
+        Assert.Equal(0x3B, saved[^1]);
+
+        File.Delete(file);
+        Directory.Delete(dir);
+    }
+
     [Theory]
     [InlineData(100, 0)]
     [InlineData(50, 5)]

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
@@ -1,11 +1,8 @@
+using ChartForgeX;
+using ChartForgeX.Raster;
 using HtmlTinkerX;
 using Microsoft.Playwright;
 using Moq;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.Formats;
 using System.Reflection;
 using System;
 using System.IO;
@@ -16,15 +13,17 @@ namespace HtmlTinkerX.Tests;
 
 public class HtmlBrowserScreenshotTests {
     private static byte[] CreatePngImage() {
-        using var image = new Image<Rgba32>(20, 20);
+        var pixels = new byte[20 * 20 * 4];
         for (int y = 0; y < 20; y++) {
             for (int x = 0; x < 20; x++) {
-                image[x, y] = Color.Blue;
+                int offset = (y * 20 + x) * 4;
+                pixels[offset] = 0;
+                pixels[offset + 1] = 0;
+                pixels[offset + 2] = 255;
+                pixels[offset + 3] = 255;
             }
         }
-        using var ms = new MemoryStream();
-        image.SaveAsPng(ms);
-        return ms.ToArray();
+        return new RgbaImage(20, 20, pixels).ToPng();
     }
 
     [Fact]
@@ -84,6 +83,9 @@ public class HtmlBrowserScreenshotTests {
         byte[] original = CreatePngImage();
         byte[] saved = File.ReadAllBytes(file);
         Assert.NotEqual(original, saved);
+        var decoded = RasterImageDecoder.Decode(saved);
+        var highlightPixel = PixelAt(decoded, 1, 1);
+        Assert.True(highlightPixel.R > 180 && highlightPixel.G < 80 && highlightPixel.B < 80);
         element.Verify(e => e.BoundingBoxAsync(), Times.AtLeastOnce());
 
         File.Delete(file);
@@ -120,10 +122,14 @@ public class HtmlBrowserScreenshotTests {
     [InlineData(100, 0)]
     [InlineData(50, 5)]
     [InlineData(0, 9)]
-    public void GetEncoder_MapsQualityToCompression(int quality, int expected) {
-        MethodInfo method = typeof(HtmlBrowser).GetMethod("GetEncoder", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var encoder = (IImageEncoder)method.Invoke(null, new object[] { ImageFormat.Png, quality })!;
-        var png = Assert.IsType<PngEncoder>(encoder);
-        Assert.Equal(expected, (int)png.CompressionLevel);
+    public void QualityToCompression_MapsScreenshotQuality(int quality, int expected) {
+        MethodInfo method = typeof(HtmlBrowser).GetMethod("QualityToCompression", BindingFlags.NonPublic | BindingFlags.Static)!;
+        int compression = (int)method.Invoke(null, new object[] { quality })!;
+        Assert.Equal(expected, compression);
+    }
+
+    private static (byte R, byte G, byte B, byte A) PixelAt(RgbaImage image, int x, int y) {
+        int offset = (y * image.Width + x) * 4;
+        return (image.Pixels[offset], image.Pixels[offset + 1], image.Pixels[offset + 2], image.Pixels[offset + 3]);
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserScreenshotTests.cs
@@ -93,6 +93,38 @@ public class HtmlBrowserScreenshotTests {
     }
 
     [Fact]
+    public async Task CaptureScreenshotAsync_SkipsZeroSizeHighlightsAndContinuesSelectorMatches() {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string file = Path.Combine(dir, "highlight-zero.png");
+        var page = new Mock<IPage>();
+        var zeroElement = new Mock<IElementHandle>();
+        var validElement = new Mock<IElementHandle>();
+        zeroElement.Setup(e => e.BoundingBoxAsync())
+            .ReturnsAsync(new ElementHandleBoundingBoxResult { X = 1, Y = 1, Width = 0, Height = 2 });
+        validElement.Setup(e => e.BoundingBoxAsync())
+            .ReturnsAsync(new ElementHandleBoundingBoxResult { X = 4, Y = 4, Width = 3, Height = 3 });
+        page.Setup(p => p.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()))
+            .ReturnsAsync(CreatePngImage());
+        page.Setup(p => p.QuerySelectorAllAsync("div"))
+            .ReturnsAsync(new[] { zeroElement.Object, validElement.Object });
+
+        await HtmlBrowser.CaptureScreenshotAsync(
+            page.Object,
+            file,
+            new ScreenshotOptions { HighlightSelectors = new[] { "div" } });
+
+        Assert.True(File.Exists(file));
+        var decoded = RasterImageDecoder.Decode(File.ReadAllBytes(file));
+        var highlightPixel = PixelAt(decoded, 4, 4);
+        Assert.True(highlightPixel.R > 180 && highlightPixel.G < 80 && highlightPixel.B < 80);
+        zeroElement.Verify(e => e.BoundingBoxAsync(), Times.Once);
+        validElement.Verify(e => e.BoundingBoxAsync(), Times.Once);
+
+        File.Delete(file);
+        Directory.Delete(dir);
+    }
+
+    [Fact]
     public async Task CaptureScreenshotAsync_SavesRequestedFormat() {
         string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         string file = Path.Combine(dir, "test.bmp");
@@ -137,7 +169,7 @@ public class HtmlBrowserScreenshotTests {
         Assert.Equal((byte)'G', saved[0]);
         Assert.Equal((byte)'I', saved[1]);
         Assert.Equal((byte)'F', saved[2]);
-        Assert.Equal(0x3B, saved[^1]);
+        Assert.Equal(0x3B, saved[saved.Length - 1]);
 
         File.Delete(file);
         Directory.Delete(dir);

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -12,6 +12,7 @@
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <OfficeImoMarkdownHtmlVersion>0.1.13</OfficeImoMarkdownHtmlVersion>
+        <ChartForgeXVersion>0.1.6</ChartForgeXVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -26,16 +27,14 @@
         <PackageReference Include="System.IO.Compression" Version="4.3.0" Condition=" '$(TargetFramework)' == 'net472' " />
         <PackageReference Include="System.Net.Http" Version="4.3.4" Condition=" '$(TargetFramework)' == 'net472' " />
         <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
+    </ItemGroup>
 
-        <!--
-            Keep the SixLabors stack on the 2.x-compatible line.
-            ImageSharp 3.x changed licensing; do not upgrade these packages to 3.x/2.x Drawing
-            unless the project intentionally accepts the new license terms.
-            See Docs/Dependencies.md for the dependency policy.
-        -->
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
-        <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
-        <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+    <ItemGroup Condition=" '$(ChartForgeXProjectPath)' != '' ">
+        <ProjectReference Include="$(ChartForgeXProjectPath)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(ChartForgeXProjectPath)' == '' ">
+        <PackageReference Include="ChartForgeX" Version="$(ChartForgeXVersion)" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
@@ -139,7 +139,7 @@ public static partial class HtmlBrowser {
                         var elements = await page.QuerySelectorAllAsync(sel);
                         foreach (var element in elements) {
                             var box = await element.BoundingBoxAsync();
-                            if (box != null) {
+                            if (box != null && box.Width > 0 && box.Height > 0) {
                                 composition.StrokeRectangle(box.X, box.Y, box.Width, box.Height, ChartColors.Red, 3);
                             }
                         }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Screenshot.cs
@@ -1,13 +1,8 @@
 ﻿using Microsoft.Playwright;
-using SixLabors.Fonts;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.Formats.Bmp;
-using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.Processing;
+using ChartForgeX.Composition;
+using ChartForgeX.Core;
+using ChartForgeX.Primitives;
+using ChartForgeX.Raster;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -137,8 +132,7 @@ public static partial class HtmlBrowser {
 
         bool needsProcessing = (options.HighlightSelectors != null && System.Linq.Enumerable.Any(options.HighlightSelectors)) || !string.IsNullOrEmpty(options.OverlayText) || (options.Format != ImageFormat.Png && options.Format != ImageFormat.Jpeg);
         if (needsProcessing) {
-            using var image = SixLabors.ImageSharp.Image.Load(data);
-            var pen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(SixLabors.ImageSharp.Color.Red, 3);
+            var composition = ImageComposition.FromBytes(data);
             if (options.HighlightSelectors != null) {
                 foreach (string sel in options.HighlightSelectors) {
                     try {
@@ -146,8 +140,7 @@ public static partial class HtmlBrowser {
                         foreach (var element in elements) {
                             var box = await element.BoundingBoxAsync();
                             if (box != null) {
-                                var rect = new SixLabors.ImageSharp.RectangleF((float)box.X, (float)box.Y, (float)box.Width, (float)box.Height);
-                                image.Mutate(c => c.Draw(pen, rect));
+                                composition.StrokeRectangle(box.X, box.Y, box.Width, box.Height, ChartColors.Red, 3);
                             }
                         }
                     } catch {
@@ -156,27 +149,38 @@ public static partial class HtmlBrowser {
                 }
             }
 
-            if (!string.IsNullOrEmpty(options.OverlayText)) {
-                SixLabors.Fonts.FontFamily fontFamily;
-                if (!SixLabors.Fonts.SystemFonts.TryGet("DejaVu Sans", out fontFamily) &&
-                    !SixLabors.Fonts.SystemFonts.TryGet("Arial", out fontFamily)) {
-                    fontFamily = SixLabors.Fonts.SystemFonts.Collection.Families.First();
-                }
-                var font = fontFamily.CreateFont(20);
-                image.Mutate(c => c.DrawText(options.OverlayText, font, SixLabors.ImageSharp.Color.Red, new SixLabors.ImageSharp.PointF(10, 10)));
+            string? overlayText = options.OverlayText;
+            if (overlayText != null && overlayText.Length > 0) {
+                composition.DrawText(10, 10, Math.Max(1, composition.Width - 20), overlayText, 20, ChartColors.Red);
             }
-            await image.SaveAsync(fullPath, GetEncoder(options.Format, options.Quality));
+            File.WriteAllBytes(fullPath, composition.ToRasterImage(ToRasterImageFormat(options.Format), GetRasterImageOptions(options.Quality)));
         } else {
             File.WriteAllBytes(fullPath, data);
         }
     }
 
-    private static IImageEncoder GetEncoder(ImageFormat format, int quality) => format switch {
-        ImageFormat.Jpeg => new JpegEncoder { Quality = quality },
-        ImageFormat.Bmp => new BmpEncoder(),
-        ImageFormat.Gif => new GifEncoder(),
-        _ => new PngEncoder { CompressionLevel = (PngCompressionLevel)QualityToCompression(quality) }
+    private static RasterImageFormat ToRasterImageFormat(ImageFormat format) => format switch {
+        ImageFormat.Jpeg => RasterImageFormat.Jpeg,
+        ImageFormat.Bmp => RasterImageFormat.Bmp,
+        ImageFormat.Gif => RasterImageFormat.Gif,
+        _ => RasterImageFormat.Png
     };
+
+    private static RasterImageOptions GetRasterImageOptions(int quality) => new() {
+        Background = ChartColors.White,
+        JpegQuality = ClampJpegQuality(quality),
+        PngCompressionLevel = QualityToCompression(quality)
+    };
+
+    private static int ClampJpegQuality(int quality) {
+        if (quality < 1) {
+            return 1;
+        }
+        if (quality > 100) {
+            return 100;
+        }
+        return quality;
+    }
 
     private static int QualityToCompression(int quality) {
         if (quality < 0) {

--- a/Tests/AssemblyLoadContext.Conflict.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Conflict.Tests.ps1
@@ -40,7 +40,7 @@ Import-Module PSParseHTML -Force
     ForEach-Object {
         `$alc = `$_
         foreach (`$assembly in `$alc.Assemblies) {
-            if (`$assembly.GetName().Name -in @('PSParseHTML.PowerShell', 'HtmlTinkerX', 'SixLabors.ImageSharp', 'Spectre.Console')) {
+            if (`$assembly.GetName().Name -in @('PSParseHTML.PowerShell', 'HtmlTinkerX', 'ChartForgeX', 'Spectre.Console')) {
                 [pscustomobject]@{
                     Assembly = `$assembly.GetName().Name
                     Version = `$assembly.GetName().Version.ToString()


### PR DESCRIPTION
## Summary
- replace screenshot post-processing with ChartForgeX image composition and raster encoding
- remove the three SixLabors package references from HtmlTinkerX
- update screenshot tests, dependency docs, README, and packaged ALC assembly tracking for the ChartForgeX path

## Validation
- dotnet build .\Sources\HtmlTinkerX.sln -c Release -p:ChartForgeXProjectPath= -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- dotnet test .\Sources\HtmlTinkerX.Tests\HtmlTinkerX.Tests.csproj -c Release --no-build --filter FullyQualifiedName~HtmlBrowserScreenshotTests -p:ChartForgeXProjectPath= -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- dotnet build .\Sources\HtmlTinkerX\HtmlTinkerX.csproj -c Release -f net8.0 -p:ChartForgeXProjectPath=C:\Support\GitHub\ChartForgeX\ChartForgeX\ChartForgeX.csproj -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- dotnet list .\Sources\HtmlTinkerX\HtmlTinkerX.csproj package --include-transitive --no-restore
- rg -n "SixLabors|ImageSharp|ImageSharp\.Drawing|SixLabors\.Fonts" -S .
- git diff --check