### PR TITLE
Backport Playwright self-healing to HtmlTinkerX 2.0.19

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -161,6 +162,297 @@ public class HtmlBrowserInstallerTests
             if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
             if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
         }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_ReplacesStaleBrowserRevision()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            CreateHealthyDriver(tempDriver);
+            CreateCompleteChromiumRuntime(tempBrowsers, "1194");
+
+            string[]? captured = null;
+            HtmlBrowser.PlaywrightInstaller = args => captured = args;
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+
+            Assert.NotNull(captured);
+            Assert.Contains("install", captured!);
+            Assert.Contains("chromium", captured!);
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_SkipsCurrentCompleteBrowserRevision()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            CreateHealthyDriver(tempDriver);
+            CreateCompleteChromiumRuntime(tempBrowsers, "1217");
+
+            HtmlBrowser.PlaywrightInstaller = _ => throw new InvalidOperationException("Current browser runtime should not be reinstalled.");
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_UsesOnlyCurrentPlatformRevisionOverride()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        string? originalHostOverride = Environment.GetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE", "ubuntu20.04-x64");
+            CreateHealthyDriver(tempDriver);
+            string packageDirectory = Path.Combine(tempDriver, ".playwright", "package");
+            File.WriteAllText(Path.Combine(packageDirectory, "browsers.json"), """
+                {
+                  "browsers": [
+                    {
+                      "name": "webkit",
+                      "revision": "2272",
+                      "revisionOverrides": {
+                        "debian11-x64": "2105",
+                        "ubuntu20.04-x64": "2092"
+                      }
+                    }
+                  ]
+                }
+                """);
+            CreateCompleteRuntime(tempBrowsers, "webkit-2272");
+            CreateCompleteRuntime(tempBrowsers, "webkit_debian11_x64_special-2105");
+
+            string[]? captured = null;
+            HtmlBrowser.PlaywrightInstaller = args => captured = args;
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.WebKit);
+
+            Assert.NotNull(captured);
+            Assert.Contains("webkit", captured!);
+
+            CreateCompleteRuntime(tempBrowsers, "webkit_ubuntu20.04_x64_special-2092");
+            HtmlBrowser.PlaywrightInstaller = _ => throw new InvalidOperationException("The current host override should be accepted.");
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.WebKit);
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE", originalHostOverride);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_CleansIncompleteCurrentPlatformRevisionOverride()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        string? originalHostOverride = Environment.GetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+        string overrideDirectory = Path.Combine(tempBrowsers, "webkit_ubuntu20.04_x64_special-2092");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE", "ubuntu20.04-x64");
+            CreateHealthyDriver(tempDriver);
+            File.WriteAllText(Path.Combine(tempDriver, ".playwright", "package", "browsers.json"), """
+                {
+                  "browsers": [
+                    {
+                      "name": "webkit",
+                      "revision": "2272",
+                      "revisionOverrides": { "ubuntu20.04-x64": "2092" }
+                    }
+                  ]
+                }
+                """);
+            Directory.CreateDirectory(overrideDirectory);
+            File.WriteAllText(Path.Combine(overrideDirectory, "partial-download"), "incomplete");
+
+            HtmlBrowser.PlaywrightInstaller = _ =>
+            {
+                Assert.False(Directory.Exists(overrideDirectory));
+                CreateCompleteRuntime(tempBrowsers, "webkit_ubuntu20.04_x64_special-2092");
+            };
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.WebKit);
+
+            Assert.True(File.Exists(Path.Combine(overrideDirectory, "INSTALLATION_COMPLETE")));
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE", originalHostOverride);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_ReinstallsDriverWithMissingBrowserManifest()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+        var originalFactory = HtmlBrowser.HttpClientFactory;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            CreateHealthyDriver(tempDriver);
+            string manifestPath = Path.Combine(tempDriver, ".playwright", "package", "browsers.json");
+            File.Delete(manifestPath);
+            HtmlBrowser.HttpClientFactory = () => new HttpClient(new FakeHandler(CreateDriverArchive()));
+
+            string[]? captured = null;
+            HtmlBrowser.PlaywrightInstaller = args => captured = args;
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+
+            Assert.True(File.Exists(manifestPath));
+            Assert.NotNull(captured);
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            HtmlBrowser.HttpClientFactory = originalFactory;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_ReinstallsDriverWithMalformedBrowserManifest()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+        var originalFactory = HtmlBrowser.HttpClientFactory;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            CreateHealthyDriver(tempDriver);
+            string manifestPath = Path.Combine(tempDriver, ".playwright", "package", "browsers.json");
+            File.WriteAllText(manifestPath, "{not-json");
+            HtmlBrowser.HttpClientFactory = () => new HttpClient(new FakeHandler(CreateDriverArchive()));
+            HtmlBrowser.PlaywrightInstaller = _ => CreateCompleteChromiumRuntime(tempBrowsers, "1217");
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+
+            using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            Assert.Equal(JsonValueKind.Array, manifest.RootElement.GetProperty("browsers").ValueKind);
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            HtmlBrowser.HttpClientFactory = originalFactory;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_RechecksExistingRuntimeAfterDriverDownload()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalInstaller = HtmlBrowser.PlaywrightInstaller;
+        var originalFactory = HtmlBrowser.HttpClientFactory;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            CreateCompleteChromiumRuntime(tempBrowsers, "1217");
+            HtmlBrowser.HttpClientFactory = () => new HttpClient(new FakeHandler(CreateDriverArchive()));
+            HtmlBrowser.PlaywrightInstaller = _ => throw new InvalidOperationException("An existing exact runtime should not be reinstalled.");
+
+            await HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium);
+
+            Assert.True(HtmlBrowser.HasDriverLayout(Path.Combine(tempDriver, ".playwright")));
+        }
+        finally
+        {
+            HtmlBrowser.PlaywrightInstaller = originalInstaller;
+            HtmlBrowser.HttpClientFactory = originalFactory;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Theory]
+    [InlineData(23, Architecture.X64, "mac14")]
+    [InlineData(24, Architecture.Arm64, "mac15-arm64")]
+    [InlineData(19, Architecture.X64, "mac10.15")]
+    public void GetMacPlaywrightHostPlatform_UsesDarwinMajor(int darwinMajor, Architecture architecture, string expected)
+    {
+        Assert.Equal(expected, HtmlBrowser.GetMacPlaywrightHostPlatform(architecture, darwinMajor));
     }
 
     [Fact]
