### PR TITLE
Update AngleSharp for GHSA-pgww-w46g-26qg

### DIFF
--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>2.0.19</VersionPrefix>
+        <VersionPrefix>2.0.20</VersionPrefix>
         <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
         <AssemblyName>HtmlTinkerX</AssemblyName>
         <AssemblyTitle>HtmlTinkerX</AssemblyTitle>
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.4.1-beta.523" />
+        <PackageReference Include="AngleSharp" Version="1.5.2" />
         <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.213" />
         <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
         <PackageReference Include="AngleSharp.Js" Version="1.0.0-beta.47" />


### PR DESCRIPTION
## Summary

- upgrade AngleSharp from the vulnerable prerelease to 1.5.2
- publish the supported HtmlTinkerX 2.0 line as 2.0.20
- unblock downstream PowerForge website builds that treat NuGet vulnerability warnings as errors

AngleSharp versions below 1.5.0 are affected by [GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg).

## Validation

- full Release test matrix: 2,401 total, 2 expected skips, 0 failures across net472/net8/net10
- `dotnet list package --vulnerable --include-transitive`: no vulnerable packages
- packed `HtmlTinkerX 2.0.20` declares AngleSharp 1.5.2