### PR TITLE
Align HtmlTinkerX with OfficeIMO Markdown 3.0

### DIFF
--- a/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
+++ b/Sources/HtmlTinkerX/HtmlMarkdownConverterAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Html;
 using OfficeIMO.Markdown;
 using OfficeIMO.Markdown.Html;
 
@@ -16,7 +17,7 @@ internal static class HtmlMarkdownConverterAdapter {
         }
 
         var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode, markdownProfile);
-        return html.LoadFromHtml(options);
+        return HtmlConversionDocument.Parse(html).ToMarkdownDocument(options);
     }
 
     public static string ConvertToMarkdown(
@@ -30,7 +31,7 @@ internal static class HtmlMarkdownConverterAdapter {
         }
 
         var options = CreateOptions(pageUrl, imageMode, listingCardMetadataMode, markdownProfile);
-        return html.LoadFromHtml(options).ToMarkdown(options.MarkdownWriteOptions);
+        return HtmlConversionDocument.Parse(html).ToMarkdown(options);
     }
 
     internal static HtmlToMarkdownOptions CreateOptions(

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>2.2.0</VersionPrefix>
+        <VersionPrefix>2.2.1</VersionPrefix>
         <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
         <AssemblyName>HtmlTinkerX</AssemblyName>
         <AssemblyTitle>HtmlTinkerX</AssemblyTitle>
@@ -18,7 +18,7 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OfficeImoMarkdownHtmlVersion>0.1.13</OfficeImoMarkdownHtmlVersion>
+        <OfficeImoMarkdownHtmlVersion>3.0.2</OfficeImoMarkdownHtmlVersion>
         <ChartForgeXVersion>0.1.6</ChartForgeXVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- upgrades HtmlTinkerX to 2.2.1 and aligns its HTML-to-Markdown owner with OfficeIMO.Markdown.Html 3.0.2
- migrates conversion through `HtmlConversionDocument`, preserving profiles, image rendering, listing-card metadata, and base-URI handling
- removes the mixed OfficeIMO 0.x/3.x dependency graph that could compile successfully and fail at runtime
- keeps PSParseHTML and downstream products on the same shared parser/conversion implementation

## Release note

Publish HtmlTinkerX 2.2.1 and PSParseHTML 2.2.1 from this head before downstream consumers switch their locked restores to the public package.

## Validation

- focused HTML-to-Markdown contracts: 40/40 on net472, 40/40 on net8, and 40/40 on net10
- full HtmlTinkerX suite: 844 passed / 2 skipped on net472, 848/848 on net8, and 848/848 on net10
- independent review and targeted confirmation found no remaining parser, option-propagation, or package-graph issues