@@ -340,7 +632,32 @@ public class HtmlBrowserInstallerTests
         Directory.CreateDirectory(packageDir);
         File.WriteAllText(Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"), "node");
         File.WriteAllText(Path.Combine(packageDir, "package.json"), "{}");
+        File.WriteAllText(Path.Combine(packageDir, "browsers.json"), """
+            {
+              "browsers": [
+                { "name": "chromium", "revision": "1217" },
+                { "name": "chromium-headless-shell", "revision": "1217" },
+                { "name": "firefox", "revision": "1511" },
+                { "name": "webkit", "revision": "2272" }
+              ]
+            }
+            """);
         File.WriteAllText(Path.Combine(baseDir, ".version"), typeof(Microsoft.Playwright.Playwright).Assembly.GetName().Version?.ToString(3) ?? "1.52.0");
+    }
+
+    private static void CreateCompleteChromiumRuntime(string browserRoot, string revision)
+    {
+        foreach (string name in new[] { "chromium", "chromium_headless_shell" })
+        {
+            CreateCompleteRuntime(browserRoot, $"{name}-{revision}");
+        }
+    }
+
+    private static void CreateCompleteRuntime(string browserRoot, string directoryName)
+    {
+        string directory = Path.Combine(browserRoot, directoryName);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "INSTALLATION_COMPLETE"), string.Empty);
     }
 
     private static byte[] CreateDriverArchive()
