### PR TITLE
Add JavaScript long-line formatting controls

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
@@ -36,6 +36,71 @@ public class HtmlFormatterTests {
     }
 
     [Fact]
+    public void FormatJavaScript_BreaksStatementCommaSequences() {
+        const string js = "! function(n) { n.value = \"text\", n.value2 = \"hello world\", n.value3 = \"foo\" }";
+        const string expected =
+            "! function(n) {\n    n.value = \"text\",\n    n.value2 = \"hello world\",\n    n.value3 = \"foo\"\n}";
+
+        string result = HtmlFormatter.FormatJavaScript(js);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_WrapLineLengthBreaksBeforeArrayStringArgument() {
+        const string js = "! function(n, r, e) { (r = e(2)(!1)).push([n.i, 'my really long string', \"\"]), n.exports = r }";
+        BeautifierOptions opts = new BeautifierOptions { WrapLineLength = 40 };
+        const string expected =
+            "! function(n, r, e) {\n    (r = e(2)(!1)).push([n.i,\n        'my really long string', \"\"]),\n        n.exports = r\n}";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_SplitsLongStringLiteralsWhenRequested() {
+        const string js = "var payload='abcdefghijkl';";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "var payload = 'abcd' +\n    'efgh' +\n    'ijkl';";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_SplitLongStringKeepsIssueScenarioBelowEditorLimit() {
+        string js = $"! function(n, r, e) {{ (r = e(2)(!1)).push([n.i, '{new string('x', 2600)}', \"\"]), n.exports = r }}";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true
+        };
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        int maxLineLength = result
+            .Replace("\r\n", "\n")
+            .Split('\n')
+            .Max(line => line.Length);
+
+        Assert.True(maxLineLength < 2500, $"Expected all lines below 2500 columns, longest line was {maxLineLength}.");
+    }
+
+    [Fact]
+    public void FormatJavaScript_DoesNotSplitInsideEscapeSequences() {
+        const string js = "var payload='ab\\'cdef';";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "var payload = 'ab\\'' +\n    'cdef';";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
     /// <summary>
     /// Formats minified CSS text.
     /// </summary>

--- a/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
@@ -141,6 +141,45 @@ public class HtmlFormatterTests {
     }
 
     [Fact]
+    public void FormatJavaScript_DoesNotSplitImportAttributeValues() {
+        const string js = "import data from './data.json' with { type: 'abcdefghijkl' };";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        Assert.Contains("'abcdefghijkl'", result);
+        Assert.DoesNotContain("'abcd' +", result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_DoesNotSplitStringNamedImportSpecifiers() {
+        const string js = "import { a, 'abcdefghijkl' as b } from './m.js';";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        Assert.Contains("'abcdefghijkl'", result);
+        Assert.DoesNotContain("'abcd' +", result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_DoesNotSplitStringNamedExportSpecifiers() {
+        const string js = "export { a, 'abcdefghijkl' as b } from './m.js';";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        Assert.Contains("'abcdefghijkl'", result);
+        Assert.DoesNotContain("'abcd' +", result);
+    }
+
+    [Fact]
     public void FormatJavaScript_SplitsFirstFunctionCallArgument() {
         const string js = "send('abcdefghijkl');";
         BeautifierOptions opts = new BeautifierOptions {

--- a/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
@@ -114,6 +114,48 @@ public class HtmlFormatterTests {
     }
 
     [Fact]
+    public void FormatJavaScript_DoesNotSplitCommaFollowingObjectPropertyKeys() {
+        const string js = "var payload={'a':1,'abcdefghijkl':2};";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected = "var payload = {\n    'a': 1,\n    'abcdefghijkl': 2\n};";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_SplitsFirstFunctionCallArgument() {
+        const string js = "send('abcdefghijkl');";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "send(('abcd' +\n    'efgh' +\n    'ijkl'));";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_SplitStringNewlinesSurviveKeepArrayIndentation() {
+        const string js = "var values=['abcdefghijkl'];";
+        BeautifierOptions opts = new BeautifierOptions {
+            KeepArrayIndentation = true,
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "var values = [('abcd' +\n    'efgh' +\n    'ijkl')];";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
     public void FormatJavaScript_ParenthesizesSplitStringBeforeMemberAccess() {
         const string js = "var size='abcdefghijkl'.length;";
         BeautifierOptions opts = new BeautifierOptions {
@@ -137,6 +179,20 @@ public class HtmlFormatterTests {
 
         string result = HtmlFormatter.FormatJavaScript(js, opts);
         TestHelpers.EqualIgnoringLineEndings(js, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_KeepsCrLfContinuationsInOneSplitUnit() {
+        const string js = "var payload=\"ab\\\r\ncdef\";";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "var payload = (\"ab\" +\n    \"\\\r\nc\" +\n    \"def\");";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
@@ -64,7 +64,7 @@ public class HtmlFormatterTests {
             MaxStringLiteralLength = 4
         };
         const string expected =
-            "var payload = 'abcd' +\n    'efgh' +\n    'ijkl';";
+            "var payload = ('abcd' +\n    'efgh' +\n    'ijkl');";
 
         string result = HtmlFormatter.FormatJavaScript(js, opts);
         TestHelpers.EqualIgnoringLineEndings(expected, result);
@@ -94,7 +94,60 @@ public class HtmlFormatterTests {
             MaxStringLiteralLength = 4
         };
         const string expected =
-            "var payload = 'ab\\'' +\n    'cdef';";
+            "var payload = ('ab\\'' +\n    'cdef');";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_DoesNotSplitObjectPropertyKeys() {
+        const string js = "var payload={'abcdefghijkl':1};";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected = "var payload = {\n    'abcdefghijkl': 1\n};";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_ParenthesizesSplitStringBeforeMemberAccess() {
+        const string js = "var size='abcdefghijkl'.length;";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "var size = ('abcd' +\n    'efgh' +\n    'ijkl').length;";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_DoesNotSplitDirectivePositionLiterals() {
+        const string js = "'abcdefghijkl';";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(js, result);
+    }
+
+    [Fact]
+    public void FormatJavaScript_KeepsLegacyOctalEscapesInOneSplitUnit() {
+        const string js = "var payload=\"\\123456\";";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 2
+        };
+        const string expected =
+            "var payload = (\"\\123\" +\n    \"45\" +\n    \"6\");";
 
         string result = HtmlFormatter.FormatJavaScript(js, opts);
         TestHelpers.EqualIgnoringLineEndings(expected, result);

--- a/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlFormatterTests.cs
@@ -127,6 +127,20 @@ public class HtmlFormatterTests {
     }
 
     [Fact]
+    public void FormatJavaScript_SplitsObjectPropertyValues() {
+        const string js = "var payload={a:'abcdefghijkl'};";
+        BeautifierOptions opts = new BeautifierOptions {
+            SplitLongStringLiterals = true,
+            MaxStringLiteralLength = 4
+        };
+        const string expected =
+            "var payload = {\n    a: ('abcd' +\n        'efgh' +\n        'ijkl')\n};";
+
+        string result = HtmlFormatter.FormatJavaScript(js, opts);
+        TestHelpers.EqualIgnoringLineEndings(expected, result);
+    }
+
+    [Fact]
     public void FormatJavaScript_SplitsFirstFunctionCallArgument() {
         const string js = "send('abcdefghijkl');";
         BeautifierOptions opts = new BeautifierOptions {

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
@@ -1,0 +1,177 @@
+#region License
+// MIT License
+//
+// Copyright (c) 2018 Denis Ivanov
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#endregion
+
+namespace HtmlTinkerX.JavaScriptBeautifier {
+    using System.Collections.Generic;
+    using System.Text;
+
+    public partial class Beautifier {
+        private const int DefaultMaxStringLiteralLength = 2400;
+
+        private bool ShouldBreakStatementComma()
+            => (Flags.Mode == BeautifierMode.Block || Flags.Mode == BeautifierMode.DoBlock) &&
+               (LastType == "TK_STRING" || LastType == "TK_WORD");
+
+        private bool ShouldSplitStringLiteral(string tokenText)
+            => Opts.SplitLongStringLiterals &&
+               TryGetQuotedStringContent(tokenText, out _, out string content) &&
+               content.Length > GetStringLiteralChunkLength();
+
+        private void AppendStringToken(string tokenText) {
+            if (!TrySplitStringLiteral(tokenText, out List<string>? chunks)) {
+                Append(tokenText);
+                return;
+            }
+
+            List<string> literalChunks = chunks!;
+            Append(literalChunks[0]);
+            for (int i = 1; i < literalChunks.Count; i++) {
+                Append(" ");
+                Append("+");
+                AppendNewline(resetStatementFlags: false);
+                AppendIndentString();
+                Append(literalChunks[i]);
+            }
+        }
+
+        private bool TrySplitStringLiteral(string tokenText, out List<string>? chunks) {
+            chunks = null;
+
+            if (!Opts.SplitLongStringLiterals ||
+                !TryGetQuotedStringContent(tokenText, out char quote, out string content)) {
+                return false;
+            }
+
+            int chunkLength = GetStringLiteralChunkLength();
+            if (content.Length <= chunkLength) {
+                return false;
+            }
+
+            chunks = new List<string>();
+            var current = new StringBuilder();
+            foreach (string unit in EnumerateStringLiteralUnits(content)) {
+                if (current.Length > 0 && current.Length + unit.Length > chunkLength) {
+                    chunks.Add(QuoteStringChunk(quote, current.ToString()));
+                    current.Clear();
+                }
+
+                current.Append(unit);
+            }
+
+            if (current.Length > 0) {
+                chunks.Add(QuoteStringChunk(quote, current.ToString()));
+            }
+
+            return chunks.Count > 1;
+        }
+
+        private int GetStringLiteralChunkLength() {
+            if (Opts.MaxStringLiteralLength > 0) {
+                return Opts.MaxStringLiteralLength;
+            }
+
+            if (Opts.WrapLineLength > 0) {
+                return Opts.WrapLineLength;
+            }
+
+            return DefaultMaxStringLiteralLength;
+        }
+
+        private static bool TryGetQuotedStringContent(string tokenText, out char quote, out string content) {
+            quote = '\0';
+            content = string.Empty;
+
+            if (tokenText.Length < 2) {
+                return false;
+            }
+
+            quote = tokenText[0];
+            if ((quote != '\'' && quote != '"') || tokenText[tokenText.Length - 1] != quote) {
+                quote = '\0';
+                return false;
+            }
+
+            content = tokenText.Substring(1, tokenText.Length - 2);
+            return true;
+        }
+
+        private static IEnumerable<string> EnumerateStringLiteralUnits(string content) {
+            for (int i = 0; i < content.Length; i++) {
+                if (content[i] != '\\' || i + 1 >= content.Length) {
+                    yield return content[i].ToString();
+                    continue;
+                }
+
+                int escapeEnd = GetEscapeEnd(content, i + 1);
+                yield return content.Substring(i, escapeEnd - i + 1);
+                i = escapeEnd;
+            }
+        }
+
+        private static int GetEscapeEnd(string content, int escapedIndex) {
+            char escaped = content[escapedIndex];
+
+            if (escaped == 'x' && HasHexDigits(content, escapedIndex + 1, 2)) {
+                return escapedIndex + 2;
+            }
+
+            if (escaped == 'u') {
+                if (escapedIndex + 1 < content.Length && content[escapedIndex + 1] == '{') {
+                    int closingBrace = content.IndexOf('}', escapedIndex + 2);
+                    if (closingBrace > escapedIndex + 2) {
+                        return closingBrace;
+                    }
+                }
+
+                if (HasHexDigits(content, escapedIndex + 1, 4)) {
+                    return escapedIndex + 4;
+                }
+            }
+
+            return escapedIndex;
+        }
+
+        private static bool HasHexDigits(string content, int start, int count) {
+            if (start + count > content.Length) {
+                return false;
+            }
+
+            for (int i = start; i < start + count; i++) {
+                char c = content[i];
+                bool isHex =
+                    c >= '0' && c <= '9' ||
+                    c >= 'a' && c <= 'f' ||
+                    c >= 'A' && c <= 'F';
+                if (!isHex) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string QuoteStringChunk(char quote, string content)
+            => string.Concat(quote, content, quote);
+    }
+}

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
@@ -35,6 +35,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
         private bool ShouldSplitStringLiteral(string tokenText)
             => Opts.SplitLongStringLiterals &&
+               IsStringLiteralSplitContext() &&
                TryGetQuotedStringContent(tokenText, out _, out string content) &&
                content.Length > GetStringLiteralChunkLength();
 
@@ -45,6 +46,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             }
 
             List<string> literalChunks = chunks!;
+            Append("(");
             Append(literalChunks[0]);
             for (int i = 1; i < literalChunks.Count; i++) {
                 Append(" ");
@@ -53,12 +55,15 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                 AppendIndentString();
                 Append(literalChunks[i]);
             }
+
+            Append(")");
         }
 
         private bool TrySplitStringLiteral(string tokenText, out List<string>? chunks) {
             chunks = null;
 
             if (!Opts.SplitLongStringLiterals ||
+                !IsStringLiteralSplitContext() ||
                 !TryGetQuotedStringContent(tokenText, out char quote, out string content)) {
                 return false;
             }
@@ -97,6 +102,11 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
             return DefaultMaxStringLiteralLength;
         }
+
+        private bool IsStringLiteralSplitContext()
+            => LastType == "TK_EQUALS" ||
+               LastType == "TK_COMMA" ||
+               LastType == "TK_OPERATOR";
 
         private static bool TryGetQuotedStringContent(string tokenText, out char quote, out string content) {
             quote = '\0';
@@ -147,6 +157,18 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                 if (HasHexDigits(content, escapedIndex + 1, 4)) {
                     return escapedIndex + 4;
                 }
+            }
+
+            if (escaped >= '0' && escaped <= '7') {
+                int end = escapedIndex;
+                while (end + 1 < content.Length &&
+                       end - escapedIndex < 2 &&
+                       content[end + 1] >= '0' &&
+                       content[end + 1] <= '7') {
+                    end++;
+                }
+
+                return end;
             }
 
             return escapedIndex;

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
@@ -51,8 +51,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             for (int i = 1; i < literalChunks.Count; i++) {
                 Append(" ");
                 Append("+");
-                AppendNewline(resetStatementFlags: false);
-                AppendIndentString();
+                AppendSplitStringNewline();
                 Append(literalChunks[i]);
             }
 
@@ -103,10 +102,46 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             return DefaultMaxStringLiteralLength;
         }
 
-        private bool IsStringLiteralSplitContext()
-            => LastType == "TK_EQUALS" ||
-               LastType == "TK_COMMA" ||
-               LastType == "TK_OPERATOR";
+        private bool IsStringLiteralSplitContext() {
+            if (Flags.Mode == BeautifierMode.Object) {
+                return false;
+            }
+
+            if (LastType == "TK_EQUALS" ||
+                LastType == "TK_COMMA" ||
+                LastType == "TK_OPERATOR") {
+                return true;
+            }
+
+            if (LastType == "TK_START_EXPR" && IsExpression(Flags.Mode)) {
+                return true;
+            }
+
+            return LastType == "TK_WORD" && (LastText == "return" || LastText == "throw");
+        }
+
+        private void AppendSplitStringNewline() {
+            TrimOutput();
+
+            if (Output.Count == 0) {
+                return;
+            }
+
+            if (Output[Output.Count - 1] != "\n") {
+                JustAddedNewline = true;
+                Output.Add("\n");
+            }
+
+            if (!string.IsNullOrEmpty(PreindentString)) {
+                Output.Add(PreindentString);
+            }
+
+            for (int i = 0; i < Flags.IndentationLevel + Flags.ChainExtraIndentation; i++) {
+                AppendIndentString();
+            }
+
+            AppendIndentString();
+        }
 
         private static bool TryGetQuotedStringContent(string tokenText, out char quote, out string content) {
             quote = '\0';
@@ -157,6 +192,10 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                 if (HasHexDigits(content, escapedIndex + 1, 4)) {
                     return escapedIndex + 4;
                 }
+            }
+
+            if (escaped == '\r' && escapedIndex + 1 < content.Length && content[escapedIndex + 1] == '\n') {
+                return escapedIndex + 1;
             }
 
             if (escaped >= '0' && escaped <= '7') {

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
@@ -29,6 +29,10 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
     public partial class Beautifier {
         private const int DefaultMaxStringLiteralLength = 2400;
 
+        private int ImportAttributeBlockDepth { get; set; }
+
+        private int ModuleSpecifierBlockDepth { get; set; }
+
         private bool ShouldBreakStatementComma()
             => (Flags.Mode == BeautifierMode.Block || Flags.Mode == BeautifierMode.DoBlock) &&
                (LastType == "TK_STRING" || LastType == "TK_WORD");
@@ -103,6 +107,10 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
         }
 
         private bool IsStringLiteralSplitContext() {
+            if (ImportAttributeBlockDepth > 0 || ModuleSpecifierBlockDepth > 0) {
+                return false;
+            }
+
             if (Flags.Mode == BeautifierMode.Object) {
                 return LastText == ":";
             }
@@ -118,6 +126,30 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
             }
 
             return LastType == "TK_WORD" && (LastText == "return" || LastText == "throw");
+        }
+
+        private void TrackStringLiteralBlockStart() {
+            if (ImportAttributeBlockDepth > 0) {
+                ImportAttributeBlockDepth++;
+            } else if (LastWord == "with" || LastWord == "assert") {
+                ImportAttributeBlockDepth = 1;
+            }
+
+            if (ModuleSpecifierBlockDepth > 0) {
+                ModuleSpecifierBlockDepth++;
+            } else if (LastWord == "import" || LastWord == "export") {
+                ModuleSpecifierBlockDepth = 1;
+            }
+        }
+
+        private void TrackStringLiteralBlockEnd() {
+            if (ImportAttributeBlockDepth > 0) {
+                ImportAttributeBlockDepth--;
+            }
+
+            if (ModuleSpecifierBlockDepth > 0) {
+                ModuleSpecifierBlockDepth--;
+            }
         }
 
         private void AppendSplitStringNewline() {

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.StringLiterals.cs
@@ -104,7 +104,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
 
         private bool IsStringLiteralSplitContext() {
             if (Flags.Mode == BeautifierMode.Object) {
-                return false;
+                return LastText == ":";
             }
 
             if (LastType == "TK_EQUALS" ||

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
@@ -32,7 +32,7 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
     /// <summary>
     /// Provides functionality for beautifying JavaScript code.
     /// </summary>
-    public class Beautifier {
+    public partial class Beautifier {
         /// <summary>
         /// Initializes a new instance of the <see cref="Beautifier"/> class using default options.
         /// </summary>
@@ -1100,13 +1100,13 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                        LastType == "TK_EQUALS" ||
                        LastType == "TK_OPERATOR") {
                 if (Flags.Mode != BeautifierMode.Object) {
-                    AllowWrapOrPreservedNewline(tokenText);
+                    AllowWrapOrPreservedNewline(tokenText, LastType == "TK_COMMA" && ShouldSplitStringLiteral(tokenText));
                 }
             } else {
                 AppendNewline();
             }
 
-            Append(tokenText);
+            AppendStringToken(tokenText);
         }
 
         private void HandleEquals(string tokenText) {
@@ -1150,6 +1150,9 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
                 } else {
                     Append(" ");
                 }
+            } else if (ShouldBreakStatementComma()) {
+                Append(tokenText);
+                AppendNewline();
             } else {
                 if (Flags.Mode == BeautifierMode.Object) {
                     Append(tokenText);

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/Beautifier.cs
@@ -840,6 +840,8 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
         }
 
         private void HandleStartBlock(string tokenText) {
+            TrackStringLiteralBlockStart();
+
             if (LastWord == "do") {
                 SetMode(BeautifierMode.DoBlock);
             } else {
@@ -880,6 +882,8 @@ namespace HtmlTinkerX.JavaScriptBeautifier {
         }
 
         private void HandleEndBlock(string tokenText) {
+            TrackStringLiteralBlockEnd();
+
             RestoreMode();
             if (Opts.BraceStyle == BraceStyle.Expand) {
                 if (LastText != "{") {

--- a/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierOptions.cs
+++ b/Sources/HtmlTinkerX/JavaScriptBeautifier/BeautifierOptions.cs
@@ -45,6 +45,8 @@ public class BeautifierOptions {
         WrapLineLength = 0;
         BreakChainedMethods = false;
         UnescapeStrings = false;
+        SplitLongStringLiterals = false;
+        MaxStringLiteralLength = 0;
     }
 
     /// <summary>
@@ -111,4 +113,15 @@ public class BeautifierOptions {
     /// Gets or sets a value indicating whether hexadecimal escape sequences in strings should be converted to characters.
     /// </summary>
     public bool UnescapeStrings { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether long quoted string literals should be split into concatenated chunks.
+    /// </summary>
+    public bool SplitLongStringLiterals { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum raw content length for a quoted string chunk when splitting long literals.
+    /// A value of zero uses <see cref="WrapLineLength"/> when set, otherwise a conservative editor-friendly default.
+    /// </summary>
+    public int MaxStringLiteralLength { get; set; }
 }

--- a/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
+++ b/Sources/PSParseHTML.PowerShell/CmdletFormatJavaScript.cs
@@ -78,6 +78,20 @@ public sealed class CmdletFormatJavaScript : AsyncPSCmdlet {
     [Parameter]
     public bool EvalCode { get; set; }
 
+    /// <summary>Line length at which formatter may wrap before the next token. Use 0 to disable token wrapping.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int WrapLineLength { get; set; }
+
+    /// <summary>Split long quoted string literals into concatenated chunks.</summary>
+    [Parameter]
+    [Alias("SplitLongLine", "SplitLongString")]
+    public SwitchParameter SplitLongStringLiterals { get; set; }
+
+    /// <summary>Maximum raw content length for each string literal chunk. Use 0 for the formatter default.</summary>
+    [Parameter]
+    [ValidateRange(0, int.MaxValue)]
+    public int MaxStringLiteralLength { get; set; }
 
     /// <summary>Break chained methods.</summary>
     [Parameter]
@@ -96,7 +110,10 @@ public sealed class CmdletFormatJavaScript : AsyncPSCmdlet {
             KeepArrayIndentation = KeepArrayIndentation,
             KeepFunctionIndentation = KeepFunctionIndentation,
             EvalCode = EvalCode,
-            BreakChainedMethods = BreakChainedMethods
+            WrapLineLength = WrapLineLength,
+            BreakChainedMethods = BreakChainedMethods,
+            SplitLongStringLiterals = SplitLongStringLiterals.IsPresent,
+            MaxStringLiteralLength = MaxStringLiteralLength
         };
 
         string formatted = ParameterSetName == ParameterSetFile

--- a/Tests/Format-JS.Tests.ps1
+++ b/Tests/Format-JS.Tests.ps1
@@ -43,9 +43,9 @@ function x()
         $Content = "var payload='abcdefghijkl';"
         $Output = Format-JavaScript -Content $Content -SplitLongLine -MaxStringLiteralLength 4
         $Output.Replace("`r`n", "`n") | Should -Be @"
-var payload = 'abcd' +
+var payload = ('abcd' +
     'efgh' +
-    'ijkl';
+    'ijkl');
 "@.Replace("`r`n", "`n").TrimEnd()
     }
 

--- a/Tests/Format-JS.Tests.ps1
+++ b/Tests/Format-JS.Tests.ps1
@@ -38,4 +38,26 @@ function x()
         $Output = Format-JavaScript -Content $Content -IndentSize 2 -BraceStyle Expand
         $Output.Replace("`r`n", "`n") | Should -Be $Expected.Replace("`r`n", "`n").TrimEnd()
     }
+
+    It 'Exposes wrapping and long string splitting options' {
+        $Content = "var payload='abcdefghijkl';"
+        $Output = Format-JavaScript -Content $Content -SplitLongLine -MaxStringLiteralLength 4
+        $Output.Replace("`r`n", "`n") | Should -Be @"
+var payload = 'abcd' +
+    'efgh' +
+    'ijkl';
+"@.Replace("`r`n", "`n").TrimEnd()
+    }
+
+    It 'Wraps before a long array string argument when requested' {
+        $Content = "! function(n, r, e) { (r = e(2)(!1)).push([n.i, 'my really long string', `"`"]), n.exports = r }"
+        $Output = Format-JavaScript -Content $Content -WrapLineLength 40
+        $Output.Replace("`r`n", "`n") | Should -Be @"
+! function(n, r, e) {
+    (r = e(2)(!1)).push([n.i,
+        'my really long string', ""]),
+        n.exports = r
+}
+"@.Replace("`r`n", "`n").TrimEnd()
+    }
 }


### PR DESCRIPTION
## Summary
- breaks comma-separated JavaScript statement sequences onto separate lines in `Format-JS`
- exposes `-WrapLineLength` plus `-SplitLongStringLiterals` (`-SplitLongLine` alias) and `-MaxStringLiteralLength`
- splits long quoted string literals into concatenated chunks without cutting through escape sequences

Closes #394

## Validation
- `dotnet build Sources\HtmlTinkerX.sln -c Debug`
- `dotnet test Sources\HtmlTinkerX.Tests\HtmlTinkerX.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~JavaScriptBeautifier|FullyQualifiedName~HtmlFormatter"`
- `pwsh -NoProfile -Command "Import-Module '$((Get-Location).Path)\PSParseHTML.psd1' -Force; Invoke-Pester -Path '.\Tests\Format-JS.Tests.ps1' -Output Detailed"`
- `dotnet test Sources\HtmlTinkerX.sln -c Debug --no-build`
- smoke: `Format-JS -SplitLongLine` on a 2600-character issue-shaped array string produced max line length `2412`