### PR TITLE
Add HtmlNode input for JSON-LD parsing

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerStructuredDataTests.cs
@@ -18,12 +18,30 @@ public class HtmlCrawlerStructuredJsonTests {
     }
 
     private static HttpListener StartServer(Dictionary<string, string> responses, out string rootUrl) {
-        int port = GetFreePort();
-        rootUrl = $"http://localhost:{port}/";
-        HttpListener listener = new();
-        listener.Prefixes.Add(rootUrl);
-        listener.Start();
+        const int maxAttempts = 20;
+        Exception? lastException = null;
 
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            int port = GetFreePort();
+            string candidateRootUrl = $"http://127.0.0.1:{port}/";
+            HttpListener listener = new();
+            listener.Prefixes.Add(candidateRootUrl);
+
+            try {
+                listener.Start();
+                rootUrl = candidateRootUrl;
+                StartResponseLoop(listener, responses);
+                return listener;
+            } catch (HttpListenerException ex) {
+                lastException = ex;
+                DisposeListenerSafely(listener);
+            }
+        }
+
+        throw new InvalidOperationException("Unable to start test HTTP listener.", lastException);
+    }
+
+    private static void StartResponseLoop(HttpListener listener, Dictionary<string, string> responses) {
         _ = Task.Run(async () => {
             try {
                 while (listener.IsListening) {
@@ -44,8 +62,6 @@ public class HtmlCrawlerStructuredJsonTests {
             } catch (ObjectDisposedException) {
             }
         });
-
-        return listener;
     }
 
     private static void DisposeListenerSafely(HttpListener listener) {

--- a/Sources/HtmlTinkerX/HtmlModernParsers.cs
+++ b/Sources/HtmlTinkerX/HtmlModernParsers.cs
@@ -96,15 +96,24 @@ public static class HtmlJsonLdParser {
             throw new ArgumentNullException(nameof(scriptContents));
         }
 
-        List<HtmlJsonLdItem> items = new();
-        int scriptIndex = 0;
-        foreach (string scriptContent in scriptContents) {
-            string json = (scriptContent ?? string.Empty).Trim();
-            if (json.Length > 0) {
-                AddJsonLdItems(json, scriptIndex, items);
-            }
+        return ParseScriptContents(scriptContents.Select((scriptContent, scriptIndex) => new KeyValuePair<int, string>(scriptIndex, scriptContent)));
+    }
 
-            scriptIndex++;
+    /// <summary>Extracts JSON-LD items from indexed script element contents.</summary>
+    /// <param name="scriptContents">Pairs containing the original script index and the raw JSON-LD payload.</param>
+    /// <returns>Flattened JSON-LD items parsed from each non-empty script payload.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="scriptContents"/> is null.</exception>
+    public static IReadOnlyList<HtmlJsonLdItem> ParseScriptContents(IEnumerable<KeyValuePair<int, string>> scriptContents) {
+        if (scriptContents == null) {
+            throw new ArgumentNullException(nameof(scriptContents));
+        }
+
+        List<HtmlJsonLdItem> items = new();
+        foreach (KeyValuePair<int, string> scriptContent in scriptContents) {
+            string json = (scriptContent.Value ?? string.Empty).Trim();
+            if (json.Length > 0) {
+                AddJsonLdItems(json, scriptContent.Key, items);
+            }
         }
 
         return items;

--- a/Sources/HtmlTinkerX/HtmlModernParsers.cs
+++ b/Sources/HtmlTinkerX/HtmlModernParsers.cs
@@ -87,6 +87,29 @@ public sealed class HtmlRobotsRule {
 
 /// <summary>Extracts JSON-LD structured data from HTML.</summary>
 public static class HtmlJsonLdParser {
+    /// <summary>Extracts JSON-LD items from script element contents.</summary>
+    /// <param name="scriptContents">The raw contents of script elements that contain JSON-LD payloads.</param>
+    /// <returns>Flattened JSON-LD items parsed from each non-empty script payload.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="scriptContents"/> is null.</exception>
+    public static IReadOnlyList<HtmlJsonLdItem> ParseScriptContents(IEnumerable<string> scriptContents) {
+        if (scriptContents == null) {
+            throw new ArgumentNullException(nameof(scriptContents));
+        }
+
+        List<HtmlJsonLdItem> items = new();
+        int scriptIndex = 0;
+        foreach (string scriptContent in scriptContents) {
+            string json = (scriptContent ?? string.Empty).Trim();
+            if (json.Length > 0) {
+                AddJsonLdItems(json, scriptIndex, items);
+            }
+
+            scriptIndex++;
+        }
+
+        return items;
+    }
+
     public static IReadOnlyList<HtmlJsonLdItem> Parse(string html) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -10,6 +10,18 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts JSON-LD structured data from HTML.</summary>
+/// <example>
+///   <summary>Extract JSON-LD from static HTML content</summary>
+///   <code>ConvertFrom-HtmlJsonLd -Content $html</code>
+/// </example>
+/// <example>
+///   <summary>Download a page and extract JSON-LD structured data</summary>
+///   <code>ConvertFrom-HtmlJsonLd -Url https://example.org/article</code>
+/// </example>
+/// <example>
+///   <summary>Inspect only selected JSON-LD script nodes from an HtmlAgilityPack pipeline</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//script[@type="application/ld+json"]' | ConvertFrom-HtmlJsonLd</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlJsonLd", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlJsonLdItem))]
 public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -1,5 +1,7 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Net.Http;
@@ -8,11 +10,12 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts JSON-LD structured data from HTML.</summary>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlJsonLd", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlJsonLd", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlJsonLdItem))]
 public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
     private const string ParameterSetFile = "File";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML content to inspect.</summary>
@@ -25,6 +28,11 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
     [Alias("File")]
     [ValidateNotNullOrEmpty]
     public string Path { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of an HTML page to download and inspect.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -42,8 +50,35 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         ValidateProxy(Proxy, ProxyCredential);
+        if (ParameterSetName == ParameterSetNode) {
+            WriteObject(HtmlJsonLdParser.ParseScriptContents(GetJsonLdScriptContents()).ToArray(), true);
+            return;
+        }
+
         string html = await ReadHtmlAsync().ConfigureAwait(false);
         WriteObject(HtmlJsonLdParser.Parse(html).ToArray(), true);
+    }
+
+    private IEnumerable<string> GetJsonLdScriptContents() {
+        if (IsJsonLdScript(HtmlNode)) {
+            yield return HtmlNode.InnerHtml;
+            yield break;
+        }
+
+        foreach (HtmlNode script in HtmlNode.Descendants("script")) {
+            if (IsJsonLdScript(script)) {
+                yield return script.InnerHtml;
+            }
+        }
+    }
+
+    private static bool IsJsonLdScript(HtmlNode node) {
+        if (!string.Equals(node.Name, "script", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        string type = node.GetAttributeValue("type", string.Empty);
+        return type.Contains("ld+json", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<string> ReadHtmlAsync() {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -73,18 +73,34 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
 
     private IEnumerable<KeyValuePair<int, string>> GetJsonLdScriptContents() {
         if (IsJsonLdScript(HtmlNode)) {
-            yield return new KeyValuePair<int, string>(0, HtmlNode.InnerHtml);
+            yield return new KeyValuePair<int, string>(GetSourceScriptIndex(HtmlNode, 0), HtmlNode.InnerHtml);
             yield break;
         }
 
         int scriptIndex = 0;
         foreach (HtmlNode script in HtmlNode.Descendants("script")) {
             if (IsJsonLdScript(script)) {
-                yield return new KeyValuePair<int, string>(scriptIndex, script.InnerHtml);
+                yield return new KeyValuePair<int, string>(GetSourceScriptIndex(script, scriptIndex), script.InnerHtml);
             }
 
             scriptIndex++;
         }
+    }
+
+    private static int GetSourceScriptIndex(HtmlNode script, int fallbackIndex) {
+        HtmlNode? documentNode = script.OwnerDocument?.DocumentNode;
+        if (documentNode != null) {
+            int index = 0;
+            foreach (HtmlNode candidate in documentNode.Descendants("script")) {
+                if (ReferenceEquals(candidate, script)) {
+                    return index;
+                }
+
+                index++;
+            }
+        }
+
+        return fallbackIndex;
     }
 
     private static bool IsJsonLdScript(HtmlNode node) {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -59,16 +59,19 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
         WriteObject(HtmlJsonLdParser.Parse(html).ToArray(), true);
     }
 
-    private IEnumerable<string> GetJsonLdScriptContents() {
+    private IEnumerable<KeyValuePair<int, string>> GetJsonLdScriptContents() {
         if (IsJsonLdScript(HtmlNode)) {
-            yield return HtmlNode.InnerHtml;
+            yield return new KeyValuePair<int, string>(0, HtmlNode.InnerHtml);
             yield break;
         }
 
+        int scriptIndex = 0;
         foreach (HtmlNode script in HtmlNode.Descendants("script")) {
             if (IsJsonLdScript(script)) {
-                yield return script.InnerHtml;
+                yield return new KeyValuePair<int, string>(scriptIndex, script.InnerHtml);
             }
+
+            scriptIndex++;
         }
     }
 

--- a/Tests/ModernParsingCmdlets.Tests.ps1
+++ b/Tests/ModernParsingCmdlets.Tests.ps1
@@ -40,6 +40,16 @@ const csrfToken = "script-token";
         $items[0].Type | Should -Be 'Article'
     }
 
+    It 'extracts JSON-LD from selected HtmlNode pipeline input' {
+        $items = ConvertFrom-HTML -Content $script:Html |
+            Select-HtmlNode -XPath '//script[@type="application/ld+json"]' |
+            ConvertFrom-HtmlJsonLd
+
+        $items | Should -HaveCount 1
+        $items[0].Type | Should -Be 'Article'
+        $items[0].Id | Should -Be 'https://example.org/article'
+    }
+
     It 'extracts app state' {
         $state = ConvertFrom-HtmlAppState -Content $script:Html
 

--- a/Tests/ModernParsingCmdlets.Tests.ps1
+++ b/Tests/ModernParsingCmdlets.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Modern parsing cmdlets' {
 <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
 <meta name="description" content="A short summary" />
 <meta name="csrf-token" content="meta-token" />
+<script>console.log("first script");</script>
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"Article","@id":"https://example.org/article","headline":"Hello"}
 </script>
@@ -38,6 +39,7 @@ const csrfToken = "script-token";
 
         $items | Should -HaveCount 1
         $items[0].Type | Should -Be 'Article'
+        $items[0].ScriptIndex | Should -Be 1
     }
 
     It 'extracts JSON-LD from selected HtmlNode pipeline input' {
@@ -47,6 +49,15 @@ const csrfToken = "script-token";
 
         $items | Should -HaveCount 1
         $items[0].Type | Should -Be 'Article'
+        $items[0].Id | Should -Be 'https://example.org/article'
+    }
+
+    It 'preserves JSON-LD script indexes from HtmlNode document input' {
+        $items = ConvertFrom-HTML -Content $script:Html |
+            ConvertFrom-HtmlJsonLd
+
+        $items | Should -HaveCount 1
+        $items[0].ScriptIndex | Should -Be 1
         $items[0].Id | Should -Be 'https://example.org/article'
     }
 

--- a/Tests/ModernParsingCmdlets.Tests.ps1
+++ b/Tests/ModernParsingCmdlets.Tests.ps1
@@ -50,6 +50,24 @@ const csrfToken = "script-token";
         $items | Should -HaveCount 1
         $items[0].Type | Should -Be 'Article'
         $items[0].Id | Should -Be 'https://example.org/article'
+        $items[0].ScriptIndex | Should -Be 1
+    }
+
+    It 'preserves JSON-LD source script indexes from multiple selected HtmlNode inputs' {
+        $html = @'
+<html><head>
+<script>console.log("one")</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"One"}</script>
+<script>console.log("two")</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Two"}</script>
+</head></html>
+'@
+        $items = ConvertFrom-HTML -Content $html |
+            Select-HtmlNode -XPath '//script[@type="application/ld+json"]' |
+            ConvertFrom-HtmlJsonLd
+
+        $items | Should -HaveCount 2
+        $items.ScriptIndex | Should -Be @(1, 3)
     }
 
     It 'preserves JSON-LD script indexes from HtmlNode document input' {

--- a/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
+++ b/Tests/Save-HTMLAttachment.Streaming.Tests.ps1
@@ -1,33 +1,113 @@
 Describe 'Save-HTMLAttachment streaming' {
-    It 'Outputs file paths as downloads complete' -Skip:(-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
-        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
-        $listener.Start()
-        $port = $listener.LocalEndpoint.Port
-        $listener.Stop()
+    BeforeAll {
+        if (-not ('StreamingAttachmentTestHttpServer' -as [type])) {
+            Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
-        # Bind explicitly to IPv4 to avoid macOS IPv6-only listener issues
-        $server = Start-Process -FilePath python3 -ArgumentList '-u', '-m', 'http.server', $port, '--bind', '127.0.0.1' -WorkingDirectory (Join-Path $PSScriptRoot 'Documents') -PassThru
-        Start-Sleep -Seconds 1
-        $timeout = [System.Diagnostics.Stopwatch]::StartNew()
-        while ($true) {
+public sealed class StreamingAttachmentTestHttpServer : IDisposable {
+    private sealed class ServerResponse {
+        public string Body { get; set; } = string.Empty;
+        public string ContentType { get; set; } = "text/html; charset=utf-8";
+    }
+
+    private readonly HttpListener _listener = new HttpListener();
+    private readonly ConcurrentDictionary<string, ServerResponse> _responses = new ConcurrentDictionary<string, ServerResponse>(StringComparer.OrdinalIgnoreCase);
+    private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+    private readonly Task _serverTask;
+
+    public StreamingAttachmentTestHttpServer(string prefix) {
+        Prefix = prefix;
+        _listener.Prefixes.Add(prefix);
+        _listener.Start();
+        _serverTask = Task.Run(ListenAsync);
+    }
+
+    public string Prefix { get; }
+
+    public void AddResponse(string path, string body, string contentType) {
+        _responses[path] = new ServerResponse {
+            Body = body ?? string.Empty,
+            ContentType = string.IsNullOrWhiteSpace(contentType) ? "text/html; charset=utf-8" : contentType
+        };
+    }
+
+    private async Task ListenAsync() {
+        while (!_cancellation.IsCancellationRequested) {
+            HttpListenerContext context;
+
             try {
-                $socket = New-Object Net.Sockets.TcpClient
-                $socket.Connect('127.0.0.1', $port)
-                $socket.Dispose()
-                break
-            } catch {
-                if ($server.HasExited) {
-                    throw "HTTP server exited before accepting connections. Exit code: $($server.ExitCode)"
-                }
-                if ($timeout.Elapsed -gt [TimeSpan]::FromSeconds(10)) {
-                    throw 'HTTP server failed to start.'
-                }
-                Start-Sleep -Milliseconds 500
+                context = await _listener.GetContextAsync().ConfigureAwait(false);
+            } catch (HttpListenerException) when (_cancellation.IsCancellationRequested || !_listener.IsListening) {
+                break;
+            } catch (ObjectDisposedException) when (_cancellation.IsCancellationRequested) {
+                break;
             }
+
+            string rawUrl = string.IsNullOrWhiteSpace(context.Request.RawUrl) ? "/" : context.Request.RawUrl;
+            if (!_responses.TryGetValue(rawUrl, out ServerResponse response)) {
+                context.Response.StatusCode = 404;
+                context.Response.Close();
+                continue;
+            }
+
+            byte[] bytes = Encoding.UTF8.GetBytes(response.Body);
+            context.Response.ContentType = response.ContentType;
+            context.Response.ContentLength64 = bytes.Length;
+            await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+            context.Response.OutputStream.Close();
         }
+    }
+
+    public void Dispose() {
+        _cancellation.Cancel();
         try {
-            # Match the server bind address to avoid IPv6/IPv4 mismatch
-            $uri = "http://127.0.0.1:$port/multi_download.html"
+            if (_listener.IsListening) {
+                _listener.Stop();
+            }
+        } catch {
+        }
+
+        _listener.Close();
+
+        try {
+            _serverTask.Wait(TimeSpan.FromSeconds(5));
+        } catch {
+        }
+
+        _cancellation.Dispose();
+    }
+}
+"@
+        }
+
+        function New-StreamingAttachmentServerPrefix {
+            $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+            $listener.Start()
+            $port = ([System.Net.IPEndPoint] $listener.LocalEndpoint).Port
+            $listener.Stop()
+
+            "http://127.0.0.1:$port/"
+        }
+
+        function Start-StreamingAttachmentServer {
+            $documents = Join-Path $PSScriptRoot 'Documents'
+            $server = [StreamingAttachmentTestHttpServer]::new((New-StreamingAttachmentServerPrefix))
+            $server.AddResponse('/multi_download.html', [System.IO.File]::ReadAllText((Join-Path $documents 'multi_download.html')), 'text/html; charset=utf-8')
+            $server.AddResponse('/download1.txt', [System.IO.File]::ReadAllText((Join-Path $documents 'download1.txt')), 'text/plain; charset=utf-8')
+            $server.AddResponse('/download2.txt', [System.IO.File]::ReadAllText((Join-Path $documents 'download2.txt')), 'text/plain; charset=utf-8')
+            $server
+        }
+    }
+
+    It 'Outputs file paths as downloads complete' {
+        $server = Start-StreamingAttachmentServer
+        try {
+            $uri = $server.Prefix + 'multi_download.html'
             $dest = Join-Path $TestDrive 'stream'
             $results = @()
             foreach ($file in Save-HTMLAttachment -Url $uri -Path $dest) {
@@ -38,8 +118,8 @@ Describe 'Save-HTMLAttachment streaming' {
             Test-Path (Join-Path $dest 'download2.txt') | Should -BeTrue
         }
         finally {
-            if ($server -and -not $server.HasExited) {
-                $server | Stop-Process
+            if ($server) {
+                $server.Dispose()
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow ConvertFrom-HtmlJsonLd to accept HtmlAgilityPack HtmlNode input from the pipeline
- add a reusable HtmlJsonLdParser.ParseScriptContents entry point for JSON-LD script payloads
- add XML examples for content, URL, and selected HtmlNode JSON-LD extraction workflows
- cover the Select-HtmlNode | ConvertFrom-HtmlJsonLd workflow with Pester

## Use cases covered
- Extract JSON-LD from raw HTML strings, saved files, or downloaded pages with the existing ConvertFrom-HtmlJsonLd surface.
- Pipe a selected HtmlAgilityPack JSON-LD script node into ConvertFrom-HtmlJsonLd instead of reserializing the whole document.
- Pipe a root/document HtmlNode into ConvertFrom-HtmlJsonLd while preserving original script indexes so results still map back to source script positions.
- Reuse HtmlJsonLdParser.ParseScriptContents from .NET callers that already have JSON-LD script bodies and want HtmlJsonLdItem metadata.

## Usage examples
```powershell
# Extract JSON-LD from static HTML content
$jsonLd = ConvertFrom-HtmlJsonLd -Content $html
```

```powershell
# Download a page and extract JSON-LD
$jsonLd = ConvertFrom-HtmlJsonLd -Url 'https://example.org/article'
```

```powershell
# Parse only selected JSON-LD script nodes from an HtmlAgilityPack pipeline
$jsonLd = ConvertFrom-HTML -Content $html |
    Select-HtmlNode -XPath '//script[@type="application/ld+json"]' |
    ConvertFrom-HtmlJsonLd
```

```powershell
# Parse JSON-LD from a selected root/document node while preserving source script indexes
$jsonLd = ConvertFrom-HTML -Content $html |
    ConvertFrom-HtmlJsonLd
```

## Validation
- dotnet build .\Sources\HtmlTinkerX.sln -c Debug -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- Invoke-Pester -Path '.\Tests\ModernParsingCmdlets.Tests.ps1' -Output Detailed
- git diff --check