### PR TITLE
Add reusable HTML document and browser auditing

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserStyleInspectionTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserStyleInspectionTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+
+namespace HtmlTinkerX.Tests;
+
+[Collection("Playwright collection")]
+public class HtmlBrowserStyleInspectionTests {
+    [Fact]
+    public async Task StyleInspectionAndAudit_UseRenderedDocumentContract() {
+        string file = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.html");
+        File.WriteAllText(file, """
+<!doctype html>
+<html lang="en" style="--brand: #123456">
+<head><title>Style inspection</title></head>
+<body><main><h1>Style</h1><button id="action" aria-label="Run" style="color: rgb(1, 2, 3)"></button></main></body>
+</html>
+""");
+
+        await using HtmlBrowserSession session = await HtmlBrowser.OpenSessionAsync(new Uri(file).AbsoluteUri);
+        try {
+            IReadOnlyDictionary<string, string> styles = await HtmlBrowser.GetComputedStylesAsync(session, "#action", new[] { "color" });
+            IReadOnlyDictionary<string, string> variables = await HtmlBrowser.GetCssCustomPropertiesAsync(session, "html", new[] { "--brand" });
+            HtmlDocumentAuditResult audit = await HtmlBrowser.AuditDocumentAsync(session);
+
+            Assert.Equal("rgb(1, 2, 3)", styles["color"]);
+            Assert.Equal("#123456", variables["--brand"]);
+            Assert.True(audit.IsValid);
+        } finally {
+            await HtmlBrowser.CloseSessionAsync(session);
+            File.Delete(file);
+        }
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserStyleInspectionTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserStyleInspectionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 
 namespace HtmlTinkerX.Tests;
 
@@ -25,6 +26,22 @@ public class HtmlBrowserStyleInspectionTests {
             Assert.Equal("rgb(1, 2, 3)", styles["color"]);
             Assert.Equal("#123456", variables["--brand"]);
             Assert.True(audit.IsValid);
+        } finally {
+            await HtmlBrowser.CloseSessionAsync(session);
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task StyleInspection_CancelsWhileLocatorIsWaiting() {
+        string file = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.html");
+        File.WriteAllText(file, "<!doctype html><html><head><title>Cancel</title></head><body></body></html>");
+
+        await using HtmlBrowserSession session = await HtmlBrowser.OpenSessionAsync(new Uri(file).AbsoluteUri);
+        try {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                HtmlBrowser.GetComputedStylesAsync(session, "#never-created", new[] { "color" }, cancellation.Token));
         } finally {
             await HtmlBrowser.CloseSessionAsync(session);
             File.Delete(file);

--- a/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
@@ -67,6 +67,7 @@ public class HtmlDocumentAuditTests {
 <body>
 <a href="data:image/svg+xml,&lt;svg onload='alert(1)'&gt;">Unsafe navigation</a>
 <img src="data:image/png;base64,AAAA" alt="Unsafe asset">
+<object data="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;"></object>
 <form action="mailto:ops@example.com"><button>Send</button></form>
 </body>
 </html>
@@ -74,6 +75,6 @@ public class HtmlDocumentAuditTests {
 
         HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
 
-        Assert.Equal(2, result.Issues.Count(issue => issue.Code == "unsafe-url-scheme"));
+        Assert.Equal(3, result.Issues.Count(issue => issue.Code == "unsafe-url-scheme"));
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
@@ -46,6 +46,7 @@ public class HtmlDocumentAuditTests {
 <a href="/home"><img src="home.png" alt="Home"></a>
 <label for="query">Query</label><input id="query">
 <input type="image" src="submit.png" alt="Submit">
+<input type="submit"><input type="reset">
 </main>
 </body>
 </html>
@@ -55,5 +56,24 @@ public class HtmlDocumentAuditTests {
 
         Assert.True(result.IsValid);
         Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public void Analyze_UnsupportedAbsoluteSchemes_AgreeWithGeneratedHtmlPolicy() {
+        string html = """
+<!doctype html>
+<html lang="en">
+<head><title>Audit</title></head>
+<body>
+<a href="data:image/svg+xml,&lt;svg onload='alert(1)'&gt;">Unsafe navigation</a>
+<img src="data:image/png;base64,AAAA" alt="Unsafe asset">
+<form action="mailto:ops@example.com"><button>Send</button></form>
+</body>
+</html>
+""";
+
+        HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
+
+        Assert.Equal(2, result.Issues.Count(issue => issue.Code == "unsafe-url-scheme"));
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
@@ -1,0 +1,59 @@
+namespace HtmlTinkerX.Tests;
+
+public class HtmlDocumentAuditTests {
+    [Fact]
+    public void Analyze_UnsafeAndInaccessibleMarkup_ReturnsStructuredIssues() {
+        string html = """
+<!doctype html>
+<html>
+<head><title>Audit</title></head>
+<body>
+<main>
+<h1>Audit</h1><h3>Skipped</h3>
+<img src="image.png">
+<button id="duplicate"></button>
+<a id="duplicate" href="javascript:alert(1)"></a>
+<input id="unlabelled">
+</main>
+</body>
+</html>
+""";
+
+        HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, issue => issue.Code == "document-language-missing");
+        Assert.Contains(result.Issues, issue => issue.Code == "duplicate-id");
+        Assert.Contains(result.Issues, issue => issue.Code == "image-alt-missing");
+        Assert.Equal(2, result.Issues.Count(issue => issue.Code == "interactive-name-missing"));
+        Assert.Contains(result.Issues, issue => issue.Code == "form-label-missing");
+        Assert.Contains(result.Issues, issue => issue.Code == "unsafe-url-scheme");
+        Assert.Contains(result.Issues, issue => issue.Code == "heading-level-skipped");
+    }
+
+    [Fact]
+    public void Analyze_AccessibleDocument_IsValid() {
+        string html = """
+<!doctype html>
+<html lang="en">
+<head><title>Audit</title></head>
+<body>
+<main>
+<h1>Audit</h1><h2>Details</h2>
+<img src="decorative.png" alt="">
+<button aria-label="Refresh"></button>
+<a href="/docs">Documentation</a>
+<a href="/home"><img src="home.png" alt="Home"></a>
+<label for="query">Query</label><input id="query">
+<input type="image" src="submit.png" alt="Submit">
+</main>
+</body>
+</html>
+""";
+
+        HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Issues);
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace HtmlTinkerX.Tests;
 
 public class HtmlDocumentAuditTests {
@@ -111,5 +113,34 @@ public class HtmlDocumentAuditTests {
         HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
 
         Assert.Contains(result.Issues, issue => issue.Code == "unsafe-url-scheme" && issue.Element == "a");
+    }
+
+    [Fact]
+    public void Analyze_MetaRefreshExecutableTarget_IsRejected() {
+        string html = """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <title>Audit</title>
+          <meta http-equiv="refresh" content="0; URL = 'javascript:alert(1)'">
+        </head>
+        <body><main><h1>Audit</h1></main></body>
+        </html>
+        """;
+
+        HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
+
+        Assert.Contains(result.Issues, issue =>
+            issue.Code == "unsafe-url-scheme" &&
+            issue.Message.Contains("meta refresh", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_PreCanceledToken_StopsBeforeParsing() {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            HtmlDocumentAudit.AnalyzeAsync("<html><body></body></html>", cancellationToken: cancellation.Token));
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
@@ -97,4 +97,19 @@ public class HtmlDocumentAuditTests {
 
         Assert.Equal(2, result.Issues.Count(issue => issue.Code == "form-label-missing"));
     }
+
+    [Fact]
+    public void Analyze_LegacySvgExecutableLink_IsRejected() {
+        string html = """
+        <!doctype html>
+        <html lang="en">
+        <head><title>Audit</title></head>
+        <body><svg><a xlink:href="javascript:alert(1)"><text>Unsafe</text></a></svg></body>
+        </html>
+        """;
+
+        HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
+
+        Assert.Contains(result.Issues, issue => issue.Code == "unsafe-url-scheme" && issue.Element == "a");
+    }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlDocumentAuditTests.cs
@@ -66,7 +66,8 @@ public class HtmlDocumentAuditTests {
 <head><title>Audit</title></head>
 <body>
 <a href="data:image/svg+xml,&lt;svg onload='alert(1)'&gt;">Unsafe navigation</a>
-<img src="data:image/png;base64,AAAA" alt="Unsafe asset">
+<img src="data:image/png;base64,AAAA" alt="Safe embedded asset">
+<link rel="icon" href="data:image/png;base64,AAAA">
 <object data="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;"></object>
 <form action="mailto:ops@example.com"><button>Send</button></form>
 </body>
@@ -75,6 +76,25 @@ public class HtmlDocumentAuditTests {
 
         HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
 
-        Assert.Equal(3, result.Issues.Count(issue => issue.Code == "unsafe-url-scheme"));
+        Assert.Equal(2, result.Issues.Count(issue => issue.Code == "unsafe-url-scheme"));
+    }
+
+    [Fact]
+    public void Analyze_SelectAndTextareaContent_DoesNotReplaceAFormLabel() {
+        string html = """
+        <!doctype html>
+        <html lang="en">
+        <head><title>Audit</title></head>
+        <body>
+        <select><option>Visible option</option></select>
+        <textarea>Default value</textarea>
+        <span id="query-label">Query</span><input aria-labelledby="query-label">
+        </body>
+        </html>
+        """;
+
+        HtmlDocumentAuditResult result = HtmlDocumentAudit.Analyze(html);
+
+        Assert.Equal(2, result.Issues.Count(issue => issue.Code == "form-label-missing"));
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlPageWorkbenchTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlPageWorkbenchTests.cs
@@ -49,6 +49,8 @@ public class HtmlPageWorkbenchTests {
         Assert.Single(result.JsonLd);
         Assert.Single(result.OpenGraph);
         Assert.NotEmpty(result.JavaScriptConfig);
+        Assert.NotNull(result.DocumentAudit);
+        Assert.Contains(result.DocumentAudit!.Issues, issue => issue.Code == "document-language-missing");
         Assert.Contains(result.Endpoints, item => item.Url == "/api/items");
         Assert.Contains(result.Warnings, warning => warning.Contains("Hidden fields", StringComparison.OrdinalIgnoreCase));
     }

--- a/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
+++ b/Sources/HtmlTinkerX.Tests/Playwright/HtmlBrowserTesterTests.cs
@@ -25,6 +25,23 @@ public class HtmlBrowserTesterTests {
         Assert.NotNull(result.ConsoleEntries);
         Assert.NotNull(result.PageLoadTime);
     }
+
+    [Fact]
+    public async Task StaticResponseRoute_AndElementCount_ProvideTypedBrowserProof() {
+        await using HtmlBrowserSession session = await HtmlBrowser.OpenSessionAsync("about:blank");
+        const string url = "https://htmltinkerx.test/fixture";
+
+        await HtmlBrowser.RegisterResponseRouteAsync(
+            session,
+            url,
+            "<main><div class='row'>one</div><div class='row'>two</div></main>",
+            "text/html; charset=utf-8");
+
+        await session.Page.GotoAsync(url);
+        await HtmlBrowser.WaitForElementCountAsync(session, ".row", expectedCount: 2);
+
+        Assert.Equal("one", await session.Page.Locator(".row").First.TextContentAsync());
+    }
     
     [Fact]
     public async Task TestUrlAsync_CapturesNetworkRequests() {

--- a/Sources/HtmlTinkerX/Enums/HtmlDocumentAuditSeverity.cs
+++ b/Sources/HtmlTinkerX/Enums/HtmlDocumentAuditSeverity.cs
@@ -1,0 +1,15 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Describes the impact of an HTML document audit issue.
+/// </summary>
+public enum HtmlDocumentAuditSeverity {
+    /// <summary>The issue is informational and does not make the document invalid.</summary>
+    Information,
+
+    /// <summary>The issue should be corrected but may not block every consumer.</summary>
+    Warning,
+
+    /// <summary>The issue represents an invalid, unsafe, or inaccessible document contract.</summary>
+    Error
+}

--- a/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
+++ b/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
@@ -138,9 +138,12 @@ public static class HtmlDocumentAudit {
         }
 
         string? type = element.GetAttribute("type");
-        return (string.Equals(type, "button", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(type, "submit", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(type, "reset", StringComparison.OrdinalIgnoreCase)) &&
+        if (string.Equals(type, "submit", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(type, "reset", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        return string.Equals(type, "button", StringComparison.OrdinalIgnoreCase) &&
                !string.IsNullOrWhiteSpace(element.GetAttribute("value"));
     }
 
@@ -148,7 +151,7 @@ public static class HtmlDocumentAudit {
         foreach (IElement element in document.All) {
             foreach (string attribute in UrlAttributes) {
                 string? value = element.GetAttribute(attribute);
-                if (!IsUnsafeUrl(value)) {
+                if (!IsUnsafeUrl(attribute, value)) {
                     continue;
                 }
 
@@ -162,15 +165,29 @@ public static class HtmlDocumentAudit {
         }
     }
 
-    private static bool IsUnsafeUrl(string? value) {
+    private static bool IsUnsafeUrl(string attribute, string? value) {
         if (string.IsNullOrWhiteSpace(value)) {
             return false;
         }
 
         string normalized = new(value.Where(static character => !char.IsControl(character) && !char.IsWhiteSpace(character)).ToArray());
-        return normalized.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("vbscript:", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:text/html", StringComparison.OrdinalIgnoreCase);
+        if (!Uri.TryCreate(normalized, UriKind.RelativeOrAbsolute, out Uri? uri)) {
+            return true;
+        }
+
+        if (!uri.IsAbsoluteUri) {
+            return false;
+        }
+
+        bool isAsset = attribute.Equals("src", StringComparison.OrdinalIgnoreCase);
+        if (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+            uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return isAsset ||
+               (!uri.Scheme.Equals(Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase) &&
+                !uri.Scheme.Equals("tel", StringComparison.OrdinalIgnoreCase));
     }
 
     private static void AuditHeadingOrder(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {

--- a/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
+++ b/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
@@ -1,0 +1,217 @@
+using AngleSharp.Dom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Audits static or rendered HTML with one reusable correctness, safety, and accessibility contract.
+/// </summary>
+public static class HtmlDocumentAudit {
+    private static readonly string[] UrlAttributes = { "href", "src", "action", "formaction" };
+
+    /// <summary>
+    /// Audits HTML markup using the supplied checks.
+    /// </summary>
+    /// <param name="html">HTML markup to audit.</param>
+    /// <param name="options">Optional audit settings.</param>
+    /// <returns>Structured issues discovered in the document.</returns>
+    public static HtmlDocumentAuditResult Analyze(string html, HtmlDocumentAuditOptions? options = null) {
+        if (html == null) {
+            throw new ArgumentNullException(nameof(html));
+        }
+
+        HtmlDocumentAuditOptions effectiveOptions = options ?? new HtmlDocumentAuditOptions();
+        IDocument document = HtmlParser.ParseWithAngleSharp(html);
+        List<HtmlDocumentAuditIssue> issues = new();
+
+        if (effectiveOptions.CheckDocumentMetadata) {
+            AuditDocumentMetadata(document, issues);
+        }
+
+        if (effectiveOptions.CheckDuplicateIds) {
+            AuditDuplicateIds(document, issues);
+        }
+
+        if (effectiveOptions.CheckAccessibleNames) {
+            AuditAccessibleNames(document, issues);
+        }
+
+        if (effectiveOptions.CheckUnsafeUrls) {
+            AuditUnsafeUrls(document, issues);
+        }
+
+        if (effectiveOptions.CheckHeadingOrder) {
+            AuditHeadingOrder(document, issues);
+        }
+
+        return new HtmlDocumentAuditResult { Issues = issues };
+    }
+
+    private static void AuditDocumentMetadata(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+        if (string.IsNullOrWhiteSpace(document.Title)) {
+            Add(issues, "document-title-missing", HtmlDocumentAuditSeverity.Warning, "The document does not define a non-empty title.", "head");
+        }
+
+        IElement? root = document.DocumentElement;
+        if (root == null || string.IsNullOrWhiteSpace(root.GetAttribute("lang"))) {
+            Add(issues, "document-language-missing", HtmlDocumentAuditSeverity.Warning, "The document root does not declare a language.", "html");
+        }
+    }
+
+    private static void AuditDuplicateIds(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+        foreach (IGrouping<string, IElement> group in document.All
+                     .Where(static element => !string.IsNullOrWhiteSpace(element.Id))
+                     .GroupBy(static element => element.Id!, StringComparer.Ordinal)
+                     .Where(static group => group.Count() > 1)) {
+            Add(
+                issues,
+                "duplicate-id",
+                HtmlDocumentAuditSeverity.Error,
+                $"The id '{group.Key}' is used by {group.Count()} elements.",
+                $"#{group.Key}");
+        }
+    }
+
+    private static void AuditAccessibleNames(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+        Dictionary<string, string> explicitLabels = document.QuerySelectorAll("label[for]")
+            .Where(static label => !string.IsNullOrWhiteSpace(label.GetAttribute("for")))
+            .GroupBy(static label => label.GetAttribute("for")!, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => NormalizeText(group.Select(static label => label.TextContent)), StringComparer.Ordinal);
+
+        foreach (IElement image in document.QuerySelectorAll("img")) {
+            if (!image.HasAttribute("alt")) {
+                Add(issues, "image-alt-missing", HtmlDocumentAuditSeverity.Error, "The image does not define an alt attribute. Use an empty alt value for decorative images.", Describe(image));
+            }
+        }
+
+        foreach (IElement element in document.QuerySelectorAll("button, a[href], [role=button], [role=link]")) {
+            if (!HasAccessibleName(element, document, explicitLabels)) {
+                Add(issues, "interactive-name-missing", HtmlDocumentAuditSeverity.Error, "The interactive element has no accessible name.", Describe(element));
+            }
+        }
+
+        foreach (IElement control in document.QuerySelectorAll("input:not([type=hidden]), select, textarea")) {
+            if (!HasAccessibleName(control, document, explicitLabels)) {
+                Add(issues, "form-label-missing", HtmlDocumentAuditSeverity.Error, "The form control has no associated label or accessible name.", Describe(control));
+            }
+        }
+    }
+
+    private static bool HasAccessibleName(IElement element, IDocument document, IReadOnlyDictionary<string, string> explicitLabels) {
+        if (!string.IsNullOrWhiteSpace(element.GetAttribute("aria-label")) ||
+            !string.IsNullOrWhiteSpace(element.GetAttribute("title")) ||
+            !string.IsNullOrWhiteSpace(element.TextContent)) {
+            return true;
+        }
+
+        if (element.LocalName.Equals("input", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(element.GetAttribute("type"), "image", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(element.GetAttribute("alt"))) {
+            return true;
+        }
+
+        if (element.QuerySelectorAll("img[alt]").Any(static image => !string.IsNullOrWhiteSpace(image.GetAttribute("alt")))) {
+            return true;
+        }
+
+        string? labelledBy = element.GetAttribute("aria-labelledby");
+        if (labelledBy is string labelledByValue && !string.IsNullOrWhiteSpace(labelledByValue)) {
+            foreach (string id in labelledByValue.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
+                IElement? label = document.All.FirstOrDefault(candidate => string.Equals(candidate.Id, id, StringComparison.Ordinal));
+                if (label != null && !string.IsNullOrWhiteSpace(label.TextContent)) {
+                    return true;
+                }
+            }
+        }
+
+        string? idValue = element.Id;
+        if (idValue is string controlId && !string.IsNullOrWhiteSpace(controlId) && explicitLabels.TryGetValue(controlId, out string? labelText) && !string.IsNullOrWhiteSpace(labelText)) {
+            return true;
+        }
+
+        for (IElement? ancestor = element.ParentElement; ancestor != null; ancestor = ancestor.ParentElement) {
+            if (ancestor.LocalName.Equals("label", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(ancestor.TextContent)) {
+                return true;
+            }
+        }
+
+        string? type = element.GetAttribute("type");
+        return (string.Equals(type, "button", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "submit", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "reset", StringComparison.OrdinalIgnoreCase)) &&
+               !string.IsNullOrWhiteSpace(element.GetAttribute("value"));
+    }
+
+    private static void AuditUnsafeUrls(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+        foreach (IElement element in document.All) {
+            foreach (string attribute in UrlAttributes) {
+                string? value = element.GetAttribute(attribute);
+                if (!IsUnsafeUrl(value)) {
+                    continue;
+                }
+
+                Add(
+                    issues,
+                    "unsafe-url-scheme",
+                    HtmlDocumentAuditSeverity.Error,
+                    $"The {attribute} attribute uses an executable URL scheme.",
+                    Describe(element));
+            }
+        }
+    }
+
+    private static bool IsUnsafeUrl(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return false;
+        }
+
+        string normalized = new(value.Where(static character => !char.IsControl(character) && !char.IsWhiteSpace(character)).ToArray());
+        return normalized.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("vbscript:", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:text/html", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AuditHeadingOrder(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+        int previousLevel = 0;
+        foreach (IElement heading in document.QuerySelectorAll("h1, h2, h3, h4, h5, h6")) {
+            int level = heading.LocalName[1] - '0';
+            if (previousLevel > 0 && level > previousLevel + 1) {
+                Add(
+                    issues,
+                    "heading-level-skipped",
+                    HtmlDocumentAuditSeverity.Warning,
+                    $"Heading hierarchy jumps from h{previousLevel} to h{level}.",
+                    Describe(heading));
+            }
+
+            previousLevel = level;
+        }
+    }
+
+    private static string Describe(IElement element) {
+        if (!string.IsNullOrWhiteSpace(element.Id)) {
+            return $"{element.LocalName}#{element.Id}";
+        }
+
+        string? className = element.ClassList.FirstOrDefault();
+        return string.IsNullOrWhiteSpace(className) ? element.LocalName : $"{element.LocalName}.{className}";
+    }
+
+    private static string NormalizeText(IEnumerable<string> values) =>
+        string.Join(" ", values.Where(static value => !string.IsNullOrWhiteSpace(value)).Select(static value => value.Trim()));
+
+    private static void Add(
+        ICollection<HtmlDocumentAuditIssue> issues,
+        string code,
+        HtmlDocumentAuditSeverity severity,
+        string message,
+        string element) =>
+        issues.Add(new HtmlDocumentAuditIssue {
+            Code = code,
+            Severity = severity,
+            Message = message,
+            Element = element
+        });
+}

--- a/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
+++ b/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
@@ -151,7 +151,7 @@ public static class HtmlDocumentAudit {
         foreach (IElement element in document.All) {
             foreach (string attribute in UrlAttributes) {
                 string? value = element.GetAttribute(attribute);
-                if (!IsUnsafeUrl(attribute, value)) {
+                if (!IsUnsafeUrl(element, attribute, value)) {
                     continue;
                 }
 
@@ -162,10 +162,35 @@ public static class HtmlDocumentAudit {
                     $"The {attribute} attribute uses an executable URL scheme.",
                     Describe(element));
             }
+
+            AuditElementSpecificUrl(element, "object", "data", issues);
+            AuditElementSpecificUrl(element, "video", "poster", issues);
         }
     }
 
-    private static bool IsUnsafeUrl(string attribute, string? value) {
+    private static void AuditElementSpecificUrl(
+        IElement element,
+        string elementName,
+        string attribute,
+        ICollection<HtmlDocumentAuditIssue> issues) {
+        if (!element.LocalName.Equals(elementName, StringComparison.OrdinalIgnoreCase)) {
+            return;
+        }
+
+        string? value = element.GetAttribute(attribute);
+        if (!IsUnsafeUrl(element, attribute, value)) {
+            return;
+        }
+
+        Add(
+            issues,
+            "unsafe-url-scheme",
+            HtmlDocumentAuditSeverity.Error,
+            $"The {attribute} attribute uses an executable URL scheme.",
+            Describe(element));
+    }
+
+    private static bool IsUnsafeUrl(IElement element, string attribute, string? value) {
         if (string.IsNullOrWhiteSpace(value)) {
             return false;
         }
@@ -179,7 +204,10 @@ public static class HtmlDocumentAudit {
             return false;
         }
 
-        bool isAsset = attribute.Equals("src", StringComparison.OrdinalIgnoreCase);
+        bool isAsset = attribute.Equals("src", StringComparison.OrdinalIgnoreCase) ||
+                       (element.LocalName.Equals("link", StringComparison.OrdinalIgnoreCase) && attribute.Equals("href", StringComparison.OrdinalIgnoreCase)) ||
+                       (element.LocalName.Equals("object", StringComparison.OrdinalIgnoreCase) && attribute.Equals("data", StringComparison.OrdinalIgnoreCase)) ||
+                       (element.LocalName.Equals("video", StringComparison.OrdinalIgnoreCase) && attribute.Equals("poster", StringComparison.OrdinalIgnoreCase));
         if (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
             uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
             return false;

--- a/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
+++ b/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
@@ -2,6 +2,8 @@ using AngleSharp.Dom;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace HtmlTinkerX;
 
@@ -14,165 +16,233 @@ public static class HtmlDocumentAudit {
     /// <summary>
     /// Audits HTML markup using the supplied checks.
     /// </summary>
-    /// <param name="html">HTML markup to audit.</param>
-    /// <param name="options">Optional audit settings.</param>
-    /// <returns>Structured issues discovered in the document.</returns>
-    public static HtmlDocumentAuditResult Analyze(string html, HtmlDocumentAuditOptions? options = null) {
-        if (html == null) {
-            throw new ArgumentNullException(nameof(html));
-        }
+    public static HtmlDocumentAuditResult Analyze(
+        string html,
+        HtmlDocumentAuditOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        cancellationToken.ThrowIfCancellationRequested();
+        IDocument document = HtmlParser.ParseWithAngleSharp(html);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Analyze(document, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Audits HTML markup asynchronously, including cancellable AngleSharp parsing.
+    /// </summary>
+    public static async Task<HtmlDocumentAuditResult> AnalyzeAsync(
+        string html,
+        HtmlDocumentAuditOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        IDocument document = await HtmlParser.ParseWithAngleSharpAsync(html, cancellationToken).ConfigureAwait(false);
+        return Analyze(document, options, cancellationToken);
+    }
+
+    internal static HtmlDocumentAuditResult Analyze(
+        IDocument document,
+        HtmlDocumentAuditOptions? options,
+        CancellationToken cancellationToken) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
 
         HtmlDocumentAuditOptions effectiveOptions = options ?? new HtmlDocumentAuditOptions();
-        IDocument document = HtmlParser.ParseWithAngleSharp(html);
+        List<IElement> elements = MaterializeElements(document, cancellationToken);
+        IReadOnlyDictionary<string, List<IElement>> elementsById = IndexElementsById(elements, cancellationToken);
         List<HtmlDocumentAuditIssue> issues = new();
 
-        if (effectiveOptions.CheckDocumentMetadata) {
-            AuditDocumentMetadata(document, issues);
-        }
+        if (effectiveOptions.CheckDocumentMetadata) AuditDocumentMetadata(document, issues);
+        if (effectiveOptions.CheckDuplicateIds) AuditDuplicateIds(elementsById, issues, cancellationToken);
+        if (effectiveOptions.CheckAccessibleNames) AuditAccessibleNames(elements, elementsById, issues, cancellationToken);
+        if (effectiveOptions.CheckUnsafeUrls) AuditUnsafeUrls(elements, issues, cancellationToken);
+        if (effectiveOptions.CheckHeadingOrder) AuditHeadingOrder(elements, issues, cancellationToken);
 
-        if (effectiveOptions.CheckDuplicateIds) {
-            AuditDuplicateIds(document, issues);
-        }
-
-        if (effectiveOptions.CheckAccessibleNames) {
-            AuditAccessibleNames(document, issues);
-        }
-
-        if (effectiveOptions.CheckUnsafeUrls) {
-            AuditUnsafeUrls(document, issues);
-        }
-
-        if (effectiveOptions.CheckHeadingOrder) {
-            AuditHeadingOrder(document, issues);
-        }
-
+        cancellationToken.ThrowIfCancellationRequested();
         return new HtmlDocumentAuditResult { Issues = issues };
+    }
+
+    private static List<IElement> MaterializeElements(IDocument document, CancellationToken cancellationToken) {
+        List<IElement> elements = new();
+        foreach (IElement element in document.All) {
+            cancellationToken.ThrowIfCancellationRequested();
+            elements.Add(element);
+        }
+        return elements;
+    }
+
+    private static IReadOnlyDictionary<string, List<IElement>> IndexElementsById(
+        IEnumerable<IElement> elements,
+        CancellationToken cancellationToken) {
+        Dictionary<string, List<IElement>> index = new(StringComparer.Ordinal);
+        foreach (IElement element in elements) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(element.Id)) continue;
+            if (!index.TryGetValue(element.Id!, out List<IElement>? matches)) {
+                matches = new List<IElement>();
+                index[element.Id!] = matches;
+            }
+            matches.Add(element);
+        }
+        return index;
     }
 
     private static void AuditDocumentMetadata(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
         if (string.IsNullOrWhiteSpace(document.Title)) {
             Add(issues, "document-title-missing", HtmlDocumentAuditSeverity.Warning, "The document does not define a non-empty title.", "head");
         }
-
         IElement? root = document.DocumentElement;
         if (root == null || string.IsNullOrWhiteSpace(root.GetAttribute("lang"))) {
             Add(issues, "document-language-missing", HtmlDocumentAuditSeverity.Warning, "The document root does not declare a language.", "html");
         }
     }
 
-    private static void AuditDuplicateIds(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
-        foreach (IGrouping<string, IElement> group in document.All
-                     .Where(static element => !string.IsNullOrWhiteSpace(element.Id))
-                     .GroupBy(static element => element.Id!, StringComparer.Ordinal)
-                     .Where(static group => group.Count() > 1)) {
-            Add(
-                issues,
-                "duplicate-id",
-                HtmlDocumentAuditSeverity.Error,
-                $"The id '{group.Key}' is used by {group.Count()} elements.",
-                $"#{group.Key}");
+    private static void AuditDuplicateIds(
+        IReadOnlyDictionary<string, List<IElement>> elementsById,
+        ICollection<HtmlDocumentAuditIssue> issues,
+        CancellationToken cancellationToken) {
+        foreach (KeyValuePair<string, List<IElement>> entry in elementsById) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (entry.Value.Count <= 1) continue;
+            Add(issues, "duplicate-id", HtmlDocumentAuditSeverity.Error,
+                $"The id '{entry.Key}' is used by {entry.Value.Count} elements.", $"#{entry.Key}");
         }
     }
 
-    private static void AuditAccessibleNames(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
-        IReadOnlyDictionary<string, IElement> elementsById = document.All
-            .Where(static element => !string.IsNullOrWhiteSpace(element.Id))
-            .GroupBy(static element => element.Id!, StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
-        Dictionary<string, string> explicitLabels = document.QuerySelectorAll("label[for]")
-            .Where(static label => !string.IsNullOrWhiteSpace(label.GetAttribute("for")))
-            .GroupBy(static label => label.GetAttribute("for")!, StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => NormalizeText(group.Select(static label => label.TextContent)), StringComparer.Ordinal);
-
-        foreach (IElement image in document.QuerySelectorAll("img")) {
-            if (!image.HasAttribute("alt")) {
-                Add(issues, "image-alt-missing", HtmlDocumentAuditSeverity.Error, "The image does not define an alt attribute. Use an empty alt value for decorative images.", Describe(image));
-            }
+    private static void AuditAccessibleNames(
+        IReadOnlyList<IElement> elements,
+        IReadOnlyDictionary<string, List<IElement>> elementsById,
+        ICollection<HtmlDocumentAuditIssue> issues,
+        CancellationToken cancellationToken) {
+        Dictionary<string, string> explicitLabels = new(StringComparer.Ordinal);
+        foreach (IElement label in elements) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!label.LocalName.Equals("label", StringComparison.OrdinalIgnoreCase)) continue;
+            string? target = label.GetAttribute("for");
+            if (string.IsNullOrWhiteSpace(target)) continue;
+            string text = NormalizeText(label.TextContent);
+            if (explicitLabels.TryGetValue(target!, out string? current)) text = NormalizeText(current, text);
+            explicitLabels[target!] = text;
         }
 
-        foreach (IElement element in document.QuerySelectorAll("button, a[href], [role=button], [role=link]")) {
-            if (!HasAccessibleName(element, explicitLabels, elementsById, allowElementText: true)) {
-                Add(issues, "interactive-name-missing", HtmlDocumentAuditSeverity.Error, "The interactive element has no accessible name.", Describe(element));
+        foreach (IElement element in elements) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (element.LocalName.Equals("img", StringComparison.OrdinalIgnoreCase) && !element.HasAttribute("alt")) {
+                Add(issues, "image-alt-missing", HtmlDocumentAuditSeverity.Error,
+                    "The image does not define an alt attribute. Use an empty alt value for decorative images.", Describe(element));
             }
-        }
 
-        foreach (IElement control in document.QuerySelectorAll("input:not([type=hidden]), select, textarea")) {
-            if (!HasAccessibleName(control, explicitLabels, elementsById, allowElementText: false)) {
-                Add(issues, "form-label-missing", HtmlDocumentAuditSeverity.Error, "The form control has no associated label or accessible name.", Describe(control));
+            if (IsInteractive(element) &&
+                !HasAccessibleName(element, explicitLabels, elementsById, allowElementText: true, cancellationToken)) {
+                Add(issues, "interactive-name-missing", HtmlDocumentAuditSeverity.Error,
+                    "The interactive element has no accessible name.", Describe(element));
+            }
+
+            if (IsFormControl(element) &&
+                !HasAccessibleName(element, explicitLabels, elementsById, allowElementText: false, cancellationToken)) {
+                Add(issues, "form-label-missing", HtmlDocumentAuditSeverity.Error,
+                    "The form control has no associated label or accessible name.", Describe(element));
             }
         }
+    }
+
+    private static bool IsInteractive(IElement element) {
+        if (element.LocalName.Equals("button", StringComparison.OrdinalIgnoreCase)) return true;
+        if (element.LocalName.Equals("a", StringComparison.OrdinalIgnoreCase) && element.HasAttribute("href")) return true;
+        string? role = element.GetAttribute("role");
+        return string.Equals(role, "button", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(role, "link", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsFormControl(IElement element) {
+        if (element.LocalName.Equals("select", StringComparison.OrdinalIgnoreCase) ||
+            element.LocalName.Equals("textarea", StringComparison.OrdinalIgnoreCase)) return true;
+        return element.LocalName.Equals("input", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(element.GetAttribute("type"), "hidden", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool HasAccessibleName(
         IElement element,
         IReadOnlyDictionary<string, string> explicitLabels,
-        IReadOnlyDictionary<string, IElement> elementsById,
-        bool allowElementText) {
+        IReadOnlyDictionary<string, List<IElement>> elementsById,
+        bool allowElementText,
+        CancellationToken cancellationToken) {
         if (!string.IsNullOrWhiteSpace(element.GetAttribute("aria-label")) ||
             !string.IsNullOrWhiteSpace(element.GetAttribute("title")) ||
-            (allowElementText && !string.IsNullOrWhiteSpace(element.TextContent))) {
-            return true;
-        }
+            (allowElementText && !string.IsNullOrWhiteSpace(element.TextContent))) return true;
 
         if (element.LocalName.Equals("input", StringComparison.OrdinalIgnoreCase) &&
             string.Equals(element.GetAttribute("type"), "image", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrWhiteSpace(element.GetAttribute("alt"))) {
-            return true;
-        }
+            !string.IsNullOrWhiteSpace(element.GetAttribute("alt"))) return true;
 
-        if (element.QuerySelectorAll("img[alt]").Any(static image => !string.IsNullOrWhiteSpace(image.GetAttribute("alt")))) {
-            return true;
+        foreach (IElement image in element.QuerySelectorAll("img[alt]")) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!string.IsNullOrWhiteSpace(image.GetAttribute("alt"))) return true;
         }
 
         string? labelledBy = element.GetAttribute("aria-labelledby");
-        if (labelledBy is string labelledByValue && !string.IsNullOrWhiteSpace(labelledByValue)) {
-            foreach (string id in labelledByValue.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
-                if (elementsById.TryGetValue(id, out IElement? label) && !string.IsNullOrWhiteSpace(label.TextContent)) {
-                    return true;
-                }
+        if (!string.IsNullOrWhiteSpace(labelledBy)) {
+            foreach (string id in labelledBy!.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (elementsById.TryGetValue(id, out List<IElement>? labels) &&
+                    labels.Any(static label => !string.IsNullOrWhiteSpace(label.TextContent))) return true;
             }
         }
 
-        string? idValue = element.Id;
-        if (idValue is string controlId && !string.IsNullOrWhiteSpace(controlId) && explicitLabels.TryGetValue(controlId, out string? labelText) && !string.IsNullOrWhiteSpace(labelText)) {
-            return true;
-        }
+        if (!string.IsNullOrWhiteSpace(element.Id) &&
+            explicitLabels.TryGetValue(element.Id!, out string? labelText) &&
+            !string.IsNullOrWhiteSpace(labelText)) return true;
 
         for (IElement? ancestor = element.ParentElement; ancestor != null; ancestor = ancestor.ParentElement) {
-            if (ancestor.LocalName.Equals("label", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(ancestor.TextContent)) {
-                return true;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ancestor.LocalName.Equals("label", StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(ancestor.TextContent)) return true;
         }
 
         string? type = element.GetAttribute("type");
         if (string.Equals(type, "submit", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(type, "reset", StringComparison.OrdinalIgnoreCase)) {
-            return true;
-        }
-
+            string.Equals(type, "reset", StringComparison.OrdinalIgnoreCase)) return true;
         return string.Equals(type, "button", StringComparison.OrdinalIgnoreCase) &&
                !string.IsNullOrWhiteSpace(element.GetAttribute("value"));
     }
 
-    private static void AuditUnsafeUrls(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
-        foreach (IElement element in document.All) {
+    private static void AuditUnsafeUrls(
+        IReadOnlyList<IElement> elements,
+        ICollection<HtmlDocumentAuditIssue> issues,
+        CancellationToken cancellationToken) {
+        foreach (IElement element in elements) {
+            cancellationToken.ThrowIfCancellationRequested();
             foreach (string attribute in UrlAttributes) {
-                string? value = element.GetAttribute(attribute);
-                if (!IsUnsafeUrl(element, attribute, value)) {
-                    continue;
-                }
-
-                Add(
-                    issues,
-                    "unsafe-url-scheme",
-                    HtmlDocumentAuditSeverity.Error,
-                    $"The {attribute} attribute uses an executable URL scheme.",
-                    Describe(element));
+                if (!IsUnsafeUrl(element, attribute, element.GetAttribute(attribute))) continue;
+                Add(issues, "unsafe-url-scheme", HtmlDocumentAuditSeverity.Error,
+                    $"The {attribute} attribute uses an executable URL scheme.", Describe(element));
             }
 
             AuditElementSpecificUrl(element, "object", "data", issues);
             AuditElementSpecificUrl(element, "video", "poster", issues);
+            string? refreshUrl = GetMetaRefreshUrl(element);
+            if (IsUnsafeUrl(element, "href", refreshUrl)) {
+                Add(issues, "unsafe-url-scheme", HtmlDocumentAuditSeverity.Error,
+                    "The meta refresh target uses an executable URL scheme.", Describe(element));
+            }
         }
+    }
+
+    private static string? GetMetaRefreshUrl(IElement element) {
+        if (!element.LocalName.Equals("meta", StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(element.GetAttribute("http-equiv")?.Trim(), "refresh", StringComparison.OrdinalIgnoreCase)) return null;
+        string? content = element.GetAttribute("content");
+        if (string.IsNullOrWhiteSpace(content)) return null;
+        int separator = content!.IndexOf(';');
+        if (separator < 0 || separator == content.Length - 1) return null;
+        string target = content.Substring(separator + 1).Trim();
+        int equals = target.IndexOf('=');
+        if (equals < 0 || !target.Substring(0, equals).Trim().Equals("url", StringComparison.OrdinalIgnoreCase)) return null;
+        target = target.Substring(equals + 1).Trim();
+        if (target.Length >= 2 &&
+            ((target[0] == '"' && target[target.Length - 1] == '"') ||
+             (target[0] == '\'' && target[target.Length - 1] == '\''))) {
+            target = target.Substring(1, target.Length - 2).Trim();
+        }
+        return target;
     }
 
     private static void AuditElementSpecificUrl(
@@ -180,50 +250,25 @@ public static class HtmlDocumentAudit {
         string elementName,
         string attribute,
         ICollection<HtmlDocumentAuditIssue> issues) {
-        if (!element.LocalName.Equals(elementName, StringComparison.OrdinalIgnoreCase)) {
-            return;
-        }
-
-        string? value = element.GetAttribute(attribute);
-        if (!IsUnsafeUrl(element, attribute, value)) {
-            return;
-        }
-
-        Add(
-            issues,
-            "unsafe-url-scheme",
-            HtmlDocumentAuditSeverity.Error,
-            $"The {attribute} attribute uses an executable URL scheme.",
-            Describe(element));
+        if (!element.LocalName.Equals(elementName, StringComparison.OrdinalIgnoreCase) ||
+            !IsUnsafeUrl(element, attribute, element.GetAttribute(attribute))) return;
+        Add(issues, "unsafe-url-scheme", HtmlDocumentAuditSeverity.Error,
+            $"The {attribute} attribute uses an executable URL scheme.", Describe(element));
     }
 
     private static bool IsUnsafeUrl(IElement element, string attribute, string? value) {
-        if (string.IsNullOrWhiteSpace(value)) {
-            return false;
-        }
-
+        if (string.IsNullOrWhiteSpace(value)) return false;
         string normalized = new(value.Where(static character => !char.IsControl(character) && !char.IsWhiteSpace(character)).ToArray());
-        if (!Uri.TryCreate(normalized, UriKind.RelativeOrAbsolute, out Uri? uri)) {
-            return true;
-        }
-
-        if (!uri.IsAbsoluteUri) {
-            return false;
-        }
-
-        if (IsImageSourceContext(element, attribute) && IsSafeEmbeddedImage(normalized)) {
-            return false;
-        }
+        if (!Uri.TryCreate(normalized, UriKind.RelativeOrAbsolute, out Uri? uri)) return true;
+        if (!uri.IsAbsoluteUri) return false;
+        if (IsImageSourceContext(element, attribute) && IsSafeEmbeddedImage(normalized)) return false;
 
         bool isAsset = attribute.Equals("src", StringComparison.OrdinalIgnoreCase) ||
                        (element.LocalName.Equals("link", StringComparison.OrdinalIgnoreCase) && attribute.Equals("href", StringComparison.OrdinalIgnoreCase)) ||
                        (element.LocalName.Equals("object", StringComparison.OrdinalIgnoreCase) && attribute.Equals("data", StringComparison.OrdinalIgnoreCase)) ||
                        (element.LocalName.Equals("video", StringComparison.OrdinalIgnoreCase) && attribute.Equals("poster", StringComparison.OrdinalIgnoreCase));
         if (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
-            uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-
+            uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) return false;
         return isAsset ||
                (!uri.Scheme.Equals(Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase) &&
                 !uri.Scheme.Equals("tel", StringComparison.OrdinalIgnoreCase));
@@ -237,62 +282,54 @@ public static class HtmlDocumentAudit {
                 .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                 .Any(static token => token.EndsWith("icon", StringComparison.OrdinalIgnoreCase));
         }
-
         if (attribute.Equals("poster", StringComparison.OrdinalIgnoreCase)) {
             return element.LocalName.Equals("video", StringComparison.OrdinalIgnoreCase);
         }
-
-        if (!attribute.Equals("src", StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-
+        if (!attribute.Equals("src", StringComparison.OrdinalIgnoreCase)) return false;
         return element.LocalName.Equals("img", StringComparison.OrdinalIgnoreCase) ||
                element.LocalName.Equals("image", StringComparison.OrdinalIgnoreCase) ||
                element.LocalName.Equals("source", StringComparison.OrdinalIgnoreCase) ||
                element.LocalName.Equals("input", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsSafeEmbeddedImage(string normalized) {
-        return normalized.StartsWith("data:image/png;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/jpeg;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/jpg;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/gif;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/webp;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/avif;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/bmp;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/x-icon;base64,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/svg+xml,", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("data:image/svg+xml;base64,", StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool IsSafeEmbeddedImage(string normalized) =>
+        normalized.StartsWith("data:image/png;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/jpeg;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/jpg;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/gif;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/webp;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/avif;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/bmp;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/x-icon;base64,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/svg+xml,", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith("data:image/svg+xml;base64,", StringComparison.OrdinalIgnoreCase);
 
-    private static void AuditHeadingOrder(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+    private static void AuditHeadingOrder(
+        IReadOnlyList<IElement> elements,
+        ICollection<HtmlDocumentAuditIssue> issues,
+        CancellationToken cancellationToken) {
         int previousLevel = 0;
-        foreach (IElement heading in document.QuerySelectorAll("h1, h2, h3, h4, h5, h6")) {
+        foreach (IElement heading in elements) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (heading.LocalName.Length != 2 || heading.LocalName[0] != 'h' ||
+                heading.LocalName[1] < '1' || heading.LocalName[1] > '6') continue;
             int level = heading.LocalName[1] - '0';
             if (previousLevel > 0 && level > previousLevel + 1) {
-                Add(
-                    issues,
-                    "heading-level-skipped",
-                    HtmlDocumentAuditSeverity.Warning,
-                    $"Heading hierarchy jumps from h{previousLevel} to h{level}.",
-                    Describe(heading));
+                Add(issues, "heading-level-skipped", HtmlDocumentAuditSeverity.Warning,
+                    $"Heading hierarchy jumps from h{previousLevel} to h{level}.", Describe(heading));
             }
-
             previousLevel = level;
         }
     }
 
     private static string Describe(IElement element) {
-        if (!string.IsNullOrWhiteSpace(element.Id)) {
-            return $"{element.LocalName}#{element.Id}";
-        }
-
+        if (!string.IsNullOrWhiteSpace(element.Id)) return $"{element.LocalName}#{element.Id}";
         string? className = element.ClassList.FirstOrDefault();
         return string.IsNullOrWhiteSpace(className) ? element.LocalName : $"{element.LocalName}.{className}";
     }
 
-    private static string NormalizeText(IEnumerable<string> values) =>
-        string.Join(" ", values.Where(static value => !string.IsNullOrWhiteSpace(value)).Select(static value => value.Trim()));
+    private static string NormalizeText(params string?[] values) =>
+        string.Join(" ", values.Where(static value => !string.IsNullOrWhiteSpace(value)).Select(static value => value!.Trim()));
 
     private static void Add(
         ICollection<HtmlDocumentAuditIssue> issues,
@@ -300,10 +337,5 @@ public static class HtmlDocumentAudit {
         HtmlDocumentAuditSeverity severity,
         string message,
         string element) =>
-        issues.Add(new HtmlDocumentAuditIssue {
-            Code = code,
-            Severity = severity,
-            Message = message,
-            Element = element
-        });
+        issues.Add(new HtmlDocumentAuditIssue { Code = code, Severity = severity, Message = message, Element = element });
 }

--- a/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
+++ b/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
@@ -9,7 +9,7 @@ namespace HtmlTinkerX;
 /// Audits static or rendered HTML with one reusable correctness, safety, and accessibility contract.
 /// </summary>
 public static class HtmlDocumentAudit {
-    private static readonly string[] UrlAttributes = { "href", "src", "action", "formaction" };
+    private static readonly string[] UrlAttributes = { "href", "xlink:href", "src", "action", "formaction" };
 
     /// <summary>
     /// Audits HTML markup using the supplied checks.

--- a/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
+++ b/Sources/HtmlTinkerX/HtmlDocumentAudit.cs
@@ -75,6 +75,10 @@ public static class HtmlDocumentAudit {
     }
 
     private static void AuditAccessibleNames(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {
+        IReadOnlyDictionary<string, IElement> elementsById = document.All
+            .Where(static element => !string.IsNullOrWhiteSpace(element.Id))
+            .GroupBy(static element => element.Id!, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
         Dictionary<string, string> explicitLabels = document.QuerySelectorAll("label[for]")
             .Where(static label => !string.IsNullOrWhiteSpace(label.GetAttribute("for")))
             .GroupBy(static label => label.GetAttribute("for")!, StringComparer.Ordinal)
@@ -87,22 +91,26 @@ public static class HtmlDocumentAudit {
         }
 
         foreach (IElement element in document.QuerySelectorAll("button, a[href], [role=button], [role=link]")) {
-            if (!HasAccessibleName(element, document, explicitLabels)) {
+            if (!HasAccessibleName(element, explicitLabels, elementsById, allowElementText: true)) {
                 Add(issues, "interactive-name-missing", HtmlDocumentAuditSeverity.Error, "The interactive element has no accessible name.", Describe(element));
             }
         }
 
         foreach (IElement control in document.QuerySelectorAll("input:not([type=hidden]), select, textarea")) {
-            if (!HasAccessibleName(control, document, explicitLabels)) {
+            if (!HasAccessibleName(control, explicitLabels, elementsById, allowElementText: false)) {
                 Add(issues, "form-label-missing", HtmlDocumentAuditSeverity.Error, "The form control has no associated label or accessible name.", Describe(control));
             }
         }
     }
 
-    private static bool HasAccessibleName(IElement element, IDocument document, IReadOnlyDictionary<string, string> explicitLabels) {
+    private static bool HasAccessibleName(
+        IElement element,
+        IReadOnlyDictionary<string, string> explicitLabels,
+        IReadOnlyDictionary<string, IElement> elementsById,
+        bool allowElementText) {
         if (!string.IsNullOrWhiteSpace(element.GetAttribute("aria-label")) ||
             !string.IsNullOrWhiteSpace(element.GetAttribute("title")) ||
-            !string.IsNullOrWhiteSpace(element.TextContent)) {
+            (allowElementText && !string.IsNullOrWhiteSpace(element.TextContent))) {
             return true;
         }
 
@@ -119,8 +127,7 @@ public static class HtmlDocumentAudit {
         string? labelledBy = element.GetAttribute("aria-labelledby");
         if (labelledBy is string labelledByValue && !string.IsNullOrWhiteSpace(labelledByValue)) {
             foreach (string id in labelledByValue.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
-                IElement? label = document.All.FirstOrDefault(candidate => string.Equals(candidate.Id, id, StringComparison.Ordinal));
-                if (label != null && !string.IsNullOrWhiteSpace(label.TextContent)) {
+                if (elementsById.TryGetValue(id, out IElement? label) && !string.IsNullOrWhiteSpace(label.TextContent)) {
                     return true;
                 }
             }
@@ -204,6 +211,10 @@ public static class HtmlDocumentAudit {
             return false;
         }
 
+        if (IsImageSourceContext(element, attribute) && IsSafeEmbeddedImage(normalized)) {
+            return false;
+        }
+
         bool isAsset = attribute.Equals("src", StringComparison.OrdinalIgnoreCase) ||
                        (element.LocalName.Equals("link", StringComparison.OrdinalIgnoreCase) && attribute.Equals("href", StringComparison.OrdinalIgnoreCase)) ||
                        (element.LocalName.Equals("object", StringComparison.OrdinalIgnoreCase) && attribute.Equals("data", StringComparison.OrdinalIgnoreCase)) ||
@@ -216,6 +227,42 @@ public static class HtmlDocumentAudit {
         return isAsset ||
                (!uri.Scheme.Equals(Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase) &&
                 !uri.Scheme.Equals("tel", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsImageSourceContext(IElement element, string attribute) {
+        if (attribute.Equals("href", StringComparison.OrdinalIgnoreCase) &&
+            element.LocalName.Equals("link", StringComparison.OrdinalIgnoreCase)) {
+            string? relation = element.GetAttribute("rel");
+            return !string.IsNullOrWhiteSpace(relation) && relation!
+                .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Any(static token => token.EndsWith("icon", StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (attribute.Equals("poster", StringComparison.OrdinalIgnoreCase)) {
+            return element.LocalName.Equals("video", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (!attribute.Equals("src", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        return element.LocalName.Equals("img", StringComparison.OrdinalIgnoreCase) ||
+               element.LocalName.Equals("image", StringComparison.OrdinalIgnoreCase) ||
+               element.LocalName.Equals("source", StringComparison.OrdinalIgnoreCase) ||
+               element.LocalName.Equals("input", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSafeEmbeddedImage(string normalized) {
+        return normalized.StartsWith("data:image/png;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/jpeg;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/jpg;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/gif;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/webp;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/avif;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/bmp;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/x-icon;base64,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/svg+xml,", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("data:image/svg+xml;base64,", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AuditHeadingOrder(IDocument document, ICollection<HtmlDocumentAuditIssue> issues) {

--- a/Sources/HtmlTinkerX/HtmlExtractionPlanner.cs
+++ b/Sources/HtmlTinkerX/HtmlExtractionPlanner.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace HtmlTinkerX;
 
@@ -26,7 +27,23 @@ public static class HtmlExtractionPlanner {
         IDocument document = HtmlParser.ParseWithAngleSharp(html);
         HtmlReadableTextResult readable = HtmlParserToText.ExtractReadableText(html);
         IReadOnlyList<HtmlDataItem> dataItems = HtmlParsingToolbox.SelectData(html, baseUri: url);
+        return Analyze(html, document, readable, dataItems, url, CancellationToken.None);
+    }
+
+    internal static HtmlExtractionPlan Analyze(
+        string html,
+        IDocument document,
+        HtmlReadableTextResult readable,
+        IReadOnlyList<HtmlDataItem> dataItems,
+        Uri? url,
+        CancellationToken cancellationToken) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (readable == null) throw new ArgumentNullException(nameof(readable));
+        if (dataItems == null) throw new ArgumentNullException(nameof(dataItems));
+        cancellationToken.ThrowIfCancellationRequested();
         List<HtmlFormResult> forms = HtmlParser.ParseFormsWithAngleSharp(html);
+        cancellationToken.ThrowIfCancellationRequested();
 
         int wordCount = CountWords(readable.Text);
         int scriptCount = document.QuerySelectorAll("script").Length;
@@ -49,6 +66,7 @@ public static class HtmlExtractionPlanner {
             || item.Kind.Equals("AppState", StringComparison.OrdinalIgnoreCase)
             || item.Kind.Equals("ScriptData", StringComparison.OrdinalIgnoreCase));
         bool looksLikeJavaScriptShell = LooksLikeJavaScriptShell(document, wordCount, executableScriptCount, appStateCount, externalScriptCount);
+        cancellationToken.ThrowIfCancellationRequested();
 
         List<string> reasons = new();
         List<string> warnings = new();
@@ -93,6 +111,7 @@ public static class HtmlExtractionPlanner {
         plan.SuggestedProfileName = profile.Name;
         plan.SuggestedProfileCommand = BuildProfileCommand(profile, url);
         plan.SuggestedProfileReason = BuildProfileReason(profile);
+        cancellationToken.ThrowIfCancellationRequested();
         return plan;
     }
 

--- a/Sources/HtmlTinkerX/HtmlPageWorkbench.cs
+++ b/Sources/HtmlTinkerX/HtmlPageWorkbench.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 
 namespace HtmlTinkerX;
 
@@ -30,11 +31,16 @@ public static class HtmlPageWorkbench {
 
         HtmlPageWorkbenchOptions effectiveOptions = options ?? new HtmlPageWorkbenchOptions();
         Uri? baseUri = effectiveOptions.BaseUri;
-        Uri? staticEffectiveBaseUri = GetEffectiveBaseUri(html, baseUri);
+        IDocument staticDocument = await HtmlParser.ParseWithAngleSharpAsync(html, cancellationToken).ConfigureAwait(false);
+        Uri? staticEffectiveBaseUri = HtmlModernParserUtilities.GetEffectiveBaseUri(staticDocument, baseUri);
         HtmlReadableTextResult staticReadableText = HtmlParserToText.ExtractReadableText(html);
+        cancellationToken.ThrowIfCancellationRequested();
         string staticMarkdown = HtmlParserToMarkdown.ConvertToMarkdown(html, staticEffectiveBaseUri?.AbsoluteUri);
+        cancellationToken.ThrowIfCancellationRequested();
         IReadOnlyList<HtmlDataItem> staticData = HtmlParsingToolbox.SelectData(html, baseUri: baseUri);
+        cancellationToken.ThrowIfCancellationRequested();
         IReadOnlyList<HtmlJavaScriptConfigItem> staticJavaScriptConfig = HtmlParsingToolbox.SelectJavaScriptConfig(html);
+        cancellationToken.ThrowIfCancellationRequested();
         IReadOnlyList<HtmlInteractionSurfaceItem> staticInteractionSurface = await HtmlParsingToolbox.FindInteractionSurfaceAsync(
             html,
             baseUri,
@@ -46,7 +52,12 @@ public static class HtmlPageWorkbench {
         HtmlRenderedPageSnapshot? renderedSnapshot = effectiveOptions.RenderedSnapshot;
         bool hasRenderedSnapshot = renderedSnapshot != null && !string.IsNullOrWhiteSpace(renderedSnapshot.Html);
         Uri? renderedBaseUri = GetRenderedBaseUri(renderedSnapshot, baseUri);
-        Uri? renderedEffectiveBaseUri = hasRenderedSnapshot ? GetEffectiveBaseUri(renderedSnapshot!.Html, renderedBaseUri) : null;
+        IDocument? renderedDocument = hasRenderedSnapshot
+            ? await HtmlParser.ParseWithAngleSharpAsync(renderedSnapshot!.Html, cancellationToken).ConfigureAwait(false)
+            : null;
+        Uri? renderedEffectiveBaseUri = renderedDocument == null
+            ? null
+            : HtmlModernParserUtilities.GetEffectiveBaseUri(renderedDocument, renderedBaseUri);
         IReadOnlyList<HtmlDataItem> renderedData = hasRenderedSnapshot
             ? NormalizeList(renderedSnapshot!.Data, () => HtmlParsingToolbox.SelectData(renderedSnapshot.Html, baseUri: renderedBaseUri))
             : Array.Empty<HtmlDataItem>();
@@ -66,12 +77,20 @@ public static class HtmlPageWorkbench {
         IReadOnlyList<HtmlJavaScriptConfigItem> javaScriptConfig = hasRenderedSnapshot ? renderedJavaScriptConfig : staticJavaScriptConfig;
         IReadOnlyList<HtmlInteractionSurfaceItem> interactionSurface = hasRenderedSnapshot ? renderedInteractionSurface : staticInteractionSurface;
         HtmlStaticRenderedComparison? staticRenderedComparison = CreateStaticRenderedComparison(html, renderedSnapshot, renderedBaseUri, effectiveOptions);
+        cancellationToken.ThrowIfCancellationRequested();
+        IDocument analysisDocument = renderedDocument ?? staticDocument;
+        string analysisHtml = hasRenderedSnapshot ? renderedSnapshot!.Html : html;
+        Uri? analysisBaseUri = hasRenderedSnapshot ? renderedBaseUri : baseUri;
         HtmlDocumentAuditResult? documentAudit = effectiveOptions.IncludeDocumentAudit
-            ? HtmlDocumentAudit.Analyze(hasRenderedSnapshot ? renderedSnapshot!.Html : html, effectiveOptions.DocumentAuditOptions)
+            ? HtmlDocumentAudit.Analyze(analysisDocument, effectiveOptions.DocumentAuditOptions, cancellationToken)
             : null;
         HtmlExtractionPlan plan = HtmlExtractionPlanner.Analyze(
-            hasRenderedSnapshot ? renderedSnapshot!.Html : html,
-            hasRenderedSnapshot ? renderedBaseUri : baseUri);
+            analysisHtml,
+            analysisDocument,
+            readableText,
+            data,
+            analysisBaseUri,
+            cancellationToken);
 
         IReadOnlyList<HtmlDataItem> forms = FilterData(data, "Form");
         IReadOnlyList<HtmlDataItem> links = FilterData(data, "Link");
@@ -193,15 +212,6 @@ public static class HtmlPageWorkbench {
         }
 
         return fallback;
-    }
-
-    private static Uri? GetEffectiveBaseUri(string html, Uri? baseUri) {
-        if (string.IsNullOrWhiteSpace(html)) {
-            return baseUri;
-        }
-
-        var document = HtmlParser.ParseWithAngleSharp(html);
-        return HtmlModernParserUtilities.GetEffectiveBaseUri(document, baseUri);
     }
 
     private static IReadOnlyList<T> NormalizeList<T>(IReadOnlyList<T>? source, Func<IReadOnlyList<T>> fallback) =>

--- a/Sources/HtmlTinkerX/HtmlPageWorkbench.cs
+++ b/Sources/HtmlTinkerX/HtmlPageWorkbench.cs
@@ -66,6 +66,9 @@ public static class HtmlPageWorkbench {
         IReadOnlyList<HtmlJavaScriptConfigItem> javaScriptConfig = hasRenderedSnapshot ? renderedJavaScriptConfig : staticJavaScriptConfig;
         IReadOnlyList<HtmlInteractionSurfaceItem> interactionSurface = hasRenderedSnapshot ? renderedInteractionSurface : staticInteractionSurface;
         HtmlStaticRenderedComparison? staticRenderedComparison = CreateStaticRenderedComparison(html, renderedSnapshot, renderedBaseUri, effectiveOptions);
+        HtmlDocumentAuditResult? documentAudit = effectiveOptions.IncludeDocumentAudit
+            ? HtmlDocumentAudit.Analyze(hasRenderedSnapshot ? renderedSnapshot!.Html : html, effectiveOptions.DocumentAuditOptions)
+            : null;
         HtmlExtractionPlan plan = HtmlExtractionPlanner.Analyze(
             hasRenderedSnapshot ? renderedSnapshot!.Html : html,
             hasRenderedSnapshot ? renderedBaseUri : baseUri);
@@ -95,6 +98,7 @@ public static class HtmlPageWorkbench {
             ExtractionPlan = plan,
             RenderedSnapshot = renderedSnapshot,
             StaticRenderedComparison = staticRenderedComparison,
+            DocumentAudit = documentAudit,
             SuggestedNextCommand = plan.SuggestedCommand,
             Warnings = warnings,
             Data = data,

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -36,6 +36,24 @@ public static partial class HtmlParser {
     }
 
     /// <summary>
+    /// Parses HTML markup using AngleSharp with cooperative cancellation.
+    /// </summary>
+    /// <param name="html">HTML content to parse.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The parsed document.</returns>
+    public static async Task<IDocument> ParseWithAngleSharpAsync(
+        string html,
+        CancellationToken cancellationToken = default) {
+        if (html == null) {
+            throw new ArgumentNullException(nameof(html));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var parser = new global::AngleSharp.Html.Parser.HtmlParser();
+        return await parser.ParseDocumentAsync(html, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Downloads and parses HTML markup from a URL using AngleSharp.
     /// </summary>
     /// <param name="url">URL of the page to download.</param>

--- a/Sources/HtmlTinkerX/HtmlParser.cs
+++ b/Sources/HtmlTinkerX/HtmlParser.cs
@@ -72,7 +72,7 @@ public static partial class HtmlParser {
         }
         HttpClient http = client ?? HtmlHttpClientFactory.Shared;
         string content = await HtmlUtilities.GetStringWithProperEncodingAsync(http, url, fetchOptions, cancellationToken).ConfigureAwait(false);
-        return ParseWithAngleSharp(content);
+        return await ParseWithAngleSharpAsync(content, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <Version>2.1.0-beta.1</Version>
+        <Version>2.1.0-beta.2</Version>
         <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
         <AssemblyName>HtmlTinkerX</AssemblyName>
         <AssemblyTitle>HtmlTinkerX</AssemblyTitle>

--- a/Sources/HtmlTinkerX/Models/HtmlDocumentAuditIssue.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlDocumentAuditIssue.cs
@@ -1,0 +1,18 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Describes one issue discovered while auditing an HTML document.
+/// </summary>
+public sealed class HtmlDocumentAuditIssue {
+    /// <summary>Stable machine-readable issue code.</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Impact of the issue.</summary>
+    public HtmlDocumentAuditSeverity Severity { get; set; }
+
+    /// <summary>Human-readable explanation of the issue.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Compact selector-like description of the affected element, when applicable.</summary>
+    public string Element { get; set; } = string.Empty;
+}

--- a/Sources/HtmlTinkerX/Models/HtmlDocumentAuditOptions.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlDocumentAuditOptions.cs
@@ -1,0 +1,21 @@
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Controls the reusable correctness, safety, and accessibility checks applied to an HTML document.
+/// </summary>
+public sealed class HtmlDocumentAuditOptions {
+    /// <summary>Checks document title and language metadata.</summary>
+    public bool CheckDocumentMetadata { get; set; } = true;
+
+    /// <summary>Checks that element identifiers are unique.</summary>
+    public bool CheckDuplicateIds { get; set; } = true;
+
+    /// <summary>Checks images, interactive controls, and form fields for accessible names.</summary>
+    public bool CheckAccessibleNames { get; set; } = true;
+
+    /// <summary>Checks links and resource attributes for executable URL schemes.</summary>
+    public bool CheckUnsafeUrls { get; set; } = true;
+
+    /// <summary>Checks heading levels for skipped hierarchy.</summary>
+    public bool CheckHeadingOrder { get; set; } = true;
+}

--- a/Sources/HtmlTinkerX/Models/HtmlDocumentAuditResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlDocumentAuditResult.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Contains reusable correctness, safety, and accessibility findings for one HTML document.
+/// </summary>
+public sealed class HtmlDocumentAuditResult {
+    /// <summary>Issues discovered in document order.</summary>
+    public IReadOnlyList<HtmlDocumentAuditIssue> Issues { get; set; } = Array.Empty<HtmlDocumentAuditIssue>();
+
+    /// <summary>Whether the audit completed without error-severity issues.</summary>
+    public bool IsValid => !Issues.Any(static issue => issue.Severity == HtmlDocumentAuditSeverity.Error);
+
+    /// <summary>Number of error-severity issues.</summary>
+    public int ErrorCount => Issues.Count(static issue => issue.Severity == HtmlDocumentAuditSeverity.Error);
+
+    /// <summary>Number of warning-severity issues.</summary>
+    public int WarningCount => Issues.Count(static issue => issue.Severity == HtmlDocumentAuditSeverity.Warning);
+}

--- a/Sources/HtmlTinkerX/Models/HtmlPageWorkbenchOptions.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlPageWorkbenchOptions.cs
@@ -23,4 +23,10 @@ public sealed class HtmlPageWorkbenchOptions {
 
     /// <summary>Allows linked-script endpoint inspection to download cross-origin scripts.</summary>
     public bool IncludeExternalLinkedScripts { get; set; }
+
+    /// <summary>Runs the shared correctness, safety, and accessibility audit against the primary static or rendered document.</summary>
+    public bool IncludeDocumentAudit { get; set; } = true;
+
+    /// <summary>Optional settings for the shared document audit.</summary>
+    public HtmlDocumentAuditOptions? DocumentAuditOptions { get; set; }
 }

--- a/Sources/HtmlTinkerX/Models/HtmlPageWorkbenchResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlPageWorkbenchResult.cs
@@ -40,6 +40,9 @@ public sealed class HtmlPageWorkbenchResult {
     /// <summary>Static-vs-rendered comparison when a rendered snapshot is available.</summary>
     public HtmlStaticRenderedComparison? StaticRenderedComparison { get; set; }
 
+    /// <summary>Correctness, safety, and accessibility audit of the primary static or rendered document.</summary>
+    public HtmlDocumentAuditResult? DocumentAudit { get; set; }
+
     /// <summary>PowerShell command that can be used as the next step.</summary>
     public string SuggestedNextCommand { get; set; } = string.Empty;
 

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.ElementInspection.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.ElementInspection.cs
@@ -1,6 +1,7 @@
 using Microsoft.Playwright;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Text.Json;
@@ -76,6 +77,60 @@ public static partial class HtmlBrowser {
         };
         return JSON.stringify(result);
     }";
+
+    /// <summary>
+    /// Waits until a selector resolves to an exact number of rendered elements.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="selector">CSS selector to count.</param>
+    /// <param name="expectedCount">Expected number of matching elements.</param>
+    /// <param name="timeout">Maximum wait time in milliseconds.</param>
+    /// <param name="pollMilliseconds">Polling interval in milliseconds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task WaitForElementCountAsync(
+        HtmlBrowserSession session,
+        string selector,
+        int expectedCount,
+        int timeout = 10000,
+        int pollMilliseconds = 50,
+        CancellationToken cancellationToken = default) {
+        if (session == null) {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        if (string.IsNullOrWhiteSpace(selector)) {
+            throw new ArgumentException("Selector cannot be empty.", nameof(selector));
+        }
+
+        if (expectedCount < 0) {
+            throw new ArgumentOutOfRangeException(nameof(expectedCount), "Expected count cannot be negative.");
+        }
+
+        if (timeout <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
+        }
+
+        if (pollMilliseconds <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(pollMilliseconds), "Polling interval must be greater than zero.");
+        }
+
+        ILocator locator = session.Page.Locator(selector);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        int actualCount = -1;
+        while (stopwatch.ElapsedMilliseconds <= timeout) {
+            cancellationToken.ThrowIfCancellationRequested();
+            actualCount = await locator.CountAsync().ConfigureAwait(false);
+            if (actualCount == expectedCount) {
+                return;
+            }
+
+            await session.Page.WaitForTimeoutAsync(pollMilliseconds)
+                .WaitWithCancellationAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Selector '{selector}' resolved to {actualCount} element(s), not {expectedCount}, within {timeout}ms.");
+    }
 
     /// <summary>
     /// Returns browser-observed element information for a CSS selector.

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Interactions.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Interactions.cs
@@ -211,4 +211,9 @@ public static partial class HtmlBrowser {
 
         await task.ConfigureAwait(false);
     }
+
+    private static async Task<T> WaitWithCancellationAsync<T>(this Task<T> task, CancellationToken cancellationToken) {
+        await ((Task)task).WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
+        return await task.ConfigureAwait(false);
+    }
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Routes.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Routes.cs
@@ -34,6 +34,73 @@ public static partial class HtmlBrowser {
         => RegisterRouteAsync(session.Page, pattern, handler, cancellationToken);
 
     /// <summary>
+    /// Registers a static browser response without exposing Playwright route plumbing to the caller.
+    /// </summary>
+    /// <param name="page">Target page.</param>
+    /// <param name="pattern">Matching URL pattern.</param>
+    /// <param name="body">Response body.</param>
+    /// <param name="contentType">Response content type.</param>
+    /// <param name="status">HTTP response status.</param>
+    /// <param name="headers">Optional additional response headers.</param>
+    /// <param name="cancellationToken">Token used to cancel registration.</param>
+    public static Task RegisterResponseRouteAsync(
+        IPage page,
+        string pattern,
+        string? body,
+        string contentType = "text/plain; charset=utf-8",
+        int status = 200,
+        IReadOnlyDictionary<string, string>? headers = null,
+        CancellationToken cancellationToken = default) {
+        if (page == null) {
+            throw new ArgumentNullException(nameof(page));
+        }
+
+        if (status < 100 || status > 599) {
+            throw new ArgumentOutOfRangeException(nameof(status), "HTTP status must be between 100 and 599.");
+        }
+
+        if (string.IsNullOrWhiteSpace(contentType)) {
+            throw new ArgumentException("Content type cannot be empty.", nameof(contentType));
+        }
+
+        return RegisterRouteAsync(
+            page,
+            pattern,
+            route => route.FulfillAsync(new RouteFulfillOptions {
+                Status = status,
+                ContentType = contentType,
+                Body = body ?? string.Empty,
+                Headers = headers?.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.OrdinalIgnoreCase)
+            }),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Registers a static browser response on an active HtmlTinkerX session.
+    /// </summary>
+    public static Task RegisterResponseRouteAsync(
+        HtmlBrowserSession session,
+        string pattern,
+        string? body,
+        string contentType = "text/plain; charset=utf-8",
+        int status = 200,
+        IReadOnlyDictionary<string, string>? headers = null,
+        CancellationToken cancellationToken = default) {
+        if (session == null) {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        return RegisterResponseRouteAsync(
+            session.Page,
+            pattern,
+            body,
+            contentType,
+            status,
+            headers,
+            cancellationToken);
+    }
+
+    /// <summary>
     /// Removes a previously registered route handler from the page.
     /// </summary>
     /// <param name="page">Target page.</param>

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.StyleInspection.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.StyleInspection.cs
@@ -46,7 +46,7 @@ public static partial class HtmlBrowser {
     /// <param name="attributeName">Attribute name to read.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The attribute value, or <see langword="null"/> when it is absent.</returns>
-    public static Task<string?> GetAttributeAsync(
+    public static async Task<string?> GetAttributeAsync(
         HtmlBrowserSession session,
         string selector,
         string attributeName,
@@ -64,7 +64,9 @@ public static partial class HtmlBrowser {
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        return session.Page.Locator(selector).First.GetAttributeAsync(attributeName);
+        return await session.Page.Locator(selector).First.GetAttributeAsync(attributeName)
+            .WaitWithCancellationAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -83,7 +85,9 @@ public static partial class HtmlBrowser {
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        string html = await session.Page.ContentAsync().ConfigureAwait(false);
+        string html = await session.Page.ContentAsync()
+            .WaitWithCancellationAsync(cancellationToken)
+            .ConfigureAwait(false);
         return HtmlDocumentAudit.Analyze(html, options);
     }
 
@@ -115,7 +119,7 @@ public static partial class HtmlBrowser {
         cancellationToken.ThrowIfCancellationRequested();
         string json = await session.Page.Locator(selector).First.EvaluateAsync<string>(
             "(element, names) => JSON.stringify(Object.fromEntries(names.map(name => [name, getComputedStyle(element).getPropertyValue(name).trim()])))",
-            names).ConfigureAwait(false);
+            names).WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
 
         Dictionary<string, string>? values = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
         return values ?? new Dictionary<string, string>(StringComparer.Ordinal);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.StyleInspection.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.StyleInspection.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX;
+
+public static partial class HtmlBrowser {
+    /// <summary>
+    /// Reads selected computed CSS properties from one rendered element.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="selector">CSS selector identifying the element.</param>
+    /// <param name="propertyNames">CSS property names to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Computed values keyed by the requested property names.</returns>
+    public static Task<IReadOnlyDictionary<string, string>> GetComputedStylesAsync(
+        HtmlBrowserSession session,
+        string selector,
+        IEnumerable<string> propertyNames,
+        CancellationToken cancellationToken = default) =>
+        GetStyleValuesAsync(session, selector, propertyNames, cancellationToken);
+
+    /// <summary>
+    /// Reads selected CSS custom properties from one rendered element.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="selector">CSS selector identifying the element, typically <c>html</c>.</param>
+    /// <param name="propertyNames">Custom property names, including their leading <c>--</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Computed values keyed by the requested custom property names.</returns>
+    public static Task<IReadOnlyDictionary<string, string>> GetCssCustomPropertiesAsync(
+        HtmlBrowserSession session,
+        string selector,
+        IEnumerable<string> propertyNames,
+        CancellationToken cancellationToken = default) =>
+        GetStyleValuesAsync(session, selector, propertyNames, cancellationToken);
+
+    /// <summary>
+    /// Reads one attribute from the first rendered element matching a selector.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="selector">CSS selector identifying the element.</param>
+    /// <param name="attributeName">Attribute name to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The attribute value, or <see langword="null"/> when it is absent.</returns>
+    public static Task<string?> GetAttributeAsync(
+        HtmlBrowserSession session,
+        string selector,
+        string attributeName,
+        CancellationToken cancellationToken = default) {
+        if (session == null) {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        if (string.IsNullOrWhiteSpace(selector)) {
+            throw new ArgumentException("Selector cannot be empty.", nameof(selector));
+        }
+
+        if (string.IsNullOrWhiteSpace(attributeName)) {
+            throw new ArgumentException("Attribute name cannot be empty.", nameof(attributeName));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return session.Page.Locator(selector).First.GetAttributeAsync(attributeName);
+    }
+
+    /// <summary>
+    /// Audits the current rendered DOM using the shared HtmlTinkerX document audit contract.
+    /// </summary>
+    /// <param name="session">Active browser session.</param>
+    /// <param name="options">Optional audit settings.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Structured issues discovered in the rendered document.</returns>
+    public static async Task<HtmlDocumentAuditResult> AuditDocumentAsync(
+        HtmlBrowserSession session,
+        HtmlDocumentAuditOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (session == null) {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        string html = await session.Page.ContentAsync().ConfigureAwait(false);
+        return HtmlDocumentAudit.Analyze(html, options);
+    }
+
+    private static async Task<IReadOnlyDictionary<string, string>> GetStyleValuesAsync(
+        HtmlBrowserSession session,
+        string selector,
+        IEnumerable<string> propertyNames,
+        CancellationToken cancellationToken) {
+        if (session == null) {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        if (string.IsNullOrWhiteSpace(selector)) {
+            throw new ArgumentException("Selector cannot be empty.", nameof(selector));
+        }
+
+        if (propertyNames == null) {
+            throw new ArgumentNullException(nameof(propertyNames));
+        }
+
+        string[] names = propertyNames
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (names.Length == 0) {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        string json = await session.Page.Locator(selector).First.EvaluateAsync<string>(
+            "(element, names) => JSON.stringify(Object.fromEntries(names.map(name => [name, getComputedStyle(element).getPropertyValue(name).trim()])))",
+            names).ConfigureAwait(false);
+
+        Dictionary<string, string>? values = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+        return values ?? new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.StyleInspection.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.StyleInspection.cs
@@ -88,7 +88,7 @@ public static partial class HtmlBrowser {
         string html = await session.Page.ContentAsync()
             .WaitWithCancellationAsync(cancellationToken)
             .ConfigureAwait(false);
-        return HtmlDocumentAudit.Analyze(html, options);
+        return await HtmlDocumentAudit.AnalyzeAsync(html, options, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<IReadOnlyDictionary<string, string>> GetStyleValuesAsync(

--- a/Sources/HtmlTinkerX/README.md
+++ b/Sources/HtmlTinkerX/README.md
@@ -5,11 +5,11 @@ HtmlTinkerX is a .NET library for parsing and inspecting HTML, CSS, and JavaScri
 ## Install
 
 ```shell
-dotnet add package HtmlTinkerX --prerelease
+dotnet add package HtmlTinkerX --version 2.1.0-beta.2
 ```
 
-The 2.1 line is prerelease while its required upstream AngleSharp CSS and
-JavaScript integrations remain prerelease packages.
+HtmlTinkerX 2.1.0-beta.2 consumes prerelease AngleSharp CSS and JavaScript
+integration packages. Pin the HtmlTinkerX version when reproducible restores matter.
 
 ## Parse HTML
 
@@ -25,6 +25,38 @@ IDocument document = HtmlParser.ParseWithAngleSharp("""
     """);
 
 string title = document.QuerySelector("h1")?.TextContent ?? string.Empty;
+```
+
+## Audit generated or supplied HTML
+
+`HtmlDocumentAudit` provides one reusable contract for static output checks. It reports duplicate IDs, missing document metadata, image alternatives, control names and labels, unsafe URL schemes, and heading-order problems.
+
+```csharp
+HtmlDocumentAuditResult audit = HtmlDocumentAudit.Analyze(html);
+
+foreach (HtmlDocumentAuditIssue issue in audit.Issues) {
+    Console.WriteLine($"{issue.Severity}: {issue.Code} - {issue.Message}");
+}
+```
+
+The audit is diagnostic; it does not rewrite the document or claim full WCAG conformance.
+
+For client-rendered pages, run the same contract after navigation:
+
+```csharp
+await using HtmlBrowserSession session = await HtmlBrowser.OpenSessionAsync(url);
+HtmlDocumentAuditResult renderedAudit = await HtmlBrowser.AuditDocumentAsync(session);
+```
+
+Rendered UI tests can inspect styles and attributes without creating another Playwright wrapper:
+
+```csharp
+IReadOnlyDictionary<string, string> values = await HtmlBrowser.GetComputedStylesAsync(
+    session,
+    ".report-panel",
+    new[] { "position", "padding", "overflow" });
+
+string? label = await HtmlBrowser.GetAttributeAsync(session, "#export", "aria-label");
 ```
 
 URL parsers stream responses with a 16 MiB default limit and cooperative


### PR DESCRIPTION
## Summary

- adds one reusable static HTML audit for metadata, duplicate IDs, heading order, accessible names, form labels, image alternatives, unsafe URL sinks, and meta-refresh navigation
- uses element-aware URL rules for navigation, assets, forms, object data, SVG links, and video posters
- integrates audit results with `HtmlPageWorkbench` and reuses the parsed AngleSharp document instead of creating another DOM brain
- adds typed Playwright helpers for rendered audits, computed styles, CSS custom properties, and attributes
- carries cancellation through browser capture, parsing, and audit loops
- documents the reusable static and browser APIs used by HtmlForgeX and TestimoX

## Ownership

HtmlTinkerX / PSParseHTML owns HTML parsing and rendered-page inspection. HtmlForgeX and consumers use this contract instead of maintaining separate Playwright, DOM, accessibility, or style-analysis implementations.

The package remains `2.1.0-beta.2` because its AngleSharp CSS/JS dependencies are prerelease packages.

## Validation

- exact reviewed head: `59acd8f722fce4fcaad1f05643823ed19155312f`
- independent exact-head review: no actionable P0-P2 findings
- net8: 848/848 passed
- net10: 848/848 passed
- net472: 844 passed / 2 environment-gated skipped
- focused audit/cancellation regressions: 21/21 passed
- frozen package contains version 2.1.0-beta.2, its README, and matching repository commit metadata
- current GitHub matrix is fully green across Windows, macOS, Ubuntu, PowerShell, and packaged ALC-conflict validation
- HtmlForgeX and TestimoX exercise the owner through real Chromium/Playwright tests