### PR TITLE
Use latest PSPublishModule in CI

### DIFF
--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -16,7 +16,7 @@ on:
       - v2-speedygonzales
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   DOTNET_VERSION: |
@@ -45,16 +45,24 @@ jobs:
         run: |
           .\Build\Build-Module.ps1 -ConfigurationGateMode Manifest
 
-      - name: Commit refreshed PSD1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+      - name: Report refreshed PSD1
+        shell: pwsh
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add PSParseHTML.psd1
-          git commit -m "chore: regenerate psd1" || echo "No changes to commit"
-          git push origin HEAD:$Env:HEAD_BRANCH
+          $changes = git status --short -- PSParseHTML.psd1
+          if ([string]::IsNullOrWhiteSpace($changes)) {
+            "### PSParseHTML.psd1" >> $env:GITHUB_STEP_SUMMARY
+            "" >> $env:GITHUB_STEP_SUMMARY
+            "No manifest changes were produced by the refresh step." >> $env:GITHUB_STEP_SUMMARY
+          } else {
+            Write-Warning "PSParseHTML.psd1 changed during refresh. The test jobs will use the refreshed artifact, but CI will not push generated commits."
+            "### PSParseHTML.psd1 refreshed" >> $env:GITHUB_STEP_SUMMARY
+            "" >> $env:GITHUB_STEP_SUMMARY
+            "The manifest changed during the refresh step. Test jobs will use the refreshed manifest artifact. Commit the generated change in the PR when the manifest update is intentional." >> $env:GITHUB_STEP_SUMMARY
+            "" >> $env:GITHUB_STEP_SUMMARY
+            "```diff" >> $env:GITHUB_STEP_SUMMARY
+            git diff -- PSParseHTML.psd1 >> $env:GITHUB_STEP_SUMMARY
+            "```" >> $env:GITHUB_STEP_SUMMARY
+          }
 
       - name: Upload refreshed manifest
         uses: actions/upload-artifact@v4

--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -59,9 +59,9 @@ jobs:
             "" >> $env:GITHUB_STEP_SUMMARY
             "The manifest changed during the refresh step. Test jobs will use the refreshed manifest artifact. Commit the generated change in the PR when the manifest update is intentional." >> $env:GITHUB_STEP_SUMMARY
             "" >> $env:GITHUB_STEP_SUMMARY
-            "```diff" >> $env:GITHUB_STEP_SUMMARY
+            '```diff' >> $env:GITHUB_STEP_SUMMARY
             git diff -- PSParseHTML.psd1 >> $env:GITHUB_STEP_SUMMARY
-            "```" >> $env:GITHUB_STEP_SUMMARY
+            '```' >> $env:GITHUB_STEP_SUMMARY
           }
 
       - name: Upload refreshed manifest

--- a/.github/workflows/powershell-tests-7.yml
+++ b/.github/workflows/powershell-tests-7.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PowerShell modules
         shell: pwsh
         run: |
-          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.33 -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name PSPublishModule -Repository PSGallery -Force -Scope CurrentUser -AllowClobber
 
       - name: Refresh module manifest
         shell: pwsh
@@ -121,7 +121,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
-          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.33 -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name PSPublishModule -Repository PSGallery -Force -Scope CurrentUser -AllowClobber
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name TextMate -Repository PSGallery -RequiredVersion 0.2.1 -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name PwshSpectreConsole -Repository PSGallery -RequiredVersion 2.6.3 -Force -SkipPublisherCheck -AllowClobber

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -8,7 +8,7 @@
     Description          = 'Module that allows to manipulate, parse, format and optimize HTML, JavaScript and CSS'
     FunctionsToExport    = @()
     GUID                 = 'f0387960-7034-4918-a1e1-d5847cbf90df'
-    ModuleVersion        = '2.0.16'
+    ModuleVersion        = '2.0.17'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{


### PR DESCRIPTION
## Summary
- remove stale PSPublishModule minimum-version constraints from the PowerShell 7 workflow setup
- keep CI on the current PSGallery PSPublishModule release instead of a historical floor
- stop the PSD1 refresh job from pushing generated commits back to the PR branch; tests still consume the refreshed manifest artifact

## Validation
- GitHub Actions: Test .NET matrix passed
- GitHub Actions: Test PowerShell (7) matrix passed, including rerun Ubuntu PowerShell 7