### PR TITLE
Remove redundant XmlDoc2CmdletDoc dependency

### DIFF
--- a/Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj
+++ b/Sources/PSParseHTML.PowerShell/PSParseHTML.PowerShell.csproj
@@ -48,18 +48,6 @@
     </Target>
 
     <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml" DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml" Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
-    </Target>
-
-    <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 


### PR DESCRIPTION
PowerForge already generates binary cmdlet Markdown and external MAML through this repository's existing documentation configuration and NETBinaryModuleDocumentation setting.

This removes the redundant MatejKafka.XmlDoc2CmdletDoc package and its package-specific dll-Help.xml copy target. Compiler XML generation remains enabled for PowerForge enrichment; no public API or cmdlet behavior changes.