### PR TITLE
Restore README content and stable release configuration

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -22,7 +22,7 @@ Build-Module -ModuleName 'PSParseHTML' -RunMode $RunMode {
         # ID used to uniquely identify this module
         GUID                 = 'f0387960-7034-4918-a1e1-d5847cbf90df'
         # Version number of this module.
-        ModuleVersion        = '2.1.X'
+        ModuleVersion        = '2.0.X'
         # Author of this module
         Author               = 'Przemyslaw Klys'
         # Company or vendor of this module
@@ -39,8 +39,6 @@ Build-Module -ModuleName 'PSParseHTML' -RunMode $RunMode {
         LicenseUri           = 'https://github.com/EvotecIT/HtmlTinkerX/blob/v2-speedygonzales/LICENSE'
         # A URL to an icon representing this module.
         IconUri              = 'https://evotec.xyz/wp-content/uploads/2018/12/PSWriteHTML.png'
-        # Pre-release tag for this module.
-        PreReleaseTag        = 'beta1'
     }
     New-ConfigurationManifest @Manifest
     # Add external module dependencies, using loop for simplicity

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -3,13 +3,13 @@
   "RootPath": "..\\Sources",
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
-    "HtmlTinkerX": "2.1.0-beta.1"
+    "HtmlTinkerX": "2.0.X"
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
   "ExcludeProjects": [],
   "NugetSource": [],
-  "IncludePrerelease": true,
+  "IncludePrerelease": false,
   "Configuration": "Release",
   "OutputPath": null,
   "StagingPath": "../Artefacts/ProjectBuild",
@@ -30,7 +30,7 @@
   "GitHubAccessTokenFilePath": "C:\\Support\\Important\\GithubAPI.txt",
   "GitHubUsername": "EvotecIT",
   "GitHubRepositoryName": "HtmlTinkerX",
-  "GitHubIsPreRelease": true,
+  "GitHubIsPreRelease": false,
   "GitHubIncludeProjectNameInTag": true,
   "GitHubGenerateReleaseNotes": true,
   "GitHubReleaseMode": "Single",

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -3,16 +3,15 @@
 ## AngleSharp package stability
 
 HtmlTinkerX uses the stable AngleSharp core package. Its CSSOM and DOM JavaScript
-integration still require the upstream `AngleSharp.Css` and `AngleSharp.Js` 1.0
+integration currently use the upstream `AngleSharp.Css` and `AngleSharp.Js` 1.0
 prerelease lines. Both upstream packages declare compatibility with AngleSharp
 1.x; `AngleSharp.Js` also declares compatibility with Jint 4.x.
 
-Because those extensions are runtime dependencies, HtmlTinkerX NuGet and
-PSParseHTML releases must remain prerelease builds while they are present. Do
-not publish a stable HtmlTinkerX package that produces NuGet warning NU5104.
-Before promoting a future stable release, replace these dependencies with stable
-versions and rerun all target-framework tests plus package-only .NET and
-PowerShell smoke tests.
+Upstream dependency labels do not determine the HtmlTinkerX or PSParseHTML
+release channel. Publish normal stable releases after the full target-framework
+tests and package-only .NET and PowerShell smoke tests pass. Treat any NU5104
+warning as a known dependency-metadata warning, not as a reason to mark our
+packages prerelease.
 
 ## Screenshot image processing
 

--- a/Docs/Examples/01-InstallingUpdatingModule/README.MD
+++ b/Docs/Examples/01-InstallingUpdatingModule/README.MD
@@ -1,10 +1,11 @@
-﻿### Install from PSGallery
+### Install from PSGallery
 
-```PowerShell
+```powershell
 Install-Module -Name PSParseHTML -AllowClobber -Force
 ```
 
-Force and AllowClobber aren't necessary, but they do skip errors in case some appear.
+`-Force` reinstalls the selected version when necessary. `-AllowClobber` permits
+commands with the same names as commands already available in the session.
 
 ### Update from PSGallery
 
@@ -12,6 +13,6 @@ Force and AllowClobber aren't necessary, but they do skip errors in case some ap
 Update-Module -Name PSParseHTML
 ```
 
-That's it. Whenever there's a new version you simply run the command and you can enjoy it. Remember, that you may need to close, and reopen the **PowerShell** session if you have already used module before updating it.
-
-**The important thing** is if something works for you on production, keep using it till you test the new version on a test computer. I do changes that may not be big, but big enough that auto-update will break your code. For example, a small rename to a parameter and your code stops working! Be responsible!
+If the module is already imported, start a new PowerShell session before using
+the newly installed version. Pin a tested version in production automation when
+parameter or behavior changes would be disruptive.

--- a/Docs/Examples/03-GetInteractableElements/README.MD
+++ b/Docs/Examples/03-GetInteractableElements/README.MD
@@ -58,14 +58,38 @@ Get-HtmlBrowserInteractable -Path './report.html'
 Get-HtmlBrowserInteractable -Session $session -Filter 'Media' -Limit 10
 ```
 
-The returned selector can be passed directly to an interaction cmdlet:
+The returned selector is a starting point for interaction. A selector based on
+a shared class, link target, or tag can match more than one element, so inspect
+those matches and pass the selected zero-based index through `-Nth`:
 
 ```powershell
 $pick = Get-HtmlBrowserInteractable -Session $session |
-    Out-GridView -Title 'Pick an element' -PassThru
+    Out-GridView -Title 'Pick an element' -OutputMode Single
 
 if ($pick) {
-    Invoke-HtmlBrowserClick -Session $session -Selector $pick.Selector
+    $selectorMatches = try {
+        @(
+            Get-HtmlBrowserElement -Session $session -Selector $pick.Selector `
+                -IncludeAttributes -ErrorAction Stop
+        )
+    } catch {
+        @()
+    }
+
+    if ($selectorMatches.Count -eq 0) {
+        Write-Warning 'The selected element is no longer present on the page.'
+    } else {
+        $target = if ($selectorMatches.Count -eq 1) {
+            $selectorMatches[0]
+        } else {
+            $selectorMatches |
+                Out-GridView -Title 'Choose the exact matching element' -OutputMode Single
+        }
+
+        if ($target) {
+            Invoke-HtmlBrowserClick -Session $session -Selector $pick.Selector -Nth $target.Index
+        }
+    }
 }
 ```
 

--- a/Docs/Examples/03-GetInteractableElements/README.MD
+++ b/Docs/Examples/03-GetInteractableElements/README.MD
@@ -1,142 +1,74 @@
 # `Get-HtmlBrowserInteractable`
 
-## 📖 Summary
+`Get-HtmlBrowserInteractable` returns controls that can be inspected or acted
+on in a browser session. It can use an existing session, open a URL, or open a
+local HTML file.
 
-`Get-HtmlBrowserInteractable` lists all visible or optionally hidden clickable/interactable elements from the current HTML page inside a browser session.
-Typical use includes discovering links, buttons, or form elements a user or script might want to interact with — ideal for automation or semi-interactive scripting.
+For the complete parameter sets, browser profile options, and authentication
+parameters, see the generated
+[`Get-HtmlBrowserInteractable` command reference](../../Get-HtmlBrowserInteractable.md).
 
----
-
-## 🧰 Syntax
+## Common syntax
 
 ```powershell
 Get-HtmlBrowserInteractable
-    [-Session <BrowserSession>]
+    [-Session <HtmlBrowserSession>]
     [-Url <string>]
     [-Path <string>]
-    [-Browser <BrowserEngine>]
-    [-Clean]
     [-IncludeHidden]
     [-Limit <int>]
     [-Filter <string>]
 ```
 
----
+Use one input mode:
 
-## 📥 Parameters
+- `-Session` inspects an existing browser session. When omitted in this
+  parameter set, the cmdlet uses the module's default session.
+- `-Url` opens a URL in a temporary session.
+- `-Path` opens a local HTML file. `-File` is an alias.
 
-| Name             | Type     | Required | Description                                                                 |
-|------------------|----------|----------|-----------------------------------------------------------------------------|
-| `-Session`       | BrowserSession | Yes* | The session object returned by `Start-HtmlBrowserSession`. |
-| `-Url`           | string   | Yes* | Load a page at the specified URL and list elements. |
-| `-Path`          | string   | Yes* | Load a local HTML file. Alias: `-File`. |
-| `-Browser`       | BrowserEngine | No | Choose browser engine when using `-Url` or `-Path`. |
-| `-Clean`         | switch   | No | Reinstall browser runtimes for `-Url` or `-Path`. |
-| `-IncludeHidden` | switch   | No       | If specified, includes elements not visible to the user (e.g. `display:none`).     |
-| `-Limit`         | int      | No       | Limits the number of results returned. Default is 100.                      |
-| `-Filter`        | string   | No       | Case-insensitive text filter applied to element text. |
+`-IncludeHidden` keeps elements Playwright reports as not visible. `-Limit`
+defaults to 100. `-Filter` performs a case-insensitive match against element
+text.
 
-`*` Exactly one of `-Session`, `-Url` or `-Path` must be specified.
+## Output
 
----
+Each `HtmlInteractableInfo` result includes:
 
-## 📤 Output
+| Property | Description |
+| --- | --- |
+| `Index`, `Text`, `Tag`, `Id`, `Class` | Element identity and visible text |
+| `Selector` | CSS selector that identifies the element |
+| `Href` | Link target when applicable |
+| `Visible`, `PotentiallyHidden` | Playwright visibility and possible accessibility hiding |
+| `Enabled`, `Editable`, `InViewport` | Current interaction state |
+| `X`, `Y`, `Width`, `Height` | Viewport geometry in CSS pixels |
 
-A list of objects with the following structure:
-
-| Property  | Type   | Description                                            |
-|-----------|--------|--------------------------------------------------------|
-| `Index`   | int    | Order number in result set                             |
-| `Text`    | string | Inner text or value of the element                     |
-| `Tag`     | string | Tag name (e.g., `a`, `button`, `input`)                |
-| `Selector`| string | First 80 characters of the outer HTML (for preview)    |
-| `Href`    | string | The `href` or `onclick` attribute value if applicable  |
-| `Visible` | bool   | `True` when Playwright reports the element as visible   |
-| `PotentiallyHidden` | bool | `True` when the element or an ancestor has attributes or styles that may hide it |
-
----
-
-## 📋 Example Output
-
-```plaintext
-Index Text Visible Selector                                        Href                                      Tag Id Class
------ ---- ------- --------                                        ----                                      --- -- -----
-10    Media True    a[href='upload.php']                            upload.php                                a      wp-has-submenu
-12    AddMedia True a[href='media-new.php']                         media-new.php                             a
-51    Media False   a[href='https://evotec.xyz/wp-admin/media-new.php'] https://evotec.xyz/wp-admin/media-new.php a      ab-item
-```
-
----
-
-## 💡 Examples
-
-### 🧪 Get interactable elements from current page
+## Examples
 
 ```powershell
-Get-HtmlBrowserInteractable -Session $Session
-```
+# Inspect the current or default session
+Get-HtmlBrowserInteractable -Session $session
 
-### 🧪 Load a URL directly
-
-```powershell
+# Open a URL or local file for inspection
 Get-HtmlBrowserInteractable -Url 'https://example.com'
-```
-
-### 🧪 Parse a local HTML file
-
-```powershell
 Get-HtmlBrowserInteractable -Path './report.html'
+
+# Narrow a large page
+Get-HtmlBrowserInteractable -Session $session -Filter 'Media' -Limit 10
 ```
 
-### 🧪 Include hidden elements, limit results to 10
+The returned selector can be passed directly to an interaction cmdlet:
 
 ```powershell
-Get-HtmlBrowserInteractable -Session $Session -IncludeHidden -Limit 10
+$pick = Get-HtmlBrowserInteractable -Session $session |
+    Out-GridView -Title 'Pick an element' -PassThru
+
+if ($pick) {
+    Invoke-HtmlBrowserClick -Session $session -Selector $pick.Selector
+}
 ```
 
-### 🧪 Filter elements and show table output
-
-```powershell
-Get-HtmlBrowserInteractable -Session $Session -Filter 'Media' -IncludeHidden | Format-Table
-```
-
-### 🧪 Use interactively with `Out-GridView`
-
-```powershell
-$pick = Get-HtmlBrowserInteractable -Session $Session | Out-GridView -Title "Pick element" -PassThru
-Invoke-HtmlBrowserNavigation -Session $Session -Text $pick.Text
-```
-
----
-
-## 🔧 Internal Behavior
-
-Internally, the following JavaScript logic is executed inside the Playwright context:
-
-```javascript
-(() => {
-    const isVisible = el => !!( el.offsetWidth || el.offsetHeight || el.getClientRects().length );
-    const elements = Array.from(document.querySelectorAll('a, button, input[type="submit"]'));
-    return elements
-        .filter(el => /* IncludeHidden? */ isVisible(el))
-        .map((el, index) => ({
-            Index: index,
-            Text: el.innerText || el.value || '',
-            Tag: el.tagName.toLowerCase(),
-            Selector: el.outerHTML.slice(0, 80),
-            Href: el.href || el.getAttribute('onclick') || null
-        }));
-})();
-```
-
-This provides a readable list of interactable elements useful for further automation or navigation.
-
----
-
-## 🧼 Notes
-
-- This cmdlet does not perform any interaction — use `Invoke-HtmlBrowserNavigation` to act on returned elements.
-- Use `-Limit` to avoid processing overly large DOM trees.
-- Visibility filtering uses bounding box and layout heuristics (`getClientRects()`).
-
----
+This cmdlet only inspects the page. Use commands such as
+`Invoke-HtmlBrowserClick`, `Set-HtmlBrowserInput`, or
+`Invoke-HtmlBrowserNavigation` to change browser state.

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: PSParseHTML
 Module Guid: f0387960-7034-4918-a1e1-d5847cbf90df
 Download Help Link: https://github.com/EvotecIT/HtmlTinkerX
-Help Version: 2.1.0
+Help Version: 2.0.20
 Locale: en-US
 ---
 # PSParseHTML Module

--- a/PSParseHTML.psd1
+++ b/PSParseHTML.psd1
@@ -8,14 +8,13 @@
     Description          = 'Module that allows to manipulate, parse, format and optimize HTML, JavaScript and CSS'
     FunctionsToExport    = @()
     GUID                 = 'f0387960-7034-4918-a1e1-d5847cbf90df'
-    ModuleVersion        = '2.1.0'
+    ModuleVersion        = '2.0.20'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
             ExternalModuleDependencies = @()
             IconUri                    = 'https://evotec.xyz/wp-content/uploads/2018/12/PSWriteHTML.png'
             LicenseUri                 = 'https://github.com/EvotecIT/HtmlTinkerX/blob/v2-speedygonzales/LICENSE'
-            Prerelease                 = 'beta1'
             ProjectUri                 = 'https://github.com/EvotecIT/HtmlTinkerX'
             RequireLicenseAcceptance   = $false
             Tags                       = @('HTML', 'WWW', 'JavaScript', 'CSS', 'Windows', 'MacOS', 'Linux')

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,8 @@
-# HtmlTinkerX & PSParseHTML - Modern HTML Processing for .NET and PowerShell
+# HtmlTinkerX & PSParseHTML - HTML processing for .NET and PowerShell
 
-HtmlTinkerX is available as NuGet from the Nuget Gallery and PSParseHTML PowerShell module from PSGallery
+HtmlTinkerX is the shared .NET engine for parsing, extracting, auditing,
+formatting, crawling, and rendering web content. PSParseHTML exposes the same
+engine as PowerShell cmdlets.
 
 ## 📦 NuGet Package
 [![nuget downloads](https://img.shields.io/nuget/dt/HtmlTinkerX?label=nuget%20downloads)](https://www.nuget.org/packages/HtmlTinkerX)
@@ -8,7 +10,6 @@ HtmlTinkerX is available as NuGet from the Nuget Gallery and PSParseHTML PowerSh
 
 ## 💻 PowerShell Module
 [![powershell gallery version](https://img.shields.io/powershellgallery/v/PSParseHTML.svg)](https://www.powershellgallery.com/packages/PSParseHTML)
-[![powershell gallery preview](https://img.shields.io/powershellgallery/v/PSParseHTML.svg?include_prereleases&label=powershell%20gallery%20preview&color=yellow)](https://www.powershellgallery.com/packages/PSParseHTML)
 [![powershell gallery platforms](https://img.shields.io/powershellgallery/p/PSParseHTML.svg)](https://www.powershellgallery.com/packages/PSParseHTML)
 [![powershell gallery downloads](https://img.shields.io/powershellgallery/dt/PSParseHTML.svg)](https://www.powershellgallery.com/packages/PSParseHTML)
 
@@ -26,130 +27,47 @@ Dependency guardrails, including the ChartForgeX-backed screenshot image-process
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-pklys-0077B5.svg?logo=LinkedIn)](https://www.linkedin.com/in/pklys)
 [![Discord](https://img.shields.io/discord/508328927853281280?style=flat-square&label=discord%20chat)](https://evo.yt/discord)
 
-## What it's all about
+## What it covers
 
-**HtmlTinkerX** is a powerful async C# library for HTML, CSS, and JavaScript processing, parsing, formatting, and optimization. It provides comprehensive web content processing capabilities including browser automation with Playwright, document parsing with multiple engines, resource optimization, and much more. **PSParseHTML** is the PowerShell module that exposes HtmlTinkerX functionality through easy-to-use cmdlets.
+- HTML parsing with AngleSharp and Html Agility Pack
+- tables, lists, forms, metadata, JSON-LD, microdata, Open Graph, application
+  state, tokens, image candidates, and API endpoint extraction
+- static and rendered document audits for duplicate IDs, document metadata,
+  accessible names, unsafe URL schemes, and heading order
+- bounded website crawling to offline HTML, text, Markdown, JSON, JSONL, graph,
+  and asset datasets
+- Playwright sessions, interaction, screenshots, PDFs, HAR files, traces,
+  browser recipes, cookies, storage, and SSO handoff inspection
+- HTML, CSS, JavaScript, and email formatting or optimization
+- .NET Framework 4.7.2, .NET 8, and .NET 10
 
-Whether you're working in C# or PowerShell, you get access to:
-- 🔍 **HTML Parsing** - Multiple parsing engines (AngleSharp, HtmlAgilityPack)
-- 🎨 **Resource Optimization** - Minify and format HTML, CSS, JavaScript
-- 🌐 **Browser Automation** - Full Playwright integration for screenshots, PDFs, interaction
-- 📊 **Data Extraction** - Tables, forms, metadata, microdata, Open Graph
-- 📧 **Email Processing** - CSS inlining for email compatibility
-- 🔧 **Network Tools** - HAR export, request interception, console logging
-- 🍪 **State Management** - Cookie handling, session persistence
-- 📱 **Multi-Platform** - .NET Framework 4.7.2, .NET 8.0, .NET 10.0
+## PowerShell and C# entry points
 
-## 🔄 PowerShell to C# Method Mapping
+The PowerShell commands are thin surfaces over HtmlTinkerX. The generated
+[command reference](Docs/Readme.md) covers every cmdlet.
 
-This comprehensive table shows how PowerShell cmdlets map to C# methods, making it easy to transition between platforms:
-
-### HTML Parsing & Processing
-| PowerShell Cmdlet            | C# Method                                | Description                                 |
-| ---------------------------- | ---------------------------------------- | ------------------------------------------- |
-| `ConvertFrom-HTML`           | `HtmlParser.ParseWithAngleSharp()`       | Parse HTML documents                        |
-| `ConvertFrom-HtmlTable`      | `HtmlParser.ParseTablesWithAngleSharp()` | Extract tables with rowspan/colspan support |
-| `ConvertFrom-HTMLAttributes` | `HtmlParserExtensions.GetElements()`     | Query elements by tag, class, id, or name   |
-| `ConvertFrom-HtmlForm`       | `HtmlFormExtractor.ExtractForms()`       | Extract form data and structure             |
-| `ConvertFrom-HtmlList`       | `HtmlListParser.ParseLists()`            | Parse list elements into structured data    |
-| `ConvertFrom-HtmlMeta`       | `HtmlMetaParser.ExtractMeta()`           | Extract meta tag name/content pairs         |
-| `ConvertFrom-HtmlMicrodata`  | `HtmlMicrodataParser.ExtractMicrodata()` | Extract schema.org structured data          |
-| `ConvertFrom-HtmlOpenGraph`  | `HtmlOpenGraphParser.ExtractOpenGraph()` | Extract Open Graph metadata                 |
-| `Convert-HTMLToText`         | `HtmlUtilities.ConvertToText()`          | Convert HTML to plain text                  |
-| `Compare-HTML`               | `HtmlDiffer.Compare()`                   | Compare HTML documents                      |
-| `Measure-HTMLDocument`       | `HtmlParser.AnalyzeDocument()`           | Analyze document metrics                    |
-
-### Resource Formatting & Optimization
-| PowerShell Cmdlet     | C# Method                            | Description                        |
-| --------------------- | ------------------------------------ | ---------------------------------- |
-| `Format-HTML`         | `HtmlFormatter.FormatHtml()`         | Pretty-print HTML markup           |
-| `Format-CSS`          | `HtmlFormatter.FormatCss()`          | Format CSS stylesheets             |
-| `Format-JavaScript`   | `HtmlFormatter.FormatJavaScript()`   | Beautify JavaScript with options   |
-| `Optimize-HTML`       | `HtmlOptimizer.OptimizeHtml()`       | Minify HTML content                |
-| `Optimize-CSS`        | `HtmlOptimizer.OptimizeCss()`        | Minify CSS stylesheets             |
-| `Optimize-JavaScript` | `HtmlOptimizer.OptimizeJavaScript()` | Minify JavaScript code             |
-| `Optimize-Email`      | `PreMailerClient.MoveCssInline()`    | Inline CSS for email compatibility |
-| `Select-CssRule`      | `HtmlCssQueryParser.SelectRules()`   | Query CSS rules by selector        |
-| `Select-CssDeclaration` | `HtmlCssQueryParser.SelectDeclarations()` | Query CSS declarations       |
-| `Get-CssVariable`     | `HtmlCssQueryParser.SelectVariables()` | Extract CSS custom properties    |
-| `ConvertFrom-CssUrl`  | `HtmlCssQueryParser.SelectUrls()`    | Extract and resolve CSS URLs       |
-| `Measure-CssSpecificity` | `HtmlCssQueryParser.MeasureSpecificity()` | Measure selector specificity |
-
-### Browser Automation & Sessions
-| PowerShell Cmdlet       | C# Method                          | Description                      |
-| ----------------------- | ---------------------------------- | -------------------------------- |
-| `Start-HtmlBrowserSession` | `HtmlBrowser.OpenSessionAsync()` | Create browser session           |
-| `Close-HtmlBrowserSession` | `session.DisposeAsync()`         | Close browser session            |
-| `Invoke-HtmlRendering`  | `HtmlBrowser.OpenSessionAsync()`   | Render pages with authentication |
-| `Invoke-HtmlBrowserNavigation` | `HtmlBrowser.NavigateAsync()` | Navigate to different URLs       |
-| `Invoke-HtmlBrowserScript` | `HtmlBrowser.ExecuteScriptAsync()` | Execute JavaScript in browser    |
-| `Invoke-HtmlBrowserDomScript` | `HtmlScriptRunner.ExecuteScript()` | Run JavaScript with AngleSharp   |
-| `Export-HtmlBrowserState` | `HtmlBrowser.ExportStateAsync()` | Save browser state               |
-| `Import-HtmlBrowserState` | `HtmlBrowser.ImportStateAsync()` | Restore browser state            |
-| `Export-HtmlBrowserSession` | `HtmlBrowser.ExportSessionAsync()` | Export session data              |
-| `Import-HtmlBrowserSession` | `HtmlBrowser.ImportSessionAsync()` | Import session data              |
-
-### Screenshots & Media
-| PowerShell Cmdlet          | C# Method                                | Description                     |
-| -------------------------- | ---------------------------------------- | ------------------------------- |
-| `Save-HtmlBrowserScreenshot` | `HtmlBrowser.SaveScreenshotAsync()`    | Capture page screenshots        |
-| `Save-HtmlBrowserPdf`     | `HtmlBrowser.SavePdfAsync()`             | Generate PDFs from pages        |
-| `Start-HtmlBrowserVideoCapture` | `HtmlBrowser.StartVideoRecordingAsync()` | Start recording browser session |
-| `Stop-HtmlBrowserVideoCapture` | `HtmlBrowser.StopVideoRecordingAsync()` | Stop video recording            |
-
-### Element Interaction
-| PowerShell Cmdlet      | C# Method                                    | Description                    |
-| ---------------------- | -------------------------------------------- | ------------------------------ |
-| `Invoke-HtmlBrowserClick` | `HtmlBrowser.ClickAsync()`                | Click elements                 |
-| `Set-HtmlBrowserInput` | `HtmlBrowser.SetInputAsync()`                | Set input field values         |
-| `Set-HtmlBrowserSelectOption` | `HtmlBrowser.SetSelectAsync()`       | Select dropdown options        |
-| `Set-HtmlBrowserChecked` | `HtmlBrowser.SetCheckedAsync()`            | Check/uncheck checkboxes       |
-| `Submit-HtmlBrowserForm` | `HtmlBrowser.SubmitFormAsync()`            | Submit forms                   |
-| `Get-HtmlBrowserInteractable` | `HtmlBrowser.GetInteractableElementsAsync()` | List clickable elements        |
-| `Get-HtmlBrowserFormField` | `HtmlFormExtractor.GetFormFields()`      | Extract form field information |
-| `Get-HtmlBrowserLoginForm` | `HtmlFormExtractor.DetectLoginForms()`   | Detect login forms             |
-
-### Network & Debugging
-| PowerShell Cmdlet      | C# Method                            | Description                     |
-| ---------------------- | ------------------------------------ | ------------------------------- |
-| `Get-HtmlBrowserNetworkLog` | `HtmlBrowser.GetNetworkLog()`  | View network requests/responses |
-| `Get-HtmlBrowserConsoleLog` | `HtmlBrowser.GetConsoleLog()`  | Retrieve console messages       |
-| `Export-HtmlBrowserHar` | `HtmlBrowser.SaveHarAsync()`         | Export network traffic to HAR   |
-| `Start-HtmlBrowserTracing` | `HtmlBrowser.StartTracingAsync()` | Start Playwright tracing        |
-| `Stop-HtmlBrowserTracing` | `HtmlBrowser.StopTracingAsync()` | Stop tracing and save           |
-| `Register-HtmlRoute`   | `HtmlBrowser.RegisterRouteAsync()`   | Intercept requests              |
-| `Unregister-HtmlRoute` | `HtmlBrowser.UnregisterRouteAsync()` | Remove route handler            |
-| `Show-HtmlBrowserHar`  | `HtmlHarViewer.ShowHar()`            | Visualize HAR files             |
-
-### Browser Testing
-| PowerShell Cmdlet        | C# Method                                    | Description                                     |
-| ------------------------ | -------------------------------------------- | ----------------------------------------------- |
-| `Test-HtmlBrowser`       | `HtmlBrowserTester.TestUrlAsync()`           | Comprehensive browser testing                   |
-| `Test-HtmlBrowser`       | `HtmlBrowserTester.TestFileAsync()`          | Test local HTML file (with -Path)               |
-| `Test-HtmlBrowser`       | `HtmlBrowserTester.TestCssResourceAsync()`   | Test specific CSS resource (with -CssResource)  |
-| `Test-HtmlBrowser`       | `HtmlBrowserTester.TestConsoleErrorsAsync()` | Get console errors (with -ErrorsOnly)           |
-| `Test-HtmlBrowser`       | `HtmlBrowserTester.TestPerformanceAsync()`   | Get performance metrics (with -PerformanceOnly) |
-| `Clear-HtmlBrowserCache` | `HtmlBrowserCacheCleaner.CleanAllCache()`    | Clean Playwright browser downloads              |
-
-### Cookies & State
-| PowerShell Cmdlet | C# Method                       | Description              |
-| ----------------- | ------------------------------- | ------------------------ |
-| `Get-HtmlBrowserCookie` | `HtmlBrowser.GetCookiesAsync()` | Retrieve session cookies |
-| `Set-HtmlBrowserCookie` | `HtmlBrowser.SetCookieAsync()`  | Add cookies to session   |
-| `New-HtmlBrowserCookie` | `new HtmlCookie()`              | Create cookie objects    |
-
-### Content & Resources
-| PowerShell Cmdlet          | C# Method                               | Description                   |
-| -------------------------- | --------------------------------------- | ----------------------------- |
-| `Get-HTMLResource`         | `HtmlResourceParser.ExtractResources()` | Extract scripts and CSS       |
-| `Select-HtmlScript`        | `HtmlWorkflowParser.SelectScripts()`    | Select script tags by real JS type rules |
-| `Select-HtmlAsset`         | `HtmlWorkflowParser.SelectAssets()`     | Extract scripts, stylesheets, images, preloads, manifests, and icons |
-| `Measure-HtmlCompatibility` | `HtmlWorkflowParser.MeasureCompatibility()` | Find common HTML compatibility issues |
-| `Invoke-HTMLCrawl`         | `HtmlCrawler.CrawlAsync()`              | Crawl a site offline          |
-| `Save-HtmlBrowserAttachment` | `HtmlBrowser.SaveAttachmentsAsync()`  | Download files from pages     |
-| `Get-HtmlBrowserContent`  | `HtmlBrowser.GetContentAsync()`         | Retrieve page content         |
-| `Export-HTMLOutline`       | `HtmlOutlineBuilder.BuildOutline()`     | Generate document outlines    |
-| `Set-HTMLHttpClientOption` | `HttpClientFactory.ConfigureClient()`   | Configure HTTP client options |
+| Task | PowerShell | C# owner |
+| --- | --- | --- |
+| Parse a document | `ConvertFrom-Html` | `HtmlParser.ParseWithAngleSharp`, `HtmlParser.ParseWithHtmlAgilityPack` |
+| Extract tables | `ConvertFrom-HtmlTable` | `HtmlParser.ParseTablesWithAngleSharpDetailed`, `HtmlParser.ParseTablesWithHtmlAgilityPackDetailed` |
+| Extract lists | `ConvertFrom-HtmlList` | `HtmlParser.ParseListsWithAngleSharpDetailed`, `HtmlParser.ParseListsWithHtmlAgilityPackDetailed` |
+| Extract forms | `ConvertFrom-HtmlForm` | `HtmlParser.ParseFormsWithAngleSharp` |
+| Extract metadata | `ConvertFrom-HtmlMeta` | `HtmlParser.ParseMetaTags` |
+| Extract Open Graph data | `ConvertFrom-HtmlOpenGraph` | `HtmlParser.ParseOpenGraph` |
+| Extract microdata | `ConvertFrom-HtmlMicrodata` | `HtmlParser.ParseMicrodataItems` |
+| Normalize mixed page data | `Select-HtmlData` | `HtmlParsingToolbox.SelectData` |
+| Build a page workbench and audit | `Invoke-HtmlPageWorkbench` | `HtmlPageWorkbench.AnalyzeAsync`, `HtmlDocumentAudit.Analyze` |
+| Find interaction surfaces | `Find-HtmlInteractionSurface` | `HtmlParsingToolbox.FindInteractionSurfaceAsync` |
+| Discover API endpoints | `Find-HtmlApiEndpoint` | `HtmlApiEndpointInventory.Build` |
+| Compare static and rendered HTML | `Compare-HtmlStaticRendered` | `HtmlParsingToolbox.CompareStaticRendered` |
+| Crawl and export a dataset | `Invoke-HtmlCrawl` | `HtmlCrawler.CrawlAsync` |
+| Open or navigate a browser | `Start-HtmlBrowserSession`, `Invoke-HtmlBrowserNavigation` | `HtmlBrowser.OpenSessionAsync`, `HtmlBrowser.NavigateAsync` |
+| Click or fill an element | `Invoke-HtmlBrowserClick`, `Set-HtmlBrowserInput` | `HtmlBrowser.ClickSelectorAsync`, `HtmlBrowser.FillInputAsync` |
+| Capture a screenshot or PDF | `Save-HtmlBrowserScreenshot`, `Save-HtmlBrowserPdf` | `HtmlBrowser.CaptureScreenshotAsync`, `HtmlBrowser.SavePagePdfAsync` |
+| Export HAR or trace data | `Export-HtmlBrowserHar`, `Start-HtmlBrowserTracing`, `Stop-HtmlBrowserTracing` | `HtmlBrowser.ExportHarAsync`, `HtmlBrowser.StartTracingAsync`, `HtmlBrowser.StopTracingAsync` |
+| Test a rendered page | `Test-HtmlBrowser` | `HtmlBrowserTester` |
+| Inline email CSS | `Optimize-Email` | `PreMailerClient.MoveCssInline`, `PreMailerClient.MoveCssInlineAsync` |
+| Format or minify resources | `Format-Html`, `Format-Css`, `Format-JavaScript`, `Optimize-*` | `HtmlFormatter`, `HtmlOptimizer` |
 
 ## 📦 Installation & Packages
 
@@ -163,11 +81,14 @@ dotnet add package HtmlTinkerX
 Install-Module -Name PSParseHTML -AllowClobber -Force
 ```
 
+These commands install the current stable releases. Upstream dependency version
+labels do not change HtmlTinkerX or PSParseHTML release channels.
+
 ### 📋 Package Information
 - **📦 NuGet Package**: `HtmlTinkerX` - Core .NET library
 - **🔧 PowerShell Module**: `PSParseHTML` - PowerShell cmdlets wrapper
-- **🎯 Target Frameworks**: .NET Framework 4.7.2, .NET Standard 2.0, .NET 8.0
-- **💻 PowerShell Compatibility**: Windows PowerShell 5.1+ and PowerShell Core 6.0+
+- **🎯 Target Frameworks**: .NET Framework 4.7.2, .NET 8.0, and .NET 10.0
+- **💻 PowerShell Compatibility**: Windows PowerShell 5.1 and PowerShell 7.4+
 
 ## 🚀 Quick Start
 
@@ -178,14 +99,15 @@ using HtmlTinkerX;
 // Parse HTML and extract tables
 string html = await File.ReadAllTextAsync("page.html");
 var tables = HtmlParser.ParseTablesWithAngleSharp(html);
+HtmlDocumentAuditResult audit = HtmlDocumentAudit.Analyze(html);
 
 // Format and optimize resources
 string formatted = HtmlFormatter.FormatHtml(html);
-string minified = HtmlOptimizer.OptimizeHtml(html);
+string minified = HtmlOptimizer.OptimizeHtml(html, cssDecodeEscapes: false);
 
 // Browser automation
 await using var session = await HtmlBrowser.OpenSessionAsync("https://example.com");
-await HtmlBrowser.SaveScreenshotAsync(session, "screenshot.png");
+await HtmlBrowser.CaptureScreenshotAsync(session.Page, "screenshot.png");
 
 // Offline crawl
 var crawl = await HtmlCrawler.CrawlAsync("https://example.com/docs", new HtmlCrawlOptions {
@@ -1144,7 +1066,7 @@ var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(html);
 var tables2 = HtmlParser.ParseTablesWithHtmlAgilityPack(html);
 
 // Parse from URLs
-var urlDoc = await HtmlParser.ParseFromUrlAsync("https://example.com");
+var urlDoc = await HtmlParser.ParseUrlWithAngleSharpAsync("https://example.com");
 ```
 
 #### HtmlFormatter
@@ -1168,12 +1090,15 @@ string formatted = await HtmlFormatter.FormatHtmlAsync(html);
 #### HtmlOptimizer
 ```csharp
 // Minify resources
-string minifiedHtml = HtmlOptimizer.OptimizeHtml(html);
+string minifiedHtml = HtmlOptimizer.OptimizeHtml(html, cssDecodeEscapes: false);
 string minifiedCss = HtmlOptimizer.OptimizeCss(css);
 string minifiedJs = HtmlOptimizer.OptimizeJavaScript(javascript);
 
 // File operations
-await HtmlOptimizer.OptimizeHtmlFileAsync("input.html", "output.html");
+string optimizedFile = await HtmlOptimizer.OptimizeHtmlFileAsync(
+    "input.html",
+    cssDecodeEscapes: false);
+await File.WriteAllTextAsync("output.html", optimizedFile);
 ```
 
 #### HtmlBrowser (Browser Automation)
@@ -1181,48 +1106,62 @@ await HtmlOptimizer.OptimizeHtmlFileAsync("input.html", "output.html");
 // Create browser sessions
 await using var session = await HtmlBrowser.OpenSessionAsync("https://example.com");
 
-// Authentication
-var credentials = new NetworkCredential("user", "pass");
+// Form-based authentication
+var formLogin = new HtmlFormLogin
+{
+    LoginUrl = "https://example.com/login",
+    UsernameSelector = "#username",
+    PasswordSelector = "#password",
+    SubmitSelector = "button[type='submit']"
+};
 await using var authSession = await HtmlBrowser.OpenSessionAsync(
     "https://example.com/protected",
-    credential: credentials,
-    loginUrl: "https://example.com/login"
+    username: "user",
+    password: "pass",
+    formLogin: formLogin
 );
 
 // Screenshots
-await HtmlBrowser.SaveScreenshotAsync(session, "screenshot.png");
-await HtmlBrowser.SaveScreenshotAsync(session, "full.png", fullPage: true);
+await HtmlBrowser.CaptureScreenshotAsync(session.Page, "screenshot.png");
+await HtmlBrowser.CaptureScreenshotAsync(
+    session.Page,
+    "full.png",
+    new ScreenshotOptions { FullPage = true });
 
 // PDF generation
-await HtmlBrowser.SavePdfAsync(session, "document.pdf");
+await HtmlBrowser.SavePagePdfAsync(session.Page, "document.pdf");
 
 // Navigation
 await HtmlBrowser.NavigateAsync(session, "https://example.com/page2");
 
 // JavaScript execution
-var result = await HtmlBrowser.ExecuteScriptAsync(session, "return document.title;");
+string? title = await HtmlBrowser.EvaluateAsync<string>(session, "document.title");
 
 // Element interaction
-await HtmlBrowser.ClickAsync(session, "#button");
-await HtmlBrowser.SetInputAsync(session, "#username", "user");
-await HtmlBrowser.SubmitFormAsync(session, "#loginForm");
+await HtmlBrowser.ClickSelectorAsync(session, "#button");
+await HtmlBrowser.FillInputAsync(session, "#username", "user");
+await HtmlBrowser.ClickSelectorAsync(session, "#loginForm button[type='submit']");
 ```
 
 #### HtmlUtilities
 ```csharp
 // Convert HTML to plain text
-string plainText = HtmlUtilities.ConvertToText(html);
+string plainText = HtmlParserToText.ConvertToText(html);
 
 // HTTP client operations
-using var httpClient = HttpClientFactory.CreateHttpClient();
+HttpClient httpClient = HtmlHttpClientFactory.Shared;
 string content = await httpClient.GetStringAsync("https://example.com");
 ```
 
 #### PreMailerClient
 ```csharp
 // Email optimization
-string inlinedCss = PreMailerClient.MoveCssInline(emailHtml);
-string optimized = await PreMailerClient.MoveCssInlineAsync(emailHtml, downloadRemoteCss: true);
+PreMailerResult inlineResult = PreMailerClient.MoveCssInline(emailHtml, new PreMailerOptions());
+string inlinedHtml = inlineResult.Html;
+
+var preMailerOptions = new PreMailerOptions { DownloadRemoteCss = true };
+PreMailerResult remoteCssResult = await PreMailerClient.MoveCssInlineAsync(emailHtml, preMailerOptions);
+string optimized = remoteCssResult.Html;
 ```
 
 ### Extension Methods
@@ -1230,9 +1169,9 @@ string optimized = await PreMailerClient.MoveCssInlineAsync(emailHtml, downloadR
 #### HtmlParserExtensions
 ```csharp
 // Quick element queries
-var elements = doc.GetElements("div.class-name");
-var byId = doc.GetElements("#element-id");
-var byTag = doc.GetElements("p");
+var elements = HtmlParserExtensions.GetElements(html, className: "class-name");
+var byId = HtmlParserExtensions.GetElements(html, id: "element-id");
+var byTag = HtmlParserExtensions.GetElements(html, tag: "p");
 ```
 
 ## 📚 Examples
@@ -1299,6 +1238,7 @@ Close-HtmlBrowserSession -Session $session
 
 #### Document Processing
 ```csharp
+using AngleSharp.Dom;
 using HtmlTinkerX;
 
 // Parse and process HTML
@@ -1306,15 +1246,15 @@ string html = await File.ReadAllTextAsync("document.html");
 var document = HtmlParser.ParseWithAngleSharp(html);
 
 // Extract specific elements
-var links = document.GetElements("a[href]");
-var images = document.GetElements("img[src]");
+var links = document.QuerySelectorAll("a[href]");
+var images = document.QuerySelectorAll("img[src]");
 
 // Extract tables with detailed information
 var tables = HtmlParser.ParseTablesWithAngleSharpDetailed(html);
 foreach (var table in tables)
 {
-    Console.WriteLine($"Table has {table.Rows.Count} rows and {table.Headers.Count} columns");
-    foreach (var row in table.Rows)
+    Console.WriteLine($"Table has {table.Metadata.RowCount} rows and {table.Metadata.ColumnCount} columns");
+    foreach (var row in table.Data)
     {
         Console.WriteLine(string.Join(" | ", row.Values));
     }
@@ -1337,13 +1277,15 @@ var jsOptions = new BeautifierOptions
 string formattedJs = HtmlFormatter.FormatJavaScript(javascript, jsOptions);
 
 // Minification
-string minifiedHtml = HtmlOptimizer.OptimizeHtml(html);
+string minifiedHtml = HtmlOptimizer.OptimizeHtml(html, cssDecodeEscapes: false);
 string minifiedCss = HtmlOptimizer.OptimizeCss(css);
 string minifiedJs = HtmlOptimizer.OptimizeJavaScript(javascript);
 
 // Email optimization
 string emailBody = await File.ReadAllTextAsync("newsletter.html");
-string inlined = await PreMailerClient.MoveCssInlineAsync(emailBody, downloadRemoteCss: true);
+var preMailerOptions = new PreMailerOptions { DownloadRemoteCss = true };
+PreMailerResult preMailerResult = await PreMailerClient.MoveCssInlineAsync(emailBody, preMailerOptions);
+string inlined = preMailerResult.Html;
 ```
 
 #### Browser Automation
@@ -1352,23 +1294,27 @@ string inlined = await PreMailerClient.MoveCssInlineAsync(emailBody, downloadRem
 await using var session = await HtmlBrowser.OpenSessionAsync("https://example.com");
 
 // Authenticated session
-var credentials = new NetworkCredential("username", "password");
+var formLogin = new HtmlFormLogin
+{
+    LoginUrl = "https://example.com/login",
+    UsernameSelector = "#username",
+    PasswordSelector = "#password",
+    SubmitSelector = "#login-button"
+};
 await using var authSession = await HtmlBrowser.OpenSessionAsync(
     "https://example.com/protected",
-    credential: credentials,
-    loginUrl: "https://example.com/login",
-    usernameSelector: "#username",
-    passwordSelector: "#password",
-    submitSelector: "#login-button"
+    username: "username",
+    password: "password",
+    formLogin: formLogin
 );
 
 // Interact with the page
-await HtmlBrowser.SetInputAsync(session, "#search", "query");
-await HtmlBrowser.ClickAsync(session, "#search-button");
+await HtmlBrowser.FillInputAsync(session, "#search", "query");
+await HtmlBrowser.ClickSelectorAsync(session, "#search-button");
 await Task.Delay(2000); // Wait for results
 
 // Capture results
-await HtmlBrowser.SaveScreenshotAsync(session, "results.png");
+await HtmlBrowser.CaptureScreenshotAsync(session.Page, "results.png");
 var consoleMessages = HtmlBrowser.GetConsoleLog(session);
 foreach (var message in consoleMessages)
 {
@@ -1376,8 +1322,10 @@ foreach (var message in consoleMessages)
 }
 
 // Download files
-var downloads = await HtmlBrowser.SaveAttachmentsAsync(session, "./downloads", ".pdf");
-Console.WriteLine($"Downloaded {downloads.Count} files");
+await foreach (string download in HtmlBrowser.SavePageDownloadsAsync(session.Page, "./downloads", ".pdf"))
+{
+    Console.WriteLine($"Downloaded {download}");
+}
 ```
 
 ## 🧪 Browser Testing & Network Monitoring
@@ -1855,14 +1803,11 @@ public async Task Page_Performance_Should_Meet_Thresholds()
     Assert.True(metrics.TotalLoadTime < TimeSpan.FromSeconds(5));
     Assert.True(metrics.TotalBytesTransferred < 5 * 1024 * 1024); // 5MB
     Assert.True(metrics.TotalRequests < 50);
-    Assert.All(metrics.RequestsByResourceType, kvp =>
-    {
-        if (kvp.Key == HtmlNetworkResourceType.Image)
-        {
-            Assert.True(kvp.Value.TotalSizeMB < 2,
-                $"Images exceed 2MB limit: {kvp.Value.TotalSizeMB:F2}MB");
-        }
-    });
+    metrics.ResourceBreakdown.TryGetValue(
+        HtmlNetworkResourceType.Image,
+        out int imageRequestCount);
+    Assert.True(imageRequestCount < 20,
+        $"Image request count exceeds limit: {imageRequestCount}");
 }
 ```
 
@@ -1884,14 +1829,14 @@ foreach (var (url, result) in urls.Zip(results))
 {
     Console.WriteLine($"\n{url}:");
     Console.WriteLine($"  Status: {(result.Passed ? "PASS" : "FAIL")}");
-    Console.WriteLine($"  Load Time: {result.PageLoadTime.TotalSeconds:F2}s");
+    Console.WriteLine($"  Load Time: {(result.PageLoadTime?.TotalSeconds ?? 0):F2}s");
     Console.WriteLine($"  Requests: {result.TotalRequests} ({result.FailedRequestCount} failed)");
     Console.WriteLine($"  Console: {result.ErrorCount} errors, {result.WarningCount} warnings");
 }
 
 // Find slowest page
-var slowest = results.OrderByDescending(r => r.PageLoadTime).First();
-Console.WriteLine($"\nSlowest page: {slowest.Url} ({slowest.PageLoadTime.TotalSeconds:F2}s)");
+var slowest = results.OrderByDescending(r => r.PageLoadTime ?? TimeSpan.Zero).First();
+Console.WriteLine($"\nSlowest page: {slowest.Url} ({(slowest.PageLoadTime?.TotalSeconds ?? 0):F2}s)");
 ```
 
 ### Test Result Properties
@@ -1964,7 +1909,7 @@ When you first use browser testing, Playwright automatically downloads required 
    - Shows progress: "Downloading Playwright driver... X% (Y MB/s)"
    - Thread-safe - prevents concurrent downloads
    - Subsequent runs use cached components - no re-download needed
-   - You can manually ensure browsers are installed using `HtmlBrowser.EnsureInstalledAsync()`
+   - You can manually ensure Chromium is installed using `HtmlBrowser.EnsureInstalledAsync(HtmlBrowserEngine.Chromium)`
 
 #### Linux: Avoiding sudo prompts
 On Linux, Playwright can also install OS-level dependencies when invoked with `--with-deps` (this typically requires root/sudo).
@@ -2152,7 +2097,7 @@ All dependencies are distributed under permissive licenses. Refer to each projec
 ## 📖 Documentation & Support
 
 - **📚 Examples**: Check the `Examples` folder for comprehensive usage samples
-- **🐛 Issues**: Report bugs and request features on [GitHub Issues](https://github.com/EvotecIT/PSParseHTML/issues)
+- **🐛 Issues**: Report bugs and request features on [GitHub Issues](https://github.com/EvotecIT/HtmlTinkerX/issues)
 - **💬 Discord**: Join our [Discord community](https://evo.yt/discord) for support and discussions
 - **📝 Blog**: Read detailed tutorials on [evotec.xyz](https://evotec.xyz/hub)
 
@@ -2165,7 +2110,7 @@ Update-Module -Name PSParseHTML
 
 ### NuGet Package Updates
 ```bash
-dotnet add package HtmlTinkerX --version latest
+dotnet add package HtmlTinkerX
 ```
 
 **⚠️ Important**: Always test updates in a development environment before deploying to production. Breaking changes may occur between versions.
@@ -2186,41 +2131,10 @@ dotnet add package HtmlTinkerX --version latest
 
 ### Jint and JavaScript Parser Notes
 
-HtmlTinkerX uses Jint for JavaScript execution support. Jint 4.x uses Acornima as its parser; older Jint 3.x builds used Esprima. Use Acornima examples and type names when working with JavaScript AST objects in current HtmlTinkerX builds.
-
-You may see warnings about conflicting Jint versions when building for .NET Framework 4.7.2:
-
-```
-warning MSB3277: Found conflicts between different versions of "Jint" that could not be resolved.
-There was a conflict between "Jint, Version=3.1.6.0" and "Jint, Version=4.1.0.0"
-```
-
-**Why this happens:**
-- HtmlTinkerX references Jint directly
-- AngleSharp.Js 1.0.0-beta.43 (a dependency) was compiled against a different version
-- This is a known issue with prerelease packages
-
-**Impact:**
-- The warning only affects .NET Framework 4.7.2 builds
-- .NET 8.0 and .NET Standard 2.0 builds are not affected
-- The library will still work correctly when binding redirects resolve the runtime version consistently
-
-**Solutions:**
-1. **Ignore the warning** - It doesn't affect functionality
-2. **Target only modern frameworks** - Use .NET 8.0 or .NET Standard 2.0
-3. **Add binding redirect** in your app.config (for .NET Framework apps):
-   ```xml
-   <configuration>
-     <runtime>
-       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-         <dependentAssembly>
-           <assemblyIdentity name="Jint" publicKeyToken="2e92ba9c8d81157f" />
-           <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="3.1.6.0" />
-         </dependentAssembly>
-       </assemblyBinding>
-     </runtime>
-   </configuration>
-   ```
+Current builds use Jint 4.x and Acornima for JavaScript parsing. Older examples
+that reference Esprima or Jint 3.x types do not match the current API; use the
+Acornima types exposed by `ConvertFrom-JavaScriptAst` and
+`Select-JavaScriptAstNode`.
 
 ### Browser Testing Issues
 
@@ -2258,10 +2172,5 @@ If browser tests fail:
 
 ## 📄 License
 
-Copyright (c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.
-
-This project and its dependencies are distributed under various permissive licenses. See individual dependency repositories for specific license terms.
-
----
-
-*Built with ❤️ by [Evotec](https://evotec.xyz) - Making web content processing simple and powerful.*
+HtmlTinkerX and PSParseHTML are available under the [MIT License](LICENSE).
+Third-party components remain under their own license terms.

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <Version>2.1.0-beta.1</Version>
+        <VersionPrefix>2.0.21</VersionPrefix>
         <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
         <AssemblyName>HtmlTinkerX</AssemblyName>
         <AssemblyTitle>HtmlTinkerX</AssemblyTitle>

--- a/Sources/HtmlTinkerX/README.md
+++ b/Sources/HtmlTinkerX/README.md
@@ -5,11 +5,10 @@ HtmlTinkerX is a .NET library for parsing and inspecting HTML, CSS, and JavaScri
 ## Install
 
 ```shell
-dotnet add package HtmlTinkerX --version 2.1.0-beta.2
+dotnet add package HtmlTinkerX
 ```
 
-HtmlTinkerX 2.1.0-beta.2 consumes prerelease AngleSharp CSS and JavaScript
-integration packages. Pin the HtmlTinkerX version when reproducible restores matter.
+Pin a stable HtmlTinkerX version when reproducible restores matter.
 
 ## Parse HTML
 
@@ -108,5 +107,5 @@ The crawler restricts requests to the starting host, honors `robots.txt`, and us
 
 See the [repository](https://github.com/EvotecIT/HtmlTinkerX) for PowerShell examples, browser automation, API discovery, SSO handoff analysis, and package documentation.
 
-Copyright (c) 2011-2026 Przemyslaw Klys, Evotec. All rights reserved. See the
-LICENSE file included in this package.
+HtmlTinkerX is available under the MIT License. See the LICENSE file included
+in the package.


### PR DESCRIPTION
## Summary

- restores the useful README coverage and corrects examples against the current public APIs
- removes the accidental beta-release guidance and returns HtmlTinkerX and PSParseHTML to normal stable versioning
- aligns the package README, dependency guidance, module manifest, and generated help with the next stable releases
- corrects the interactable-elements, form-login, PreMailer, performance, and browser-installation examples

## Release state

The accidentally published HtmlTinkerX `2.1.0-beta.1` and PSParseHTML `2.1.0-beta1` packages have been unlisted. The existing stable packages remain listed.

## Validation

- unsigned manifest and normal build modes completed successfully
- package payload and generated Markdown/MAML help parity were verified
- corrected README C# snippets compile against the current HtmlTinkerX project
- independent local review completed on the exact pushed commit