### PR TITLE
Add node input for structured parsers

### DIFF
--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAppState.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAppState.cs
@@ -1,3 +1,4 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System;
 using System.Linq;
@@ -8,11 +9,12 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts common embedded application state objects from HTML.</summary>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlAppState", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlAppState", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlAppStateEntry))]
 public sealed class CmdletConvertFromHtmlAppState : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
     private const string ParameterSetFile = "File";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML content to inspect.</summary>
@@ -25,6 +27,11 @@ public sealed class CmdletConvertFromHtmlAppState : AsyncPSCmdlet {
     [Alias("File")]
     [ValidateNotNullOrEmpty]
     public string Path { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of an HTML page to download and inspect.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -54,6 +61,8 @@ public sealed class CmdletConvertFromHtmlAppState : AsyncPSCmdlet {
                 using (HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential)) {
                     return await HtmlUtilities.GetStringWithProperEncodingAsync(client, Url.ToString()).ConfigureAwait(false);
                 }
+            case ParameterSetNode:
+                return HtmlPipelineInput.ToHtmlMarkup(HtmlNode);
             default:
                 return Content;
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAppState.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlAppState.cs
@@ -9,6 +9,14 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts common embedded application state objects from HTML.</summary>
+/// <example>
+///   <summary>Extract framework app-state payloads from HTML content</summary>
+///   <code>ConvertFrom-HtmlAppState -Content $html</code>
+/// </example>
+/// <example>
+///   <summary>Inspect only a selected script node for app-state payloads</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//script[@id="__NEXT_DATA__"]' | ConvertFrom-HtmlAppState</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlAppState", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlAppStateEntry))]
 public sealed class CmdletConvertFromHtmlAppState : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlHeadLink.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlHeadLink.cs
@@ -1,3 +1,4 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System;
 using System.Linq;
@@ -8,11 +9,12 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts canonical, alternate, feed, icon, manifest, preload, and related head links.</summary>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlHeadLink", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlHeadLink", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlHeadLink))]
 public sealed class CmdletConvertFromHtmlHeadLink : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
     private const string ParameterSetFile = "File";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML content to inspect.</summary>