@@ -362,6 +679,18 @@ public class HtmlBrowserInstallerTests
             using (var packageStream = new StreamWriter(archive.CreateEntry("package/package.json").Open()))
             {
                 packageStream.Write("{}");
+            }
+
+            using (var browsersStream = new StreamWriter(archive.CreateEntry("package/browsers.json").Open()))
+            {
+                browsersStream.Write("""
+                    {
+                      "browsers": [
+                        { "name": "chromium", "revision": "1217" },
+                        { "name": "chromium-headless-shell", "revision": "1217" }
+                      ]
+                    }
+                    """);
             }
         }
 

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>2.0.18</VersionPrefix>
+        <VersionPrefix>2.0.19</VersionPrefix>
         <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
         <AssemblyName>HtmlTinkerX</AssemblyName>
         <AssemblyTitle>HtmlTinkerX</AssemblyTitle>

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -135,15 +137,30 @@ public static partial class HtmlBrowser {
     internal static bool HasDriverLayout(string driverPath) {
         string nodePath = Path.Combine(driverPath, "node", PlatformId, NodeExecutable);
         string packagePath = Path.Combine(driverPath, "package");
-        if (!File.Exists(nodePath) || !Directory.Exists(packagePath)) {
+        string browsersManifestPath = Path.Combine(packagePath, "browsers.json");
+        if (!File.Exists(nodePath) || !Directory.Exists(packagePath) || !File.Exists(browsersManifestPath)) {
             return false;
         }
 
         try {
-            return new FileInfo(nodePath).Length > 0 && Directory.EnumerateFileSystemEntries(packagePath).Any();
+            return new FileInfo(nodePath).Length > 0 && IsValidBrowserManifest(browsersManifestPath);
         } catch (IOException) {
             return false;
         } catch (UnauthorizedAccessException) {
+            return false;
+        }
+    }
+
+    private static bool IsValidBrowserManifest(string manifestPath) {
+        try {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            return document.RootElement.TryGetProperty("browsers", out JsonElement browsers) &&
+                   browsers.ValueKind == JsonValueKind.Array;
+        } catch (IOException) {
+            return false;
+        } catch (UnauthorizedAccessException) {
+            return false;
+        } catch (JsonException) {
             return false;
         }
     }
@@ -185,27 +202,8 @@ public static partial class HtmlBrowser {
         if (!Directory.Exists(baseDir))
             return false;
 
-        string nodePath = Path.Combine(baseDir, "node", PlatformId, NodeExecutable);
-        if (!File.Exists(nodePath))
+        if (!HasDriverLayout(baseDir))
             return true;
-
-        try {
-            if (new FileInfo(nodePath).Length == 0)
-                return true;
-        } catch {
-            return true;
-        }
-
-        string packageDir = Path.Combine(baseDir, "package");
-        if (!Directory.Exists(packageDir))
-            return true;
-
-        try {
-            if (!Directory.EnumerateFileSystemEntries(packageDir).Any())
-                return true;
-        } catch {
-            return true;
-        }
 
         if (!File.Exists(VersionFile))
             return true;
@@ -263,15 +261,14 @@ public static partial class HtmlBrowser {
                 return;
             }
 
-            bool runtimeInstalled = IsBrowserRuntimeInstalled(engine);
-
             if (!IsDriverPresent()) {
                 await DownloadAndInstallDriverAsync().ConfigureAwait(false);
             } else {
                 EnsureDriverSearchPath();
             }
 
-            if (!runtimeInstalled) {
+            // A repaired driver provides the manifest needed to identify an already-installed exact runtime.
+            if (!IsBrowserRuntimeInstalled(engine)) {
                 InstallRuntime(engine);
             }
         } finally {
@@ -325,25 +322,208 @@ public static partial class HtmlBrowser {
         string path = GetBrowserInstallPath();
         if (!Directory.Exists(path))
             return false;
-        var prefixes = GetRuntimePrefixes(engine);
-        foreach (string prefix in prefixes) {
-            bool found = false;
-            foreach (string dir in Directory.GetDirectories(path)) {
-                if (Path.GetFileName(dir).StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found)
+
+        IReadOnlyDictionary<string, IReadOnlyList<string>> expectedDirectories = GetExpectedRuntimeDirectories(path, engine);
+        if (expectedDirectories.Count == 0)
+            return false;
+
+        foreach (IReadOnlyList<string> candidates in expectedDirectories.Values) {
+            if (!candidates.Any(IsCompleteBrowserRuntime))
                 return false;
         }
+
         return true;
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> GetExpectedRuntimeDirectories(string browserRoot, HtmlBrowserEngine engine) {
+        string manifestPath = Path.Combine(GetDriverPath(), "package", "browsers.json");
+        if (!File.Exists(manifestPath))
+            return new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+        string[] requiredNames = engine == HtmlBrowserEngine.Chromium
+            ? new[] { "chromium", "chromium-headless-shell" }
+            : new[] { engine.ToString().ToLowerInvariant() };
+        var required = new HashSet<string>(requiredNames, StringComparer.OrdinalIgnoreCase);
+        var expected = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+        try {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            if (!document.RootElement.TryGetProperty("browsers", out JsonElement browsers) || browsers.ValueKind != JsonValueKind.Array)
+                return expected;
+
+            foreach (JsonElement browser in browsers.EnumerateArray()) {
+                if (!browser.TryGetProperty("name", out JsonElement nameElement) || nameElement.ValueKind != JsonValueKind.String ||
+                    !browser.TryGetProperty("revision", out JsonElement revisionElement) || revisionElement.ValueKind != JsonValueKind.String) {
+                    continue;
+                }
+
+                string? name = nameElement.GetString();
+                string? revision = revisionElement.GetString();
+                if (name is null || name.Trim().Length == 0 || revision is null || revision.Trim().Length == 0 || !required.Contains(name))
+                    continue;
+
+                string selectedName = name;
+                string selectedRevision = revision;
+                string hostPlatform = GetCurrentPlaywrightHostPlatform();
+                if (browser.TryGetProperty("revisionOverrides", out JsonElement overrides) &&
+                    overrides.ValueKind == JsonValueKind.Object &&
+                    overrides.TryGetProperty(hostPlatform, out JsonElement revisionOverride) &&
+                    revisionOverride.ValueKind == JsonValueKind.String) {
+                    string? overrideRevision = revisionOverride.GetString();
+                    if (overrideRevision is not null && overrideRevision.Trim().Length > 0) {
+                        selectedName = $"{name}_{hostPlatform}_special";
+                        selectedRevision = overrideRevision;
+                    }
+                }
+
+                expected[name] = new[] { BuildRuntimeDirectory(browserRoot, selectedName, selectedRevision) };
+            }
+        } catch (IOException) {
+            return new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        } catch (UnauthorizedAccessException) {
+            return new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        } catch (JsonException) {
+            return new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return expected.Count == required.Count
+            ? expected
+            : new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string BuildRuntimeDirectory(string browserRoot, string name, string revision) {
+        string directoryName = name.Replace('-', '_') + "-" + revision;
+        return Path.Combine(browserRoot, directoryName);
+    }
+
+    private static bool IsCompleteBrowserRuntime(string directory) {
+        return Directory.Exists(directory) && File.Exists(Path.Combine(directory, "INSTALLATION_COMPLETE"));
+    }
+
+    private static string GetCurrentPlaywrightHostPlatform() {
+        string? overridePlatform = Environment.GetEnvironmentVariable("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE");
+        if (!string.IsNullOrWhiteSpace(overridePlatform))
+            return overridePlatform.Trim();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return "win64";
+
+        string? architecture = RuntimeInformation.OSArchitecture switch {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            _ => null
+        };
+        if (architecture is null)
+            return "<unknown>";
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            return GetMacPlaywrightHostPlatform(RuntimeInformation.OSArchitecture, GetDarwinMajorVersion());
+        }
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return "<unknown>";
+
+        string suffix = "-" + architecture;
+        IReadOnlyDictionary<string, string> release = ReadLinuxOsRelease();
+        release.TryGetValue("ID", out string? id);
+        release.TryGetValue("VERSION_ID", out string? version);
+        id = id?.ToLowerInvariant() ?? string.Empty;
+        version ??= string.Empty;
+        int.TryParse(version.Split('.')[0], out int major);
+
+        if (id is "ubuntu" or "pop" or "neon" or "tuxedo") {
+            if (major < 20) return "ubuntu18.04" + suffix;
+            if (major < 22) return "ubuntu20.04" + suffix;
+            if (major < 24) return "ubuntu22.04" + suffix;
+            if (major < 26) return "ubuntu24.04" + suffix;
+            return "ubuntu" + version + suffix;
+        }
+        if (id == "linuxmint") {
+            if (major <= 20) return "ubuntu20.04" + suffix;
+            if (major == 21) return "ubuntu22.04" + suffix;
+            return "ubuntu24.04" + suffix;
+        }
+        if (id is "debian" or "raspbian") {
+            if (version is "11" or "12" or "13") return "debian" + version + suffix;
+            if (version.Length == 0) return "debian13" + suffix;
+        }
+        return "ubuntu24.04" + suffix;
+    }
+
+    internal static string GetMacPlaywrightHostPlatform(Architecture architecture, int darwinMajor) {
+        string macVersion = darwinMajor switch {
+            < 18 => "mac10.13",
+            18 => "mac10.14",
+            19 => "mac10.15",
+            _ => "mac" + Math.Min(darwinMajor - 9, 15)
+        };
+        return architecture == Architecture.Arm64 && darwinMajor >= 20
+            ? macVersion + "-arm64"
+            : macVersion;
+    }
+
+    private static int GetDarwinMajorVersion() {
+        try {
+            var startInfo = new ProcessStartInfo {
+                FileName = "/usr/bin/uname",
+                Arguments = "-r",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            using Process? process = Process.Start(startInfo);
+            if (process is not null) {
+                string release = process.StandardOutput.ReadToEnd().Trim();
+                if (process.WaitForExit(5000) && process.ExitCode == 0 &&
+                    int.TryParse(release.Split('.')[0], out int darwinMajor)) {
+                    return darwinMajor;
+                }
+            }
+        } catch (InvalidOperationException) {
+            // Fall back to Environment.OSVersion when uname cannot be started.
+        } catch (System.ComponentModel.Win32Exception) {
+            // Fall back to Environment.OSVersion when uname is unavailable.
+        }
+
+        Version version = Environment.OSVersion.Version;
+        if (version.Major >= 20)
+            return version.Major;
+        if (version.Major >= 11)
+            return version.Major + 9;
+        if (version.Major == 10 && version.Minor >= 13)
+            return version.Minor + 4;
+        return version.Major;
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadLinuxOsRelease() {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try {
+            foreach (string line in File.ReadLines("/etc/os-release")) {
+                int separator = line.IndexOf('=');
+                if (separator <= 0)
+                    continue;
+                string key = line.Substring(0, separator).Trim();
+                string value = line.Substring(separator + 1).Trim().Trim('"', '\'');
+                values[key] = value;
+            }
+        } catch (IOException) {
+            // Playwright falls back to the current Ubuntu platform for unknown Linux distributions.
+        } catch (UnauthorizedAccessException) {
+            // Playwright falls back to the current Ubuntu platform for unreadable release metadata.
+        }
+        return values;
     }
 
     private static bool IsBrowserRuntimeCorrupted(HtmlBrowserEngine engine) {
         string path = GetBrowserInstallPath();
         if (!Directory.Exists(path))
             return false;
+        IReadOnlyDictionary<string, IReadOnlyList<string>> expectedDirectories = GetExpectedRuntimeDirectories(path, engine);
+        if (expectedDirectories.Values.SelectMany(static candidates => candidates)
+            .Any(directory => Directory.Exists(directory) && !IsCompleteBrowserRuntime(directory))) {
+            return true;
+        }
         var prefixes = GetRuntimePrefixes(engine);
         foreach (string prefix in prefixes) {
             var candidates = Directory.GetDirectories(path).Where(dir =>
@@ -386,16 +566,24 @@ public static partial class HtmlBrowser {
         if (!Directory.Exists(path))
             return;
 
+        var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string expectedDirectory in GetExpectedRuntimeDirectories(path, engine).Values.SelectMany(static candidates => candidates)) {
+            directories.Add(expectedDirectory);
+        }
         var prefixes = GetRuntimePrefixes(engine);
         foreach (string prefix in prefixes) {
             foreach (string dir in Directory.GetDirectories(path)) {
-                if (!Path.GetFileName(dir).StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                    continue;
-                try {
-                    Directory.Delete(dir, true);
-                } catch {
-                    // Ignore cleanup errors - best effort only.
-                }
+                if (Path.GetFileName(dir).StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    directories.Add(dir);
+            }
+        }
+        foreach (string directory in directories) {
+            if (!Directory.Exists(directory))
+                continue;
+            try {
+                Directory.Delete(directory, true);
+            } catch {
+                // Ignore cleanup errors - best effort only.
             }
         }
     }
@@ -433,9 +621,10 @@ public static partial class HtmlBrowser {
 
     private static string[] GetRuntimePrefixes(HtmlBrowserEngine engine) {
         if (engine == HtmlBrowserEngine.Chromium) {
-            return new[] { "chromium-", "chromium_headless_shell-" };
+            return new[] { "chromium-", "chromium_" };
         }
-        return new[] { engine.ToString().ToLowerInvariant() + "-" };
+        string name = engine.ToString().ToLowerInvariant();
+        return new[] { name + "-", name + "_" };
     }
 
     private static void ValidateExistingInstallation(HtmlBrowserEngine engine) {


### PR DESCRIPTION
## Summary

- backport the reviewed Playwright runtime self-healing fix from #407 onto the stable 2.0 maintenance line
- require exact current-driver browser revisions, repair missing or malformed manifests, clean incomplete platform overrides, and avoid unnecessary runtime installation after driver repair
- prepare stable package version `2.0.19`

## Why

PowerForge.Web currently consumes stable HtmlTinkerX `2.0.18`. Publishing this narrow maintenance release fixes automatic rendered-site rebuilds without pulling the unrelated 2.1 development surface into production.

## Validation

- focused `HtmlBrowserInstallerTests`: 19 passed on each of net472, net8.0, and net10.0
- full suite: net472 797 passed / 2 intentional skips; net8.0 801 passed; net10.0 801 passed
- Windows, Ubuntu, and macOS PowerShell CI plus packaged ALC validation

Package publication and the downstream PowerForge repin remain release-state gates after merge.