### PR TITLE
Add unified project module build DSL

### DIFF
--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -38,14 +38,12 @@ jobs:
       - name: Setup PowerShell modules
         shell: pwsh
         run: |
-          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.33 -Force -Scope CurrentUser -AllowClobber
 
       - name: Refresh module manifest
         shell: pwsh
-        env:
-          RefreshPSD1Only: 'true'
         run: |
-          .\Build\Build-Module.ps1
+          .\Build\Build-Module.ps1 -ConfigurationGateMode Manifest
 
       - name: Commit refreshed PSD1
         env:
@@ -123,16 +121,14 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
-          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.33 -Force -Scope CurrentUser -AllowClobber
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name TextMate -Repository PSGallery -RequiredVersion 0.2.1 -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name PwshSpectreConsole -Repository PSGallery -RequiredVersion 2.6.3 -Force -SkipPublisherCheck -AllowClobber
 
       - name: Build packaged module
         shell: pwsh
-        env:
-          RefreshPSD1Only: 'false'
-        run: .\Build\Build-Module.ps1
+        run: .\Build\Build-Module.ps1 -ConfigurationGateMode Build
         timeout-minutes: 15
 
       - name: Run packaged ALC conflict smoke test

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -139,13 +139,7 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    $projectBuildOptions = @{
-        Manifest = $null
-        Build    = @{ CertificateThumbprint = $null }
-        Publish  = $null
-    }[$ConfigurationGateMode]
-
-    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath 'Build\project.build.json' -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub -Options $projectBuildOptions
+    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath 'Build\project.build.json' -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub
     New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     $newConfigurationArtefactSplat = @{
@@ -171,19 +165,8 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 
-    $publishCredential = @{
-        Manifest = @{ ApiKey = 'NotUsedForNonPublishGate' }
-        Build    = @{ ApiKey = 'NotUsedForNonPublishGate' }
-        Publish  = @{ FilePath = $PowerShellGalleryApiKeyPath }
-    }[$ConfigurationGateMode]
-    $githubCredential = @{
-        Manifest = @{ ApiKey = 'NotUsedForNonPublishGate' }
-        Build    = @{ ApiKey = 'NotUsedForNonPublishGate' }
-        Publish  = @{ FilePath = $GitHubApiKeyPath }
-    }[$ConfigurationGateMode]
-
-    New-ConfigurationPublish -Type PowerShellGallery @publishCredential -Enabled:$false -UseAsDependencyVersionSource
-    New-ConfigurationPublish -Type GitHub @githubCredential -UserName 'EvotecIT' -Enabled:$false -RepositoryName 'HtmlTinkerX' -OverwriteTagName 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>'
+    New-ConfigurationPublish -Type PowerShellGallery -FilePath $PowerShellGalleryApiKeyPath -Enabled:$false -UseAsDependencyVersionSource
+    New-ConfigurationPublish -Type GitHub -FilePath $GitHubApiKeyPath -UserName 'EvotecIT' -Enabled:$false -RepositoryName 'HtmlTinkerX' -OverwriteTagName 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>'
 
     New-ConfigurationGate -Mode $ConfigurationGateMode
 } -ExitCode

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,6 +1,10 @@
 param(
     [ValidateSet('Manifest', 'Build', 'Publish')]
-    [string] $ConfigurationGateMode = 'Build'
+    [string] $ConfigurationGateMode = 'Build',
+
+    [string] $PowerShellGalleryApiKeyPath = 'C:\Support\Important\PowerShellGalleryAPI.txt',
+
+    [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
 )
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
@@ -161,9 +165,19 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 
-    # global options for publishing to github/psgallery
-    New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$false -UseAsDependencyVersionSource
-    New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$false -RepositoryName 'HtmlTinkerX' -OverwriteTagName 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>'
+    $publishCredential = @{
+        Manifest = @{ ApiKey = 'NotUsedForNonPublishGate' }
+        Build    = @{ ApiKey = 'NotUsedForNonPublishGate' }
+        Publish  = @{ FilePath = $PowerShellGalleryApiKeyPath }
+    }[$ConfigurationGateMode]
+    $githubCredential = @{
+        Manifest = @{ ApiKey = 'NotUsedForNonPublishGate' }
+        Build    = @{ ApiKey = 'NotUsedForNonPublishGate' }
+        Publish  = @{ FilePath = $GitHubApiKeyPath }
+    }[$ConfigurationGateMode]
+
+    New-ConfigurationPublish -Type PowerShellGallery @publishCredential -Enabled:$false -UseAsDependencyVersionSource
+    New-ConfigurationPublish -Type GitHub @githubCredential -UserName 'EvotecIT' -Enabled:$false -RepositoryName 'HtmlTinkerX' -OverwriteTagName 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>'
 
     New-ConfigurationGate -Mode $ConfigurationGateMode
 } -ExitCode

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -91,14 +91,6 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
-    $repositoryRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..'))
-    $binaryProjectPath = [System.IO.Path]::Combine($repositoryRoot, 'Sources', 'PSParseHTML.PowerShell', 'PSParseHTML.PowerShell.csproj')
-    $projectBuildConfigPath = [System.IO.Path]::Combine($PSScriptRoot, 'project.build.json')
-    $artefactsRoot = [System.IO.Path]::Combine($repositoryRoot, 'Artefacts')
-    $uploadReadyPath = [System.IO.Path]::Combine($artefactsRoot, 'UploadReady')
-    $unpackedArtefactsPath = [System.IO.Path]::Combine($artefactsRoot, 'Unpacked')
-    $packedArtefactsPath = [System.IO.Path]::Combine($artefactsRoot, 'Packed')
-
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         # lets sign module only on my machine for now
@@ -109,7 +101,7 @@ Build-Module -ModuleName 'PSParseHTML' {
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSParseHTML.PowerShell'
         NETProjectName                    = 'PSParseHTML.PowerShell'
-        NETProjectPath                    = $binaryProjectPath
+        NETProjectPath                    = 'Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj'
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
@@ -153,24 +145,24 @@ Build-Module -ModuleName 'PSParseHTML' {
         Publish  = $null
     }[$ConfigurationGateMode]
 
-    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath $projectBuildConfigPath -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub -Options $projectBuildOptions
-    New-ConfigurationRelease -StageRoot $uploadReadyPath -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath 'Build\project.build.json' -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub -Options $projectBuildOptions
+    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     $newConfigurationArtefactSplat = @{
         Type                = 'Unpacked'
         Enable              = $true
-        Path                = $unpackedArtefactsPath
-        ModulesPath         = [System.IO.Path]::Combine($unpackedArtefactsPath, 'Modules')
-        RequiredModulesPath = [System.IO.Path]::Combine($unpackedArtefactsPath, 'Modules')
+        Path                = 'Artefacts\Unpacked'
+        ModulesPath         = 'Artefacts\Unpacked\Modules'
+        RequiredModulesPath = 'Artefacts\Unpacked\Modules'
         AddRequiredModules  = $true
     }
     New-ConfigurationArtefact @newConfigurationArtefactSplat -CopyFilesRelative
     $newConfigurationArtefactSplat = @{
         Type                = 'Packed'
         Enable              = $true
-        Path                = $packedArtefactsPath
-        ModulesPath         = [System.IO.Path]::Combine($packedArtefactsPath, 'Modules')
-        RequiredModulesPath = [System.IO.Path]::Combine($packedArtefactsPath, 'Modules')
+        Path                = 'Artefacts\Packed'
+        ModulesPath         = 'Artefacts\Packed\Modules'
+        RequiredModulesPath = 'Artefacts\Packed\Modules'
         AddRequiredModules  = $true
         ArtefactName        = 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>.zip'
         IncludeTagName      = $true

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,3 +1,8 @@
+param(
+    [ValidateSet('Manifest', 'Build', 'Publish')]
+    [string] $ConfigurationGateMode = 'Build'
+)
+
 Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'PSParseHTML' {
@@ -92,7 +97,7 @@ Build-Module -ModuleName 'PSParseHTML' {
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSParseHTML.PowerShell'
         NETProjectName                    = 'PSParseHTML.PowerShell'
-        NETProjectPath                    = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj')).Path
+        NETProjectPath                    = "$PSScriptRoot\..\Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj"
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
@@ -125,14 +130,13 @@ Build-Module -ModuleName 'PSParseHTML' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
         NETBinaryModuleDocumentation      = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath (Join-Path $PSScriptRoot 'project.build.json') -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed
-    New-ConfigurationRelease -StageRoot (Join-Path $PSScriptRoot '..\Artefacts\UploadReady') -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath "$PSScriptRoot\project.build.json" -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub
+    New-ConfigurationRelease -StageRoot "$PSScriptRoot\..\Artefacts\UploadReady" -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     $newConfigurationArtefactSplat = @{
         Type                = 'Unpacked'
@@ -158,6 +162,8 @@ Build-Module -ModuleName 'PSParseHTML' {
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 
     # global options for publishing to github/psgallery
-    #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true
-    #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true -RepositoryName "HtmlTinkerX" -OverwriteTagName 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>'
+    New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$false -UseAsDependencyVersionSource
+    New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$false -RepositoryName 'HtmlTinkerX' -OverwriteTagName 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>'
+
+    New-ConfigurationGate -Mode $ConfigurationGateMode
 } -ExitCode

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -91,6 +91,14 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
+    $repositoryRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, '..'))
+    $binaryProjectPath = [System.IO.Path]::Combine($repositoryRoot, 'Sources', 'PSParseHTML.PowerShell', 'PSParseHTML.PowerShell.csproj')
+    $projectBuildConfigPath = [System.IO.Path]::Combine($PSScriptRoot, 'project.build.json')
+    $artefactsRoot = [System.IO.Path]::Combine($repositoryRoot, 'Artefacts')
+    $uploadReadyPath = [System.IO.Path]::Combine($artefactsRoot, 'UploadReady')
+    $unpackedArtefactsPath = [System.IO.Path]::Combine($artefactsRoot, 'Unpacked')
+    $packedArtefactsPath = [System.IO.Path]::Combine($artefactsRoot, 'Packed')
+
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         # lets sign module only on my machine for now
@@ -101,7 +109,7 @@ Build-Module -ModuleName 'PSParseHTML' {
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSParseHTML.PowerShell'
         NETProjectName                    = 'PSParseHTML.PowerShell'
-        NETProjectPath                    = "$PSScriptRoot\..\Sources\PSParseHTML.PowerShell\PSParseHTML.PowerShell.csproj"
+        NETProjectPath                    = $binaryProjectPath
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
@@ -145,24 +153,24 @@ Build-Module -ModuleName 'PSParseHTML' {
         Publish  = $null
     }[$ConfigurationGateMode]
 
-    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath "$PSScriptRoot\project.build.json" -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub -Options $projectBuildOptions
-    New-ConfigurationRelease -StageRoot "$PSScriptRoot\..\Artefacts\UploadReady" -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath $projectBuildConfigPath -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub -Options $projectBuildOptions
+    New-ConfigurationRelease -StageRoot $uploadReadyPath -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     $newConfigurationArtefactSplat = @{
         Type                = 'Unpacked'
         Enable              = $true
-        Path                = "$PSScriptRoot\..\Artefacts\Unpacked"
-        ModulesPath         = "$PSScriptRoot\..\Artefacts\Unpacked\Modules"
-        RequiredModulesPath = "$PSScriptRoot\..\Artefacts\Unpacked\Modules"
+        Path                = $unpackedArtefactsPath
+        ModulesPath         = [System.IO.Path]::Combine($unpackedArtefactsPath, 'Modules')
+        RequiredModulesPath = [System.IO.Path]::Combine($unpackedArtefactsPath, 'Modules')
         AddRequiredModules  = $true
     }
     New-ConfigurationArtefact @newConfigurationArtefactSplat -CopyFilesRelative
     $newConfigurationArtefactSplat = @{
         Type                = 'Packed'
         Enable              = $true
-        Path                = "$PSScriptRoot\..\Artefacts\Packed"
-        ModulesPath         = "$PSScriptRoot\..\Artefacts\Packed\Modules"
-        RequiredModulesPath = "$PSScriptRoot\..\Artefacts\Packed\Modules"
+        Path                = $packedArtefactsPath
+        ModulesPath         = [System.IO.Path]::Combine($packedArtefactsPath, 'Modules')
+        RequiredModulesPath = [System.IO.Path]::Combine($packedArtefactsPath, 'Modules')
         AddRequiredModules  = $true
         ArtefactName        = 'PSParseHTML-PowerShellModule.<TagModuleVersionWithPreRelease>.zip'
         IncludeTagName      = $true

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -131,6 +131,9 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
+    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath (Join-Path $PSScriptRoot 'project.build.json') -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed
+    New-ConfigurationRelease -StageRoot (Join-Path $PSScriptRoot '..\Artefacts\UploadReady') -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+
     $newConfigurationArtefactSplat = @{
         Type                = 'Unpacked'
         Enable              = $true

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -139,7 +139,13 @@ Build-Module -ModuleName 'PSParseHTML' {
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath "$PSScriptRoot\project.build.json" -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub
+    $projectBuildOptions = @{
+        Manifest = $null
+        Build    = @{ CertificateThumbprint = $null }
+        Publish  = $null
+    }[$ConfigurationGateMode]
+
+    New-ConfigurationProjectBuild -Name 'HtmlTinkerX' -ConfigPath "$PSScriptRoot\project.build.json" -Enabled:$false -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget -PublishGitHub -Options $projectBuildOptions
     New-ConfigurationRelease -StageRoot "$PSScriptRoot\..\Artefacts\UploadReady" -VersionSource ProjectBuild -PrimaryProject 'HtmlTinkerX' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     $newConfigurationArtefactSplat = @{

--- a/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlCrawlerTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace HtmlTinkerX.Tests;
 
+[Collection("Playwright collection")]
 public class HtmlCrawlerTests {
     [Fact]
     public void HtmlCrawlOptions_CloneAndClearSensitiveData_WorkIndependently() {


### PR DESCRIPTION
## Summary
- add the existing HtmlTinkerX project build as a Build-Module DSL package lane
- run the package lane before the module build and provide its output as a local NuGet feed
- add release coordination so package/module assets can be staged together by PSPublishModule

## Validation
- PowerShell parser check for Build/Build-Module.ps1
- git diff --check for Build/Build-Module.ps1