@@ -25,6 +27,11 @@ public sealed class CmdletConvertFromHtmlHeadLink : AsyncPSCmdlet {
     [Alias("File")]
     [ValidateNotNullOrEmpty]
     public string Path { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of an HTML page to download and inspect.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -59,6 +66,8 @@ public sealed class CmdletConvertFromHtmlHeadLink : AsyncPSCmdlet {
                 using (HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential)) {
                     return await HtmlUtilities.GetStringWithProperEncodingAsync(client, Url.ToString()).ConfigureAwait(false);
                 }
+            case ParameterSetNode:
+                return HtmlPipelineInput.ToHtmlMarkup(HtmlNode);
             default:
                 return Content;
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlHeadLink.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlHeadLink.cs
@@ -9,6 +9,14 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts canonical, alternate, feed, icon, manifest, preload, and related head links.</summary>
+/// <example>
+///   <summary>Extract and resolve head links from a page</summary>
+///   <code>ConvertFrom-HtmlHeadLink -Url https://example.org/page</code>
+/// </example>
+/// <example>
+///   <summary>Inspect only the selected head node</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//head' | ConvertFrom-HtmlHeadLink -BaseUrl https://example.org/page</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlHeadLink", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlHeadLink))]
 public sealed class CmdletConvertFromHtmlHeadLink : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -23,6 +23,14 @@ namespace PSParseHTML.PowerShell;
 ///   <summary>Inspect only selected JSON-LD script nodes from an HtmlAgilityPack pipeline</summary>
 ///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//script[@type="application/ld+json"]' | ConvertFrom-HtmlJsonLd</code>
 /// </example>
+/// <example>
+///   <summary>Return only Product JSON-LD items</summary>
+///   <code>ConvertFrom-HtmlJsonLd -Content $html -Type Product</code>
+/// </example>
+/// <example>
+///   <summary>Emit parsed JSON payload objects instead of metadata records</summary>
+///   <code>ConvertFrom-HtmlJsonLd -Content $html -Type Product -AsObject</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlJsonLd", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlJsonLdItem))]
 public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -30,6 +30,10 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
     private const string ParameterSetFile = "File";
     private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
+    private static readonly JsonDocumentOptions JsonOptions = new() {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
 
     /// <summary>HTML content to inspect.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
@@ -143,7 +147,7 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
 
     private static object? ConvertRawJsonToObject(HtmlJsonLdItem item) {
         try {
-            using JsonDocument document = JsonDocument.Parse(item.RawJson);
+            using JsonDocument document = JsonDocument.Parse(item.RawJson, JsonOptions);
             return ConvertJsonElement(document.RootElement);
         } catch (JsonException) {
             return item.RawJson;

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlJsonLd.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace PSParseHTML.PowerShell;
@@ -59,16 +60,31 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
     [Parameter(ParameterSetName = ParameterSetUrl)]
     public PSCredential? ProxyCredential { get; set; }
 
+    /// <summary>Filters results to one or more JSON-LD @type values.</summary>
+    [Parameter]
+    public string[]? Type { get; set; }
+
+    /// <summary>Emits parsed JSON payloads instead of HtmlJsonLdItem metadata objects.</summary>
+    [Parameter]
+    public SwitchParameter AsObject { get; set; }
+
     /// <inheritdoc />
     protected override async Task ProcessRecordAsync() {
         ValidateProxy(Proxy, ProxyCredential);
+        IReadOnlyList<HtmlJsonLdItem> items;
         if (ParameterSetName == ParameterSetNode) {
-            WriteObject(HtmlJsonLdParser.ParseScriptContents(GetJsonLdScriptContents()).ToArray(), true);
-            return;
+            items = HtmlJsonLdParser.ParseScriptContents(GetJsonLdScriptContents());
+        } else {
+            string html = await ReadHtmlAsync().ConfigureAwait(false);
+            items = HtmlJsonLdParser.Parse(html);
         }
 
-        string html = await ReadHtmlAsync().ConfigureAwait(false);
-        WriteObject(HtmlJsonLdParser.Parse(html).ToArray(), true);
+        HtmlJsonLdItem[] filteredItems = FilterByType(items).ToArray();
+        if (AsObject.IsPresent) {
+            WriteObject(filteredItems.Select(ConvertRawJsonToObject).ToArray(), true);
+        } else {
+            WriteObject(filteredItems, true);
+        }
     }
 
     private IEnumerable<KeyValuePair<int, string>> GetJsonLdScriptContents() {
@@ -110,6 +126,60 @@ public sealed class CmdletConvertFromHtmlJsonLd : AsyncPSCmdlet {
 
         string type = node.GetAttributeValue("type", string.Empty);
         return type.Contains("ld+json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IEnumerable<HtmlJsonLdItem> FilterByType(IEnumerable<HtmlJsonLdItem> items) {
+        if (Type == null || Type.Length == 0) {
+            return items;
+        }
+
+        HashSet<string> types = new(Type.Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => value.Trim()), StringComparer.OrdinalIgnoreCase);
+        if (types.Count == 0) {
+            return items;
+        }
+
+        return items.Where(item => item.Type != null && item.Type.Split(',').Any(value => types.Contains(value.Trim())));
+    }
+
+    private static object? ConvertRawJsonToObject(HtmlJsonLdItem item) {
+        try {
+            using JsonDocument document = JsonDocument.Parse(item.RawJson);
+            return ConvertJsonElement(document.RootElement);
+        } catch (JsonException) {
+            return item.RawJson;
+        }
+    }
+
+    private static object? ConvertJsonElement(JsonElement element) {
+        switch (element.ValueKind) {
+            case JsonValueKind.Object:
+                PSObject obj = new();
+                foreach (JsonProperty property in element.EnumerateObject()) {
+                    obj.Properties.Add(new PSNoteProperty(property.Name, ConvertJsonElement(property.Value)));
+                }
+
+                return obj;
+            case JsonValueKind.Array:
+                return element.EnumerateArray().Select(ConvertJsonElement).ToArray();
+            case JsonValueKind.String:
+                return element.GetString();
+            case JsonValueKind.Number:
+                if (element.TryGetInt64(out long longValue)) {
+                    return longValue;
+                }
+
+                if (element.TryGetDecimal(out decimal decimalValue)) {
+                    return decimalValue;
+                }
+
+                return element.GetDouble();
+            case JsonValueKind.True:
+                return true;
+            case JsonValueKind.False:
+                return false;
+            default:
+                return null;
+        }
     }
 
     private async Task<string> ReadHtmlAsync() {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
@@ -11,7 +11,12 @@ namespace PSParseHTML.PowerShell;
 /// Parses &lt;meta&gt; tags from HTML content or a URL.
 /// </summary>
 /// <example>
-/// <code>ConvertFrom-HtmlMeta -Url https://example.com</code>
+///   <summary>Extract meta tags from a page</summary>
+///   <code>ConvertFrom-HtmlMeta -Url https://example.com</code>
+/// </example>
+/// <example>
+///   <summary>Inspect only the selected head node</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//head' | ConvertFrom-HtmlMeta</code>
 /// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlMeta", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(PSObject))]

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMeta.cs
@@ -1,3 +1,4 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System.Collections.Generic;
 using System.Management.Automation;
@@ -12,15 +13,21 @@ namespace PSParseHTML.PowerShell;
 /// <example>
 /// <code>ConvertFrom-HtmlMeta -Url https://example.com</code>
 /// </example>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlMeta", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlMeta", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(PSObject))]
 public sealed class CmdletConvertFromHtmlMeta : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML content with meta tags.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public string Content { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of a page with meta tags.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -42,6 +49,8 @@ public sealed class CmdletConvertFromHtmlMeta : AsyncPSCmdlet {
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);
             tags = await HtmlParser.ParseUrlMetaTagsAsync(Url.ToString(), client).ConfigureAwait(false);
+        } else if (ParameterSetName == ParameterSetNode) {
+            tags = HtmlParser.ParseMetaTags(HtmlPipelineInput.ToHtmlMarkup(HtmlNode));
         } else {
             tags = HtmlParser.ParseMetaTags(Content);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
@@ -1,3 +1,4 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System.Collections.Generic;
 using System.Management.Automation;
@@ -12,15 +13,21 @@ namespace PSParseHTML.PowerShell;
 /// <example>
 /// <code>ConvertFrom-HtmlMicrodata -Content $html</code>
 /// </example>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlMicrodata", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlMicrodata", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(PSObject))]
 public sealed class CmdletConvertFromHtmlMicrodata : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML markup containing microdata.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public string Content { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of a page with microdata.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -42,6 +49,8 @@ public sealed class CmdletConvertFromHtmlMicrodata : AsyncPSCmdlet {
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);
             items = await HtmlParser.ParseUrlMicrodataItemsAsync(Url.ToString(), client).ConfigureAwait(false);
+        } else if (ParameterSetName == ParameterSetNode) {
+            items = HtmlParser.ParseMicrodataItems(HtmlPipelineInput.ToHtmlMarkup(HtmlNode));
         } else {
             items = HtmlParser.ParseMicrodataItems(Content);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlMicrodata.cs
@@ -11,7 +11,12 @@ namespace PSParseHTML.PowerShell;
 /// Extracts microdata items from HTML content or a URL.
 /// </summary>
 /// <example>
-/// <code>ConvertFrom-HtmlMicrodata -Content $html</code>
+///   <summary>Extract microdata items from HTML content</summary>
+///   <code>ConvertFrom-HtmlMicrodata -Content $html</code>
+/// </example>
+/// <example>
+///   <summary>Inspect only selected microdata markup</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//*[@itemscope]' | ConvertFrom-HtmlMicrodata</code>
 /// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlMicrodata", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(PSObject))]

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlOpenGraph.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlOpenGraph.cs
@@ -1,3 +1,4 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System.Collections.Generic;
 using System.Management.Automation;
@@ -12,15 +13,21 @@ namespace PSParseHTML.PowerShell;
 /// <example>
 /// <code>ConvertFrom-HtmlOpenGraph -Content $html</code>
 /// </example>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlOpenGraph", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlOpenGraph", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(PSObject))]
 public sealed class CmdletConvertFromHtmlOpenGraph : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML markup containing Open Graph meta tags.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetContent, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public string Content { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of a page with Open Graph metadata.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -42,6 +49,8 @@ public sealed class CmdletConvertFromHtmlOpenGraph : AsyncPSCmdlet {
         if (ParameterSetName == ParameterSetUrl) {
             using HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential);
             graph = await HtmlParser.ParseUrlOpenGraphAsync(Url.ToString(), client).ConfigureAwait(false);
+        } else if (ParameterSetName == ParameterSetNode) {
+            graph = HtmlParser.ParseOpenGraph(HtmlPipelineInput.ToHtmlMarkup(HtmlNode));
         } else {
             graph = HtmlParser.ParseOpenGraph(Content);
         }

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlOpenGraph.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlOpenGraph.cs
@@ -11,7 +11,12 @@ namespace PSParseHTML.PowerShell;
 /// Extracts Open Graph metadata from HTML content or a URL.
 /// </summary>
 /// <example>
-/// <code>ConvertFrom-HtmlOpenGraph -Content $html</code>
+///   <summary>Extract Open Graph metadata from HTML content</summary>
+///   <code>ConvertFrom-HtmlOpenGraph -Content $html</code>
+/// </example>
+/// <example>
+///   <summary>Inspect only the selected head node</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//head' | ConvertFrom-HtmlOpenGraph</code>
 /// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlOpenGraph", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(PSObject))]

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlScriptData.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlScriptData.cs
@@ -9,6 +9,14 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts generic JSON data embedded in script tags.</summary>
+/// <example>
+///   <summary>Extract generic JSON script data from HTML content</summary>
+///   <code>ConvertFrom-HtmlScriptData -Content $html</code>
+/// </example>
+/// <example>
+///   <summary>Inspect a selected application/json script node</summary>
+///   <code>ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//script[@type="application/json"]' | ConvertFrom-HtmlScriptData</code>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "HtmlScriptData", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlScriptDataItem))]
 public sealed class CmdletConvertFromHtmlScriptData : AsyncPSCmdlet {

--- a/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlScriptData.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletConvertFromHtmlScriptData.cs
@@ -1,3 +1,4 @@
+using HtmlAgilityPack;
 using HtmlTinkerX;
 using System;
 using System.Linq;
@@ -8,11 +9,12 @@ using System.Threading.Tasks;
 namespace PSParseHTML.PowerShell;
 
 /// <summary>Extracts generic JSON data embedded in script tags.</summary>
-[Cmdlet(VerbsData.ConvertFrom, "HtmlScriptData", DefaultParameterSetName = ParameterSetContent)]
+[Cmdlet(VerbsData.ConvertFrom, "HtmlScriptData", DefaultParameterSetName = ParameterSetNode)]
 [OutputType(typeof(HtmlScriptDataItem))]
 public sealed class CmdletConvertFromHtmlScriptData : AsyncPSCmdlet {
     private const string ParameterSetContent = "Content";
     private const string ParameterSetFile = "File";
+    private const string ParameterSetNode = "Node";
     private const string ParameterSetUrl = "Url";
 
     /// <summary>HTML content to inspect.</summary>
@@ -25,6 +27,11 @@ public sealed class CmdletConvertFromHtmlScriptData : AsyncPSCmdlet {
     [Alias("File")]
     [ValidateNotNullOrEmpty]
     public string Path { get; set; } = string.Empty;
+
+    /// <summary>HtmlAgilityPack node to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetNode, ValueFromPipeline = true, Position = 0)]
+    [Alias("Node", "InputObject")]
+    public HtmlNode HtmlNode { get; set; } = null!;
 
     /// <summary>URL of an HTML page to download and inspect.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetUrl)]
@@ -54,6 +61,8 @@ public sealed class CmdletConvertFromHtmlScriptData : AsyncPSCmdlet {
                 using (HttpClient client = HttpClientHelper.Create(Proxy, ProxyCredential)) {
                     return await HtmlUtilities.GetStringWithProperEncodingAsync(client, Url.ToString()).ConfigureAwait(false);
                 }
+            case ParameterSetNode:
+                return HtmlPipelineInput.ToHtmlMarkup(HtmlNode);
             default:
                 return Content;
         }

--- a/Sources/PSParseHTML.PowerShell/HtmlPipelineInput.cs
+++ b/Sources/PSParseHTML.PowerShell/HtmlPipelineInput.cs
@@ -16,6 +16,11 @@ internal static class HtmlPipelineInput {
         };
     }
 
+    internal static string ToHtmlMarkup(object input) {
+        HtmlNode node = ToHtmlNode(input);
+        return node.OuterHtml;
+    }
+
     internal static object Unwrap(object input) {
         if (input == null) {
             throw new PSArgumentNullException(nameof(input));

--- a/Tests/ConvertFrom-HtmlMeta.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlMeta.Tests.ps1
@@ -6,4 +6,15 @@ Describe 'ConvertFrom-HtmlMeta' {
         $tags.Count | Should -Be 2
         ($tags | Where-Object Name -eq 'description').Content | Should -Be 'Example site'
     }
+
+    It 'Parses meta tags from selected HtmlNode pipeline input' {
+        $path = Join-Path $PSScriptRoot 'Documents/sample_meta.html'
+        $content = Get-Content -LiteralPath $path -Raw
+        $tags = ConvertFrom-HTML -Content $content |
+            Select-HtmlNode -XPath '//head' |
+            ConvertFrom-HtmlMeta
+
+        $tags.Count | Should -Be 2
+        ($tags | Where-Object Name -eq 'description').Content | Should -Be 'Example site'
+    }
 }

--- a/Tests/ConvertFrom-HtmlMicrodata.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlMicrodata.Tests.ps1
@@ -6,4 +6,15 @@ Describe 'ConvertFrom-HtmlMicrodata' {
         $items.Count | Should -Be 1
         $items[0].Properties.name[0] | Should -Be 'Jane Doe'
     }
+
+    It 'Parses microdata items from selected HtmlNode pipeline input' {
+        $path = Join-Path $PSScriptRoot 'Documents/microdata.html'
+        $content = Get-Content -LiteralPath $path -Raw
+        $items = ConvertFrom-HTML -Content $content |
+            Select-HtmlNode -XPath '//*[@itemscope]' |
+            ConvertFrom-HtmlMicrodata
+
+        $items.Count | Should -Be 1
+        $items[0].Properties.name[0] | Should -Be 'Jane Doe'
+    }
 }

--- a/Tests/ConvertFrom-HtmlOpenGraph.Tests.ps1
+++ b/Tests/ConvertFrom-HtmlOpenGraph.Tests.ps1
@@ -6,4 +6,15 @@ Describe 'ConvertFrom-HtmlOpenGraph' {
         $data.title | Should -Be 'Open Graph Title'
         $data.image | Should -Be 'https://example.com/img.png'
     }
+
+    It 'Parses Open Graph data from selected HtmlNode pipeline input' {
+        $path = Join-Path $PSScriptRoot 'Documents/open_graph.html'
+        $content = Get-Content -LiteralPath $path -Raw
+        $data = ConvertFrom-HTML -Content $content |
+            Select-HtmlNode -XPath '//head' |
+            ConvertFrom-HtmlOpenGraph
+
+        $data.title | Should -Be 'Open Graph Title'
+        $data.image | Should -Be 'https://example.com/img.png'
+    }
 }

--- a/Tests/ModernParsingCmdlets.Tests.ps1
+++ b/Tests/ModernParsingCmdlets.Tests.ps1
@@ -99,6 +99,25 @@ const csrfToken = "script-token";
         $objects[0].name | Should -Be 'Widget'
     }
 
+    It 'emits parsed JSON-LD objects when tolerant JSON syntax is accepted' {
+        $html = @'
+<html><head>
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "name":"Widget",
+  // accepted by the JSON-LD parser options
+}
+</script>
+</head></html>
+'@
+        $objects = ConvertFrom-HtmlJsonLd -Content $html -AsObject
+
+        $objects | Should -HaveCount 1
+        $objects[0].name | Should -Be 'Widget'
+    }
+
     It 'extracts app state' {
         $state = ConvertFrom-HtmlAppState -Content $script:Html
 

--- a/Tests/ModernParsingCmdlets.Tests.ps1
+++ b/Tests/ModernParsingCmdlets.Tests.ps1
@@ -79,6 +79,26 @@ const csrfToken = "script-token";
         $items[0].Id | Should -Be 'https://example.org/article'
     }
 
+    It 'filters JSON-LD by type and emits parsed objects' {
+        $html = @'
+<html><head>
+<script type="application/ld+json">
+[
+  {"@context":"https://schema.org","@type":"Article","headline":"Hello"},
+  {"@context":"https://schema.org","@type":"Product","name":"Widget"}
+]
+</script>
+</head></html>
+'@
+        $items = ConvertFrom-HtmlJsonLd -Content $html -Type Product
+        $objects = ConvertFrom-HtmlJsonLd -Content $html -Type Product -AsObject
+
+        $items | Should -HaveCount 1
+        $items[0].Type | Should -Be 'Product'
+        $objects | Should -HaveCount 1
+        $objects[0].name | Should -Be 'Widget'
+    }
+
     It 'extracts app state' {
         $state = ConvertFrom-HtmlAppState -Content $script:Html
 
@@ -87,6 +107,15 @@ const csrfToken = "script-token";
         $state.Name | Should -Contain '__APOLLO_STATE__'
         ($state | Where-Object Name -EQ '__INITIAL_STATE__').RawJson | Should -Match '"enabled":true'
         ($state | Where-Object Name -EQ '__INITIAL_STATE__').RawJson | Should -Match '"disabled":false'
+    }
+
+    It 'extracts app state from selected HtmlNode pipeline input' {
+        $state = ConvertFrom-HTML -Content $script:Html |
+            Select-HtmlNode -XPath '//script[@id="__NEXT_DATA__"]' |
+            ConvertFrom-HtmlAppState
+
+        $state | Should -HaveCount 1
+        $state[0].Name | Should -Be '__NEXT_DATA__'
     }
 
     It 'extracts head links' {

--- a/Tests/PageDiscoveryCmdlets.Tests.ps1
+++ b/Tests/PageDiscoveryCmdlets.Tests.ps1
@@ -48,6 +48,24 @@ Expires: 2026-12-31T23:59:59Z
         $items[0].IsJson | Should -BeTrue
     }
 
+    It 'extracts generic script JSON data from selected HtmlNode pipeline input' {
+        $items = ConvertFrom-HTML -Content $script:Html |
+            Select-HtmlNode -XPath '//script[@id="settings"]' |
+            ConvertFrom-HtmlScriptData
+
+        $items | Should -HaveCount 1
+        $items[0].Id | Should -Be 'settings'
+        $items[0].IsJson | Should -BeTrue
+    }
+
+    It 'extracts head links from selected HtmlNode pipeline input' {
+        $links = ConvertFrom-HTML -Content $script:Html |
+            Select-HtmlNode -XPath '//head' |
+            ConvertFrom-HtmlHeadLink -BaseUrl 'https://example.org/page'
+
+        $links.Url | Should -Contain 'https://example.org/preload.png'
+    }
+
     It 'extracts image candidates' {
         $images = ConvertFrom-HtmlImageCandidate -Content $script:Html -BaseUrl 'https://example.org/page'
 


### PR DESCRIPTION
## Summary
- add HtmlAgilityPack HtmlNode pipeline input to structured extraction cmdlets: app state, head links, script data, meta, Open Graph, and microdata
- add JSON-LD `-Type` filtering and `-AsObject` parsed payload output
- add XML examples for each structured parser node-input workflow plus JSON-LD filtering/object output
- add focused Pester coverage for node pipeline workflows and JSON-LD filtering/object output

## Stack
- stacked on #385 (`codex/htmljsonld-node-input`), which adds the initial JSON-LD node-input foundation

## Use cases covered
- Extract app-state payloads such as `__NEXT_DATA__` from full HTML or a selected script HtmlNode.
- Extract canonical, alternate, feed, icon, manifest, preload, and related head links from full pages or selected `<head>` nodes while preserving base URL resolution.
- Extract generic `application/json` script payloads from full HTML or selected script nodes.
- Extract meta tags, Open Graph data, and microdata from whole documents or selected HtmlAgilityPack subtrees.
- Filter JSON-LD results by one or more `@type` values, such as `Product`.
- Emit parsed JSON-LD payload objects with `-AsObject`, including tolerant JSON-LD syntax already accepted by the parser.

## Usage examples
```powershell
# Filter JSON-LD to Product entries
$products = ConvertFrom-HtmlJsonLd -Content $html -Type Product
```

```powershell
# Emit parsed JSON payload objects instead of metadata records
$productObjects = ConvertFrom-HtmlJsonLd -Content $html -Type Product -AsObject
```

```powershell
# Extract framework app-state from a selected script node
$state = ConvertFrom-HTML -Content $html |
    Select-HtmlNode -XPath '//script[@id="__NEXT_DATA__"]' |
    ConvertFrom-HtmlAppState
```

```powershell
# Extract head links from a selected <head> node and resolve relative URLs
$headLinks = ConvertFrom-HTML -Content $html |
    Select-HtmlNode -XPath '//head' |
    ConvertFrom-HtmlHeadLink -BaseUrl 'https://example.org/page'
```

```powershell
# Extract generic JSON script data from selected application/json scripts
$scriptData = ConvertFrom-HTML -Content $html |
    Select-HtmlNode -XPath '//script[@type="application/json"]' |
    ConvertFrom-HtmlScriptData
```

```powershell
# Extract meta tags and Open Graph data from only the selected <head> subtree
$head = ConvertFrom-HTML -Content $html | Select-HtmlNode -XPath '//head'
$meta = $head | ConvertFrom-HtmlMeta
$openGraph = $head | ConvertFrom-HtmlOpenGraph
```

```powershell
# Extract microdata from selected item scopes
$microdata = ConvertFrom-HTML -Content $html |
    Select-HtmlNode -XPath '//*[@itemscope]' |
    ConvertFrom-HtmlMicrodata
```

## Validation
- dotnet build .\Sources\HtmlTinkerX.sln -c Debug -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false
- Invoke-Pester -Path @('.\Tests\ModernParsingCmdlets.Tests.ps1','.\Tests\PageDiscoveryCmdlets.Tests.ps1','.\Tests\ConvertFrom-HtmlMeta.Tests.ps1','.\Tests\ConvertFrom-HtmlOpenGraph.Tests.ps1','.\Tests\ConvertFrom-HtmlMicrodata.Tests.ps1') -Output Detailed
- git diff --check