### PR TITLE
Fix automatic Playwright driver provisioning

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserDriverPackageTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserDriverPackageTests.cs
@@ -1,0 +1,199 @@
+using HtmlTinkerX;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+[Collection("Playwright collection")]
+public class HtmlBrowserDriverPackageTests
+{
+    [Fact]
+    public void GetSafeExtractionPath_RejectsCaseVariantSiblingEscapeOnCaseSensitivePlatforms()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "playwright-root");
+        Assert.Throws<InvalidDataException>(() =>
+            HtmlBrowser.GetSafeExtractionPath(root, "../PLAYWRIGHT-ROOT/escaped"));
+    }
+
+    [Fact]
+    public async Task AcquireInstallationFileLockAsync_SerializesIndependentCallers()
+    {
+        using FileStream firstLock = await HtmlBrowser.AcquireInstallationFileLockAsync();
+        Task<FileStream> secondLockTask = Task.Run(async () =>
+            await HtmlBrowser.AcquireInstallationFileLockAsync());
+
+        await Task.Delay(200);
+        Assert.False(secondLockTask.IsCompleted);
+
+        firstLock.Dispose();
+        Task completedTask = await Task.WhenAny(secondLockTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(secondLockTask, completedTask);
+        using FileStream secondLock = await secondLockTask;
+        Assert.True(secondLock.CanWrite);
+    }
+
+    [Fact]
+    public async Task CleanInstallationAsync_WaitsForActiveInstallerBeforeDeletingSharedRoots()
+    {
+        string tempBrowsers = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", tempBrowsers);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            Directory.CreateDirectory(tempBrowsers);
+            Directory.CreateDirectory(tempDriver);
+
+            using FileStream installationLock = await HtmlBrowser.AcquireInstallationFileLockAsync();
+            Task cleanTask = Task.Run(async () => await HtmlBrowser.CleanInstallationAsync());
+
+            await Task.Delay(200);
+            Assert.False(cleanTask.IsCompleted);
+            Assert.True(Directory.Exists(tempBrowsers));
+            Assert.True(Directory.Exists(tempDriver));
+
+            installationLock.Dispose();
+            Task completedTask = await Task.WhenAny(cleanTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(cleanTask, completedTask);
+            await cleanTask;
+            Assert.False(Directory.Exists(tempBrowsers));
+            Assert.False(Directory.Exists(tempDriver));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalBrowsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempBrowsers)) Directory.Delete(tempBrowsers, true);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    [Fact]
+    public async Task CleanCache_WaitsForActiveInstallerBeforeDeletingSelectedLocation()
+    {
+        string tempCache = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempCache);
+
+        try
+        {
+            var location = new HtmlBrowserCacheCleaner.CacheLocation { Path = tempCache };
+            using FileStream installationLock = await HtmlBrowser.AcquireInstallationFileLockAsync();
+            Task<HtmlBrowserCacheCleaner.CleanResult> cleanTask = Task.Run(() =>
+                HtmlBrowserCacheCleaner.CleanCache(new[] { location }));
+
+            await Task.Delay(200);
+            Assert.False(cleanTask.IsCompleted);
+            Assert.True(Directory.Exists(tempCache));
+
+            installationLock.Dispose();
+            Task completedTask = await Task.WhenAny(cleanTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(cleanTask, completedTask);
+            HtmlBrowserCacheCleaner.CleanResult result = await cleanTask;
+            Assert.True(result.Success);
+            Assert.False(Directory.Exists(tempCache));
+        }
+        finally
+        {
+            if (Directory.Exists(tempCache)) Directory.Delete(tempCache, true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureDriverInstalledAsync_DownloadsMatchingOfficialPackageWhenBundledDriverIsMissing()
+    {
+        string tempDriver = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        var originalFactory = HtmlBrowser.HttpClientFactory;
+        var handler = new FakeHandler(CreateDriverPackage());
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", tempDriver);
+            HtmlBrowser.HttpClientFactory = () => new HttpClient(handler, disposeHandler: false);
+
+            await HtmlBrowser.EnsureDriverInstalledAsync();
+
+            string version = typeof(Microsoft.Playwright.Playwright).Assembly.GetName().Version?.ToString(3) ?? "1.52.0";
+            Assert.Equal(
+                $"https://api.nuget.org/v3-flatcontainer/microsoft.playwright/{version}/microsoft.playwright.{version}.nupkg",
+                handler.LastRequestUri?.AbsoluteUri);
+            Assert.True(HtmlBrowser.HasDriverLayout(Path.Combine(tempDriver, ".playwright")));
+            Assert.Equal(version, File.ReadAllText(Path.Combine(tempDriver, ".playwright", ".version")));
+        }
+        finally
+        {
+            HtmlBrowser.HttpClientFactory = originalFactory;
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", originalDriverPath);
+            if (Directory.Exists(tempDriver)) Directory.Delete(tempDriver, true);
+        }
+    }
+
+    private static byte[] CreateDriverPackage()
+    {
+        using var memory = new MemoryStream();
+        using (var archive = new ZipArchive(memory, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            string nodeFile = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
+            string platformId = PlatformExtensions.GetCurrentPlatform().ToPlatformId();
+            using (var nodeStream = new StreamWriter(archive.CreateEntry($".playwright/node/{platformId}/{nodeFile}").Open()))
+            {
+                nodeStream.Write("node");
+            }
+
+            using (var licenseStream = new StreamWriter(archive.CreateEntry(".playwright/node/LICENSE").Open()))
+            {
+                licenseStream.Write("license");
+            }
+
+            using (var packageStream = new StreamWriter(archive.CreateEntry(".playwright/package/package.json").Open()))
+            {
+                packageStream.Write("{}");
+            }
+
+            using (var cliStream = new StreamWriter(archive.CreateEntry(".playwright/package/cli.js").Open()))
+            {
+                cliStream.Write("console.log('playwright');");
+            }
+
+            using (var browsersStream = new StreamWriter(archive.CreateEntry(".playwright/package/browsers.json").Open()))
+            {
+                browsersStream.Write("{\"browsers\":[]}");
+            }
+        }
+
+        return memory.ToArray();
+    }
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        private readonly byte[] _content;
+
+        public FakeHandler(byte[] content)
+        {
+            _content = content;
+        }
+
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(_content)
+            };
+            response.Content.Headers.ContentLength = _content.Length;
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserInstallerTests.cs
@@ -46,6 +46,30 @@ public class HtmlBrowserInstallerTests
     }
 
     [Fact]
+    public void HasDriverLayout_RejectsDriverWithoutPlaywrightCli()
+    {
+        string driverPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string nodeDir = Path.Combine(driverPath, "node", PlatformExtensions.GetCurrentPlatform().ToPlatformId());
+        string packageDir = Path.Combine(driverPath, "package");
+
+        try
+        {
+            Directory.CreateDirectory(nodeDir);
+            Directory.CreateDirectory(packageDir);
+            File.WriteAllText(
+                Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"),
+                "node");
+            File.WriteAllText(Path.Combine(packageDir, "browsers.json"), "{\"browsers\":[]}");
+
+            Assert.False(HtmlBrowser.HasDriverLayout(driverPath));
+        }
+        finally
+        {
+            if (Directory.Exists(driverPath)) Directory.Delete(driverPath, true);
+        }
+    }
+
+    [Fact]
     public async Task EnsureDriverInstalledAsync_UsesBundledDriverWithoutNetworkDownload()
     {
         string? originalDriverPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
@@ -482,10 +506,7 @@ public class HtmlBrowserInstallerTests
             Directory.CreateDirectory(runtimeDirectory);
             File.WriteAllText(Path.Combine(runtimeDirectory, "marker.txt"), "installed");
         };
-        HtmlBrowser.HttpClientFactory = () => new HttpClient(new FakeHandler(CreateDriverArchive()))
-        {
-            BaseAddress = new Uri("https://playwright.azureedge.net/")
-        };
+        HtmlBrowser.HttpClientFactory = () => new HttpClient(new FakeHandler(CreateDriverArchive()));
 
         try
         {
@@ -632,6 +653,7 @@ public class HtmlBrowserInstallerTests
         Directory.CreateDirectory(packageDir);
         File.WriteAllText(Path.Combine(nodeDir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node"), "node");
         File.WriteAllText(Path.Combine(packageDir, "package.json"), "{}");
+        File.WriteAllText(Path.Combine(packageDir, "cli.js"), "console.log('playwright');");
         File.WriteAllText(Path.Combine(packageDir, "browsers.json"), """
             {
               "browsers": [
@@ -666,22 +688,28 @@ public class HtmlBrowserInstallerTests
         using (var archive = new ZipArchive(memory, ZipArchiveMode.Create, leaveOpen: true))
         {
             string nodeFile = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
-            using (var nodeStream = new StreamWriter(archive.CreateEntry(nodeFile).Open()))
+            string platformId = PlatformExtensions.GetCurrentPlatform().ToPlatformId();
+            using (var nodeStream = new StreamWriter(archive.CreateEntry($".playwright/node/{platformId}/{nodeFile}").Open()))
             {
                 nodeStream.Write("node");
             }
 
-            using (var licenseStream = new StreamWriter(archive.CreateEntry("LICENSE").Open()))
+            using (var licenseStream = new StreamWriter(archive.CreateEntry(".playwright/node/LICENSE").Open()))
             {
                 licenseStream.Write("license");
             }
 
-            using (var packageStream = new StreamWriter(archive.CreateEntry("package/package.json").Open()))
+            using (var packageStream = new StreamWriter(archive.CreateEntry(".playwright/package/package.json").Open()))
             {
                 packageStream.Write("{}");
             }
 
-            using (var browsersStream = new StreamWriter(archive.CreateEntry("package/browsers.json").Open()))
+            using (var cliStream = new StreamWriter(archive.CreateEntry(".playwright/package/cli.js").Open()))
+            {
+                cliStream.Write("console.log('playwright');");
+            }
+
+            using (var browsersStream = new StreamWriter(archive.CreateEntry(".playwright/package/browsers.json").Open()))
             {
                 browsersStream.Write("""
                     {

--- a/Sources/HtmlTinkerX.Tests/PlatformExtensionsTests.cs
+++ b/Sources/HtmlTinkerX.Tests/PlatformExtensionsTests.cs
@@ -5,13 +5,12 @@ namespace HtmlTinkerX.Tests;
 
 public class PlatformExtensionsTests {
     [Theory]
-    [InlineData(HtmlPlatform.WindowsX64, "win32_x64", "win32_x64")]
-    [InlineData(HtmlPlatform.Mac, "darwin-x64", "mac")]
-    [InlineData(HtmlPlatform.MacArm64, "darwin-arm64", "mac-arm64")]
-    [InlineData(HtmlPlatform.LinuxX64, "linux-x64", "linux")]
-    [InlineData(HtmlPlatform.LinuxArm64, "linux-arm64", "linux-arm64")]
-    public void PlatformConversions_ReturnExpected(HtmlPlatform platform, string platformId, string downloadId) {
+    [InlineData(HtmlPlatform.WindowsX64, "win32_x64")]
+    [InlineData(HtmlPlatform.Mac, "darwin-x64")]
+    [InlineData(HtmlPlatform.MacArm64, "darwin-arm64")]
+    [InlineData(HtmlPlatform.LinuxX64, "linux-x64")]
+    [InlineData(HtmlPlatform.LinuxArm64, "linux-arm64")]
+    public void PlatformConversions_ReturnExpected(HtmlPlatform platform, string platformId) {
         Assert.Equal(platformId, platform.ToPlatformId());
-        Assert.Equal(downloadId, platform.ToDownloadPlatformId());
     }
 }

--- a/Sources/HtmlTinkerX/PlatformExtensions.cs
+++ b/Sources/HtmlTinkerX/PlatformExtensions.cs
@@ -25,12 +25,4 @@ internal static class PlatformExtensions {
         HtmlPlatform.LinuxArm64 => "linux-arm64",
         _ => "linux-x64"
     };
-
-    public static string ToDownloadPlatformId(this HtmlPlatform platform) => platform switch {
-        HtmlPlatform.WindowsX64 => "win32_x64",
-        HtmlPlatform.Mac => "mac",
-        HtmlPlatform.MacArm64 => "mac-arm64",
-        HtmlPlatform.LinuxArm64 => "linux-arm64",
-        _ => "linux"
-    };
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.DriverPackage.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.DriverPackage.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace HtmlTinkerX;
+
+/// <summary>
+/// Helper methods for retrieving HTML content using a headless browser.
+/// </summary>
+public static partial class HtmlBrowser {
+    private const long MaximumDriverPackageBytes = 512L * 1024 * 1024;
+    private const string PlaywrightPackageId = "microsoft.playwright";
+    private const string PlaywrightPackageBaseUrl = "https://api.nuget.org/v3-flatcontainer";
+    private static readonly TimeSpan InstallationLockTimeout = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Downloads the official Microsoft.Playwright package that matches the loaded assembly and installs only
+    /// the driver assets for the current platform. This is the fallback used when a host, such as a packaged
+    /// PowerShell module, does not preserve the SDK-copied <c>.playwright</c> output directory.
+    /// </summary>
+    private static async Task DownloadAndInstallDriverAsync() {
+        string packageUrl = GetDriverPackageUrl();
+        string packagePath = Path.Combine(Path.GetTempPath(), "playwright-driver-" + Guid.NewGuid().ToString("N") + ".nupkg");
+        string baseDir = GetDriverPath();
+        string driverRoot = Path.GetDirectoryName(baseDir) ?? GetDriverRoot();
+        string stagingDir = Path.Combine(driverRoot, ".playwright-install-" + Guid.NewGuid().ToString("N"));
+
+        try {
+            Directory.CreateDirectory(driverRoot);
+            await DownloadDriverPackageAsync(packageUrl, packagePath).ConfigureAwait(false);
+            ExtractCurrentPlatformDriver(packagePath, stagingDir);
+
+            if (!HasDriverLayout(stagingDir)) {
+                throw new InvalidDataException(
+                    $"Microsoft.Playwright {DriverVersion} did not contain a complete driver for platform '{PlatformId}'.");
+            }
+
+#if NETSTANDARD2_0 || NETFRAMEWORK
+            File.WriteAllText(Path.Combine(stagingDir, ".version"), DriverVersion);
+#else
+            await File.WriteAllTextAsync(Path.Combine(stagingDir, ".version"), DriverVersion).ConfigureAwait(false);
+#endif
+
+            if (Directory.Exists(baseDir)) {
+                Directory.Delete(baseDir, true);
+            }
+            Directory.Move(stagingDir, baseDir);
+            EnsureNodeExecutable(baseDir);
+        } catch {
+            CleanDriver();
+            throw;
+        } finally {
+            TryDeleteFile(packagePath);
+            TryDeleteDirectory(stagingDir);
+        }
+
+        EnsureDriverSearchPath();
+    }
+
+    private static string GetDriverPackageUrl() {
+        string version = DriverVersion.ToLowerInvariant();
+        return $"{PlaywrightPackageBaseUrl}/{PlaywrightPackageId}/{version}/{PlaywrightPackageId}.{version}.nupkg";
+    }
+
+    private static async Task DownloadDriverPackageAsync(string packageUrl, string destinationPath) {
+        using var client = HttpClientFactory();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("HtmlTinkerX/" + DriverVersion);
+
+        using var response = await client.GetAsync(packageUrl, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        long total = response.Content.Headers.ContentLength ?? -1L;
+        if (total > MaximumDriverPackageBytes) {
+            throw new InvalidDataException(
+                $"The Microsoft.Playwright package reported {total} bytes, exceeding the {MaximumDriverPackageBytes}-byte safety limit.");
+        }
+
+        using var source = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        using var destination = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+        var buffer = new byte[81920];
+        long read = 0;
+        int lastProgress = -1;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true) {
+            int count = await source.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+            if (count == 0) {
+                break;
+            }
+            if (read + count > MaximumDriverPackageBytes) {
+                throw new InvalidDataException(
+                    $"The Microsoft.Playwright package exceeded the {MaximumDriverPackageBytes}-byte safety limit while downloading.");
+            }
+
+            await destination.WriteAsync(buffer, 0, count).ConfigureAwait(false);
+            read += count;
+
+            if (total > 0) {
+                int progress = (int)(read * 100 / total);
+                if (progress != lastProgress) {
+                    double elapsedSeconds = Math.Max(stopwatch.Elapsed.TotalSeconds, 0.001d);
+                    double speed = read / 1024d / 1024d / elapsedSeconds;
+                    Console.Write($"\rDownloading Playwright driver... {progress}% ({speed:F1} MB/s)");
+                    lastProgress = progress;
+                }
+            }
+        }
+
+        Console.WriteLine();
+    }
+
+    private static void ExtractCurrentPlatformDriver(string packagePath, string destinationPath) {
+        string nodePrefix = ".playwright/node/" + PlatformId + "/";
+        const string nodeLicense = ".playwright/node/LICENSE";
+        const string packagePrefix = ".playwright/package/";
+        int extractedFiles = 0;
+
+        Directory.CreateDirectory(destinationPath);
+        using var archive = ZipFile.OpenRead(packagePath);
+        foreach (ZipArchiveEntry entry in archive.Entries) {
+            string entryPath = entry.FullName.Replace('\\', '/');
+            string? relativePath = null;
+
+            if (entryPath.StartsWith(nodePrefix, StringComparison.OrdinalIgnoreCase)) {
+                relativePath = "node/" + PlatformId + "/" + entryPath.Substring(nodePrefix.Length);
+            } else if (string.Equals(entryPath, nodeLicense, StringComparison.OrdinalIgnoreCase)) {
+                relativePath = "node/LICENSE";
+            } else if (entryPath.StartsWith(packagePrefix, StringComparison.OrdinalIgnoreCase)) {
+                relativePath = "package/" + entryPath.Substring(packagePrefix.Length);
+            }
+
+            if (relativePath is null || relativePath.Length == 0 || relativePath.EndsWith("/", StringComparison.Ordinal)) {
+                continue;
+            }
+
+            string destinationFile = GetSafeExtractionPath(destinationPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+            using var source = entry.Open();
+            using var destination = new FileStream(destinationFile, FileMode.Create, FileAccess.Write, FileShare.None);
+            source.CopyTo(destination);
+            extractedFiles++;
+        }
+
+        if (extractedFiles == 0) {
+            throw new InvalidDataException(
+                $"Microsoft.Playwright {DriverVersion} did not contain driver assets for platform '{PlatformId}'.");
+        }
+    }
+
+    internal static string GetSafeExtractionPath(string rootPath, string relativePath) {
+        string fullRoot = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                          + Path.DirectorySeparatorChar;
+        string destinationPath = Path.GetFullPath(Path.Combine(rootPath, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        // Archive containment must remain strict even on Windows because NTFS directories can opt into case sensitivity.
+        if (!destinationPath.StartsWith(fullRoot, StringComparison.Ordinal)) {
+            throw new InvalidDataException($"The Microsoft.Playwright package contains an unsafe entry path: '{relativePath}'.");
+        }
+        return destinationPath;
+    }
+
+    /// <summary>
+    /// Serializes driver and browser publication across independent host processes. The lock file is deliberately
+    /// outside both installation roots because repair can delete either root while holding the lock.
+    /// </summary>
+    internal static async Task<FileStream> AcquireInstallationFileLockAsync() {
+        string lockPath = GetInstallationLockPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true) {
+            try {
+                return new FileStream(
+                    lockPath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite,
+                    FileShare.None,
+                    bufferSize: 1,
+                    useAsync: true);
+            } catch (IOException exception) {
+                if (stopwatch.Elapsed >= InstallationLockTimeout) {
+                    throw new TimeoutException(
+                        $"Timed out waiting for another HtmlTinkerX Playwright installation to finish after {InstallationLockTimeout.TotalMinutes:F0} minutes.",
+                        exception);
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static string GetInstallationLockPath() {
+        string user = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string cacheRoot;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            cacheRoot = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            cacheRoot = Path.Combine(user, "Library", "Caches");
+        } else {
+            cacheRoot = Path.Combine(user, ".cache");
+        }
+
+        if (string.IsNullOrWhiteSpace(cacheRoot)) {
+            cacheRoot = Path.GetTempPath();
+        }
+
+        return Path.Combine(cacheRoot, "HtmlTinkerX", "playwright-install.lock");
+    }
+
+    private static void EnsureNodeExecutable(string driverPath) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            return;
+        }
+
+        string nodePath = Path.Combine(driverPath, "node", PlatformId, NodeExecutable);
+        try {
+            using Process? chmod = Process.Start("chmod", $"+x \"{nodePath}\"");
+            chmod?.WaitForExit();
+        } catch (InvalidOperationException) {
+            // Playwright will report an actionable launch error if the host cannot set executable permissions.
+        } catch (System.ComponentModel.Win32Exception) {
+            // Playwright will report an actionable launch error if chmod is unavailable.
+        }
+    }
+
+    private static void TryDeleteFile(string path) {
+        try {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        } catch (IOException) {
+            // Best-effort cleanup only.
+        } catch (UnauthorizedAccessException) {
+            // Best-effort cleanup only.
+        }
+    }
+
+    private static void TryDeleteDirectory(string path) {
+        try {
+            if (Directory.Exists(path)) {
+                Directory.Delete(path, true);
+            }
+        } catch (IOException) {
+            // Best-effort cleanup only.
+        } catch (UnauthorizedAccessException) {
+            // Best-effort cleanup only.
+        }
+    }
+}

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.Installer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -17,8 +16,6 @@ namespace HtmlTinkerX;
 /// </summary>
 public static partial class HtmlBrowser {
     private const string PlaywrightWithDepsEnvVar = "HTMLTINKERX_PLAYWRIGHT_WITH_DEPS";
-    private const long MaximumDriverArchiveBytes = 512L * 1024 * 1024;
-
     /// <summary>
     /// Semaphore to ensure thread-safe Playwright installation.
     /// Only one installation process can run at a time across all threads.
@@ -50,12 +47,10 @@ public static partial class HtmlBrowser {
     /// </summary>
     private static HtmlPlatform CurrentPlatform => PlatformExtensions.GetCurrentPlatform();
 
-    /// <summary>
-    /// Gets the platform identifier for downloading the Playwright driver.
-    /// </summary>
-    private static string DownloadPlatformId => CurrentPlatform.ToDownloadPlatformId();
-
     private static string NodeExecutable => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
+    private static StringComparison FileSystemPathComparison => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
 
     /// <summary>
     /// Gets the root directory for the Playwright driver installation.
@@ -139,12 +134,16 @@ public static partial class HtmlBrowser {
         string nodePath = Path.Combine(driverPath, "node", PlatformId, NodeExecutable);
         string packagePath = Path.Combine(driverPath, "package");
         string browsersManifestPath = Path.Combine(packagePath, "browsers.json");
-        if (!File.Exists(nodePath) || !Directory.Exists(packagePath) || !File.Exists(browsersManifestPath)) {
+        string cliPath = Path.Combine(packagePath, "cli.js");
+        if (!File.Exists(nodePath) || !Directory.Exists(packagePath) ||
+            !File.Exists(browsersManifestPath) || !File.Exists(cliPath)) {
             return false;
         }
 
         try {
-            return new FileInfo(nodePath).Length > 0 && IsValidBrowserManifest(browsersManifestPath);
+            return new FileInfo(nodePath).Length > 0 &&
+                   new FileInfo(cliPath).Length > 0 &&
+                   IsValidBrowserManifest(browsersManifestPath);
         } catch (IOException) {
             return false;
         } catch (UnauthorizedAccessException) {
@@ -170,7 +169,7 @@ public static partial class HtmlBrowser {
         return string.Equals(
             Path.GetFullPath(driverPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
             Path.GetFullPath(GetBundledDriverPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
-            StringComparison.OrdinalIgnoreCase);
+            FileSystemPathComparison);
     }
 
     /// <summary>
@@ -245,8 +244,6 @@ public static partial class HtmlBrowser {
     /// <param name="engine">The browser engine to ensure is installed.</param>
     /// <returns>A task that completes when the installation check/process is finished.</returns>
     public static async Task EnsureInstalledAsync(HtmlBrowserEngine engine) {
-        ValidateExistingInstallation(engine);
-
         // Fast path - check without lock first
         if (IsDriverPresent() && IsBrowserRuntimeInstalled(engine)) {
             EnsureDriverSearchPath();
@@ -255,6 +252,7 @@ public static partial class HtmlBrowser {
 
         await InstallationSemaphore.WaitAsync().ConfigureAwait(false);
         try {
+            using FileStream installationLock = await AcquireInstallationFileLockAsync().ConfigureAwait(false);
             ValidateExistingInstallation(engine);
 
             if (IsDriverPresent() && IsBrowserRuntimeInstalled(engine)) {
@@ -284,6 +282,7 @@ public static partial class HtmlBrowser {
     public static async Task RepairInstallationAsync(HtmlBrowserEngine engine) {
         await InstallationSemaphore.WaitAsync().ConfigureAwait(false);
         try {
+            using FileStream installationLock = await AcquireInstallationFileLockAsync().ConfigureAwait(false);
             CleanInstallDir();
             if (!IsDriverPresent()) {
                 await DownloadAndInstallDriverAsync().ConfigureAwait(false);
@@ -562,6 +561,16 @@ public static partial class HtmlBrowser {
         CleanDriver();
     }
 
+    internal static async Task CleanInstallationAsync() {
+        await InstallationSemaphore.WaitAsync().ConfigureAwait(false);
+        try {
+            using FileStream installationLock = await AcquireInstallationFileLockAsync().ConfigureAwait(false);
+            CleanInstallDir();
+        } finally {
+            InstallationSemaphore.Release();
+        }
+    }
+
     private static void CleanBrowserRuntime(HtmlBrowserEngine engine) {
         string path = GetBrowserInstallPath();
         if (!Directory.Exists(path))
@@ -594,10 +603,6 @@ public static partial class HtmlBrowser {
     /// </summary>
     /// <returns>A task that completes when the driver installation check/process is finished.</returns>
     internal static async Task EnsureDriverInstalledAsync() {
-        if (IsDriverCorrupted()) {
-            CleanDriver();
-        }
-
         if (IsDriverPresent()) {
             EnsureDriverSearchPath();
             return;
@@ -605,6 +610,7 @@ public static partial class HtmlBrowser {
 
         await InstallationSemaphore.WaitAsync().ConfigureAwait(false);
         try {
+            using FileStream installationLock = await AcquireInstallationFileLockAsync().ConfigureAwait(false);
             if (IsDriverCorrupted()) {
                 CleanDriver();
             }
@@ -644,132 +650,7 @@ public static partial class HtmlBrowser {
         Environment.SetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH", driverRoot);
     }
 
-    private static Func<HttpClient> DefaultHttpClientFactory => () => new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
-
-    private static async Task DownloadAndInstallDriverAsync() {
-        string urlBase = "https://playwright.azureedge.net/builds/driver";
-        if (DriverVersion.Contains("-alpha") || DriverVersion.Contains("-beta") || DriverVersion.Contains("-next"))
-            urlBase += "/next";
-        string url = $"{urlBase}/playwright-{DriverVersion}-{DownloadPlatformId}.zip";
-
-        using var client = HttpClientFactory();
-        client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
-
-        using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-
-        var total = response.Content.Headers.ContentLength ?? -1L;
-        if (total > MaximumDriverArchiveBytes) {
-            throw new InvalidDataException($"The Playwright driver archive reported {total} bytes, exceeding the {MaximumDriverArchiveBytes}-byte safety limit.");
-        }
-        using var mem = new MemoryStream();
-        var buffer = new byte[81920];
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        long read = 0;
-        int lastProgress = 0;
-        var sw = Stopwatch.StartNew();
-        while (true) {
-            int n = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
-            if (n == 0)
-                break;
-            if (mem.Length + n > MaximumDriverArchiveBytes) {
-                throw new InvalidDataException($"The Playwright driver archive exceeded the {MaximumDriverArchiveBytes}-byte safety limit while downloading.");
-            }
-            await mem.WriteAsync(buffer, 0, n).ConfigureAwait(false);
-            if (total > 0) {
-                read += n;
-                int progress = (int)(read * 100 / total);
-                if (progress != lastProgress) {
-                    double speed = read / 1024d / 1024d / sw.Elapsed.TotalSeconds;
-                    Console.Write($"\rDownloading Playwright driver... {progress}% ({speed:F1} MB/s)");
-                    lastProgress = progress;
-                }
-            }
-        }
-        Console.WriteLine();
-        mem.Position = 0;
-
-        string baseDir = GetDriverPath();
-        string tempDir = Path.Combine(Path.GetTempPath(), "pwdriver_" + Guid.NewGuid().ToString("N"));
-
-        try {
-            if (Directory.Exists(baseDir))
-                Directory.Delete(baseDir, true);
-
-            Directory.CreateDirectory(tempDir);
-
-            using (var archive = new ZipArchive(mem, ZipArchiveMode.Read, leaveOpen: true)) {
-                archive.ExtractToDirectory(tempDir);
-            }
-
-            Directory.CreateDirectory(Path.Combine(baseDir, "node", PlatformId));
-
-            string nodeDest = Path.Combine(baseDir, "node", PlatformId, NodeExecutable);
-            string nodeSource = Path.Combine(tempDir, NodeExecutable);
-            if (File.Exists(nodeDest))
-                File.Delete(nodeDest);
-            File.Move(nodeSource, nodeDest);
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                try {
-                    var chmod = Process.Start("chmod", $"+x \"{nodeDest}\"");
-                    chmod?.WaitForExit();
-                } catch {
-                    // ignore
-                }
-            }
-            string licenseDest = Path.Combine(baseDir, "node", "LICENSE");
-            if (File.Exists(licenseDest))
-                File.Delete(licenseDest);
-            File.Move(Path.Combine(tempDir, "LICENSE"), licenseDest);
-
-            string packageSrc = Path.Combine(tempDir, "package");
-            string packageDest = Path.Combine(baseDir, "package");
-            if (Directory.Exists(packageDest))
-                Directory.Delete(packageDest, true);
-            CopyDirectory(packageSrc, packageDest);
-
-#if NETSTANDARD2_0 || NETFRAMEWORK
-            File.WriteAllText(VersionFile, DriverVersion);
-#else
-            await File.WriteAllTextAsync(VersionFile, DriverVersion).ConfigureAwait(false);
-#endif
-        } catch {
-            try {
-                if (Directory.Exists(tempDir)) {
-                    Directory.Delete(tempDir, true);
-                }
-            } catch {
-                // ignore cleanup failure
-            }
-
-            CleanDriver();
-            throw;
-        } finally {
-            try {
-                if (Directory.Exists(tempDir)) {
-                    Directory.Delete(tempDir, true);
-                }
-            } catch {
-                // ignore cleanup failure
-            }
-        }
-
-        EnsureDriverSearchPath();
-    }
-
-    private static void CopyDirectory(string sourceDirectory, string destinationDirectory) {
-        Directory.CreateDirectory(destinationDirectory);
-
-        foreach (string file in Directory.GetFiles(sourceDirectory)) {
-            string destinationFile = Path.Combine(destinationDirectory, Path.GetFileName(file));
-            File.Copy(file, destinationFile, overwrite: true);
-        }
-
-        foreach (string directory in Directory.GetDirectories(sourceDirectory)) {
-            string destinationSubdirectory = Path.Combine(destinationDirectory, Path.GetFileName(directory));
-            CopyDirectory(directory, destinationSubdirectory);
-        }
-    }
+    private static Func<HttpClient> DefaultHttpClientFactory => () => new HttpClient { Timeout = TimeSpan.FromMinutes(15) };
 
     private static void InstallRuntime(HtmlBrowserEngine engine) {
         string runtime = engine.ToString().ToLowerInvariant();

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowser.cs
@@ -18,7 +18,7 @@ public static partial class HtmlBrowser {
         CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         if (options.Clean) {
-            CleanInstallDir();
+            await CleanInstallationAsync().ConfigureAwait(false);
         }
 
         await EnsureBrowserRuntimeAvailableAsync(options).ConfigureAwait(false);
@@ -69,7 +69,7 @@ public static partial class HtmlBrowser {
         CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         if (options.Clean) {
-            CleanInstallDir();
+            await CleanInstallationAsync().ConfigureAwait(false);
         }
 
         await EnsureBrowserRuntimeAvailableAsync(options).ConfigureAwait(false);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserCacheCleaner.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserCacheCleaner.cs
@@ -155,7 +155,8 @@ public static class HtmlBrowserCacheCleaner {
     /// <returns>Result of the cleaning operation.</returns>
     public static CleanResult CleanCache(IEnumerable<CacheLocation> locations) {
         var result = new CleanResult();
-        
+        using FileStream installationLock = HtmlBrowser.AcquireInstallationFileLockAsync().GetAwaiter().GetResult();
+
         foreach (var location in locations) {
             try {
                 Directory.Delete(location.Path, recursive: true);


### PR DESCRIPTION
## Summary

- automatically provision the exact Playwright driver required by the loaded `Microsoft.Playwright` assembly when a packaged host does not contain the SDK-generated `.playwright` directory
- extract only the current platform's Node.js driver plus Playwright's package/CLI assets, with size, archive-path, layout, and version validation
- serialize installation, repair, `-Clean`, and cache-clearing operations across processes so concurrent PowerShell sessions cannot corrupt the shared driver or browser cache

## Why it failed

The PSParseHTML package contains `Microsoft.Playwright.dll`, but intentionally does not ship the large SDK-copied `.playwright` payload. HtmlTinkerX therefore entered its fallback path, which downloaded a version-specific driver ZIP from a retired Azure Edge URL that now returns 404. `PLAYWRIGHT_BROWSERS_PATH` only changes the browser cache location; it cannot provide the missing Playwright driver needed to run the browser installer.

The fallback now downloads the matching official `Microsoft.Playwright` NuGet package and provisions everything automatically. Users do not need to run `npx`, locate `playwright.ps1`, or install a separate CLI.

## Validation

- full test matrix passed on .NET Framework 4.7.2, .NET 8, and .NET 10
- repository packaging produced HtmlTinkerX 2.2.2 and PSParseHTML 2.2.2.1
- the installed packaged module populated a brand-new empty driver cache, launched Chromium, and loaded a live page without any manual setup

Fixes #417