### PR TITLE
Use bundled Playwright driver assets

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
@@ -15,6 +15,35 @@ namespace HtmlTinkerX.Tests;
 [Collection("Playwright collection")]
 public class HtmlBrowserInstallerTests
 {
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void HasDriverLayout_RejectsIncompleteBundledAssets(bool hasHealthyNode, bool hasPackageContent)
+    {
+        string driverPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string nodeDir = Path.Combine(driverPath, "node", PlatformExtensions.GetCurrentPlatform().ToPlatformId());
+        string packageDir = Path.Combine(driverPath, "package");
+
+        try
+        {
+            Directory.CreateDirectory(nodeDir);
+            Directory.CreateDirectory(packageDir);
+            File.WriteAllText(
+                Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"),
+                hasHealthyNode ? "node" : string.Empty);
+            if (hasPackageContent)
+            {
+                File.WriteAllText(Path.Combine(packageDir, "package.json"), "{}");
+            }
+
+            Assert.False(HtmlBrowser.HasDriverLayout(driverPath));
+        }
+        finally
+        {
+            if (Directory.Exists(driverPath)) Directory.Delete(driverPath, true);
+        }
+    }
+
     [Fact]
     public async Task EnsureDriverInstalledAsync_UsesBundledDriverWithoutNetworkDownload()
     {
@@ -74,14 +103,7 @@ public class HtmlBrowserInstallerTests
 
         try
         {
-            // prepare fake driver so IsDriverPresent returns true
-            string baseDir = Path.Combine(tempDriver, ".playwright");
-            string platformId = PlatformExtensions.GetCurrentPlatform().ToPlatformId();
-            string nodeDir = Path.Combine(baseDir, "node", platformId);
-            Directory.CreateDirectory(nodeDir);
-            Directory.CreateDirectory(Path.Combine(baseDir, "package"));
-            File.WriteAllText(Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"), "");
-            File.WriteAllText(Path.Combine(baseDir, ".version"), typeof(Microsoft.Playwright.Playwright).Assembly.GetName().Version?.ToString(3) ?? "1.52.0");
+            CreateHealthyDriver(tempDriver);
 
             string[]? captured = null;
             HtmlBrowser.PlaywrightInstaller = args => captured = args;
@@ -120,14 +142,7 @@ public class HtmlBrowserInstallerTests
 
         try
         {
-            // prepare fake driver so IsDriverPresent returns true
-            string baseDir = Path.Combine(tempDriver, ".playwright");
-            string platformId = PlatformExtensions.GetCurrentPlatform().ToPlatformId();
-            string nodeDir = Path.Combine(baseDir, "node", platformId);
-            Directory.CreateDirectory(nodeDir);
-            Directory.CreateDirectory(Path.Combine(baseDir, "package"));
-            File.WriteAllText(Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"), "");
-            File.WriteAllText(Path.Combine(baseDir, ".version"), typeof(Microsoft.Playwright.Playwright).Assembly.GetName().Version?.ToString(3) ?? "1.52.0");
+            CreateHealthyDriver(tempDriver);
 
             string[]? captured = null;
             HtmlBrowser.PlaywrightInstaller = args => captured = args;
@@ -314,6 +329,18 @@ public class HtmlBrowserInstallerTests
             if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
             if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
         }
+    }
+
+    private static void CreateHealthyDriver(string driverRoot)
+    {
+        string baseDir = Path.Combine(driverRoot, ".playwright");
+        string nodeDir = Path.Combine(baseDir, "node", PlatformExtensions.GetCurrentPlatform().ToPlatformId());
+        string packageDir = Path.Combine(baseDir, "package");
+        Directory.CreateDirectory(nodeDir);
+        Directory.CreateDirectory(packageDir);
+        File.WriteAllText(Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"), "node");
+        File.WriteAllText(Path.Combine(packageDir, "package.json"), "{}");
+        File.WriteAllText(Path.Combine(baseDir, ".version"), typeof(Microsoft.Playwright.Playwright).Assembly.GetName().Version?.ToString(3) ?? "1.52.0");
     }
 
     private static byte[] CreateDriverArchive()

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
@@ -16,6 +16,31 @@ namespace HtmlTinkerX.Tests;
 public class HtmlBrowserInstallerTests
 {
     [Fact]
+    public async Task EnsureDriverInstalledAsync_UsesBundledDriverWithoutNetworkDownload()
+    {
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalFactory = HtmlBrowser.HttpClientFactory;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", null);
+            HtmlBrowser.HttpClientFactory = () => throw new InvalidOperationException("Bundled driver should avoid network download.");
+
+            await HtmlBrowser.EnsureDriverInstalledAsync();
+
+            string configuredRoot = Path.GetFullPath(Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH")!);
+            string nodeExecutable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
+            string nodePath = Path.Combine(configuredRoot, ".playwright", "node", PlatformExtensions.GetCurrentPlatform().ToPlatformId(), nodeExecutable);
+            Assert.True(File.Exists(nodePath), $"Expected the bundled Playwright driver at '{nodePath}'.");
+        }
+        finally
+        {
+            HtmlBrowser.HttpClientFactory = originalFactory;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+        }
+    }
+
+    [Fact]
     public void ShouldInstallBundledRuntime_SkipsRuntimeForExternalBrowsers()
     {
         Assert.True(HtmlBrowser.ShouldInstallBundledRuntime(new HtmlBrowserLaunchOptions()));

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
@@ -132,9 +132,20 @@ public static partial class HtmlBrowser {
         return HasDriverLayout(appBasePath) ? appBasePath : assemblyPath;
     }
 
-    private static bool HasDriverLayout(string driverPath) {
+    internal static bool HasDriverLayout(string driverPath) {
         string nodePath = Path.Combine(driverPath, "node", PlatformId, NodeExecutable);
-        return File.Exists(nodePath) && Directory.Exists(Path.Combine(driverPath, "package"));
+        string packagePath = Path.Combine(driverPath, "package");
+        if (!File.Exists(nodePath) || !Directory.Exists(packagePath)) {
+            return false;
+        }
+
+        try {
+            return new FileInfo(nodePath).Length > 0 && Directory.EnumerateFileSystemEntries(packagePath).Any();
+        } catch (IOException) {
+            return false;
+        } catch (UnauthorizedAccessException) {
+            return false;
+        }
     }
 
     private static bool IsBundledDriverPath(string driverPath) {

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
@@ -95,7 +95,53 @@ public static partial class HtmlBrowser {
     /// This directory contains the Playwright driver executable and other related files.
     /// </summary>
     private static string GetDriverPath() {
+        string? explicitRoot = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        if (string.IsNullOrWhiteSpace(explicitRoot)) {
+            string bundledPath = GetBundledDriverPath();
+            if (HasDriverLayout(bundledPath)) {
+                return bundledPath;
+            }
+        }
+
         return Path.Combine(GetDriverRoot(), ".playwright");
+    }
+
+    private static string GetBundledDriverPath() {
+        string assemblyDirectory = Path.GetDirectoryName(typeof(HtmlBrowser).Assembly.Location) ?? AppContext.BaseDirectory;
+        string assemblyPath = Path.Combine(assemblyDirectory, ".playwright");
+        if (HasDriverLayout(assemblyPath)) {
+            return assemblyPath;
+        }
+
+#if NETFRAMEWORK
+#pragma warning disable SYSLIB0012
+        string? codeBase = typeof(HtmlBrowser).Assembly.CodeBase;
+#pragma warning restore SYSLIB0012
+        if (!string.IsNullOrWhiteSpace(codeBase) && Uri.TryCreate(codeBase, UriKind.Absolute, out Uri? assemblyUri) && assemblyUri.IsFile) {
+            string? originalDirectory = Path.GetDirectoryName(assemblyUri.LocalPath);
+            if (!string.IsNullOrWhiteSpace(originalDirectory)) {
+                string originalPath = Path.Combine(originalDirectory, ".playwright");
+                if (HasDriverLayout(originalPath)) {
+                    return originalPath;
+                }
+            }
+        }
+#endif
+
+        string appBasePath = Path.Combine(AppContext.BaseDirectory, ".playwright");
+        return HasDriverLayout(appBasePath) ? appBasePath : assemblyPath;
+    }
+
+    private static bool HasDriverLayout(string driverPath) {
+        string nodePath = Path.Combine(driverPath, "node", PlatformId, NodeExecutable);
+        return File.Exists(nodePath) && Directory.Exists(Path.Combine(driverPath, "package"));
+    }
+
+    private static bool IsBundledDriverPath(string driverPath) {
+        return string.Equals(
+            Path.GetFullPath(driverPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            Path.GetFullPath(GetBundledDriverPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -110,10 +156,10 @@ public static partial class HtmlBrowser {
     /// <returns></returns>
     private static bool IsDriverPresent() {
         string baseDir = GetDriverPath();
-        string nodePath = Path.Combine(baseDir, "node", PlatformId, NodeExecutable);
-        string packageDir = Path.Combine(baseDir, "package");
-        if (!File.Exists(nodePath) || !Directory.Exists(packageDir))
+        if (!HasDriverLayout(baseDir))
             return false;
+        if (IsBundledDriverPath(baseDir))
+            return true;
         if (!File.Exists(VersionFile))
             return false;
         string version = File.ReadAllText(VersionFile).Trim();
@@ -168,6 +214,10 @@ public static partial class HtmlBrowser {
     /// the driver is no longer needed.
     /// </summary>
     internal static void CleanDriver() {
+        if (IsBundledDriverPath(GetDriverPath())) {
+            return;
+        }
+
         string root = GetDriverRoot();
         if (Directory.Exists(root)) {
             try {
@@ -226,7 +276,11 @@ public static partial class HtmlBrowser {
         await InstallationSemaphore.WaitAsync().ConfigureAwait(false);
         try {
             CleanInstallDir();
-            await DownloadAndInstallDriverAsync().ConfigureAwait(false);
+            if (!IsDriverPresent()) {
+                await DownloadAndInstallDriverAsync().ConfigureAwait(false);
+            } else {
+                EnsureDriverSearchPath();
+            }
             InstallRuntime(engine);
         } finally {
             InstallationSemaphore.Release();
@@ -384,7 +438,9 @@ public static partial class HtmlBrowser {
     }
 
     private static void EnsureDriverSearchPath() {
-        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", GetDriverRoot());
+        string driverPath = GetDriverPath();
+        string driverRoot = Path.GetDirectoryName(driverPath) ?? GetDriverRoot();
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", driverRoot);
     }
 
     private static Func<HttpClient> DefaultHttpClientFactory => () => new HttpClient { Timeout = TimeSpan.FromMinutes(5) };


### PR DESCRIPTION
HtmlTinkerX now uses the Playwright driver assets copied from the Microsoft.Playwright package before attempting a network download.

This fixes browser setup failures caused by the retired `playwright.azureedge.net/builds/driver` path. It also handles .NET Framework test-host shadow copying by resolving the original assembly output and keeps explicit `PLAYWRIGHT_DRIVER_SEARCH_PATH` overrides working.

Repair no longer downloads a replacement driver when the bundled layout is healthy, and cleanup will not delete bundled output assets.

A focused installer contract verifies that bundled assets avoid the network across net472, net8.0, and net10.0. The fixed source also completed the full IntelligenceX PowerForge website pipeline, including rendered audit with 0 errors and 0 warnings.

Downstream release step: publish the next three-part HtmlTinkerX package, then update PowerForge.Web to that public version.
