### PR TITLE
Upgrade AngleSharp and other NuGet dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directories:
+      - "/Sources/HtmlTinkerX"
+      - "/Sources/HtmlTinkerX.Tests"
+      - "/Sources/PSParseHTML.PowerShell"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Warsaw"
+    open-pull-requests-limit: 10

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -2,16 +2,41 @@
 
 ## AngleSharp package stability
 
-HtmlTinkerX uses the stable AngleSharp core package. Its CSSOM and DOM JavaScript
-integration currently use the upstream `AngleSharp.Css` and `AngleSharp.Js` 1.0
-prerelease lines. Both upstream packages declare compatibility with AngleSharp
-1.x; `AngleSharp.Js` also declares compatibility with Jint 4.x.
+HtmlTinkerX uses stable releases of AngleSharp, AngleSharp.Css, AngleSharp.Js,
+and AngleSharp.Diffing. AngleSharp.Js requires Jint 4.x; keep the direct Jint
+reference at or above the minimum declared by AngleSharp.Js so NuGet cannot
+resolve an older runtime beneath the DOM integration.
 
-Upstream dependency labels do not determine the HtmlTinkerX or PSParseHTML
-release channel. Publish normal stable releases after the full target-framework
-tests and package-only .NET and PowerShell smoke tests pass. Treat any NU5104
-warning as a known dependency-metadata warning, not as a reason to mark our
-packages prerelease.
+Validate AngleSharp updates across `net472`, `net8.0`, and `net10.0`, including
+package-only .NET and PowerShell smoke tests. The stable CSS and JavaScript
+packages no longer produce prerelease dependency warnings.
+
+AngleSharp.Js 1.0 moved `XMLHttpRequest` to AngleSharp.Io. Earlier prerelease
+builds exposed that constructor through `HtmlScriptRunner`, although the runner
+did not register a loader capable of sending the request. The stable runner
+intentionally keeps network-capable APIs such as `XMLHttpRequest`, `fetch`, and
+`WebSocket` unavailable. Use the existing controlled HTTP workflows or
+Playwright when a task needs network or browser behavior.
+
+### Optional AngleSharp packages
+
+Do not add companion packages only to broaden the dependency graph:
+
+- `AngleSharp.Io` can add requesters, cookies, storage, `fetch`, and related web
+  platform services. Add it only with an explicit browserless-network contract,
+  including opt-in network access, URI policy, caller-provided HTTP configuration,
+  cancellation, size limits, and deterministic tests. Enabling it implicitly in
+  `HtmlScriptRunner` would also expose network-capable constructors such as
+  `WebSocket` to previously local DOM scripts.
+- `AngleSharp.XPath` overlaps with the established HtmlAgilityPack XPath cmdlets.
+  Add it only as part of an intentional AngleSharp-native XPath surface rather
+  than maintaining two interchangeable implementations.
+- `AngleSharp.Xml` overlaps with the hardened `System.Xml` paths used for feeds,
+  discovery documents, and SAML. Keep security-sensitive XML parsing on those
+  explicit readers unless a browser-style XML DOM becomes a real requirement.
+- `AngleSharp.Renderer` and `AngleSharp.Wasm` serve specialized rendering and
+  WebAssembly scenarios. They are not replacements for browser layout, painting,
+  authentication, downloads, or interaction automation.
 
 ## Screenshot image processing
 

--- a/Docs/Dependencies.md
+++ b/Docs/Dependencies.md
@@ -2,32 +2,48 @@
 
 ## AngleSharp package stability
 
-HtmlTinkerX uses stable releases of AngleSharp, AngleSharp.Css, AngleSharp.Js,
-and AngleSharp.Diffing. AngleSharp.Js requires Jint 4.x; keep the direct Jint
-reference at or above the minimum declared by AngleSharp.Js so NuGet cannot
-resolve an older runtime beneath the DOM integration.
+HtmlTinkerX uses stable releases of AngleSharp, AngleSharp.Css, AngleSharp.Io,
+AngleSharp.Js, and AngleSharp.Diffing. AngleSharp.Js requires Jint 4.x; keep the
+direct Jint reference at or above the minimum declared by AngleSharp.Js so NuGet
+cannot resolve an older runtime beneath the DOM integration.
 
 Validate AngleSharp updates across `net472`, `net8.0`, and `net10.0`, including
 package-only .NET and PowerShell smoke tests. The stable CSS and JavaScript
 packages no longer produce prerelease dependency warnings.
 
-AngleSharp.Js 1.0 moved `XMLHttpRequest` to AngleSharp.Io. Earlier prerelease
-builds exposed that constructor through `HtmlScriptRunner`, although the runner
-did not register a loader capable of sending the request. The stable runner
-intentionally keeps network-capable APIs such as `XMLHttpRequest`, `fetch`, and
-`WebSocket` unavailable. Use the existing controlled HTTP workflows or
-Playwright when a task needs network or browser behavior.
+AngleSharp.Js 1.0 moved `XMLHttpRequest` to AngleSharp.Io. HtmlTinkerX includes
+the stable I/O package so callers do not need to add a second package before
+using that integration. The default `HtmlScriptRunner.RunAsync` overload still
+registers only AngleSharp.Js, keeping network-capable APIs such as
+`XMLHttpRequest`, `fetch`, and `WebSocket` unavailable.
+
+Use the browsing-context overload when a script should deliberately receive I/O
+services. Its configuration is the security boundary: registering AngleSharp.Io
+requesters and a document loader exposes network-capable browser APIs to the
+script. Register requesters individually: `WithRequesters` enables HTTP, FTP,
+file, data, and about protocols together, so it is inappropriate when an HTTP
+URI policy is the intended boundary. Prefer a caller-owned HTTP client wrapped
+in one `HttpClientRequester`, with the required URI policy, authentication,
+proxy, timeouts, and response limits. The caller also owns the context and its
+document lifetime.
+
+```csharp
+var configuration = Configuration.Default
+    .With(new HttpClientRequester(httpClient))
+    .WithDefaultLoader()
+    .WithJs();
+using var context = BrowsingContext.New(configuration);
+
+var result = await HtmlScriptRunner.RunAsync<string>(html, script, context);
+```
+
+This is a browserless HTTP/DOM workflow. Use Playwright when a task depends on
+layout, painting, browser authentication, downloads, or interaction automation.
 
 ### Optional AngleSharp packages
 
 Do not add companion packages only to broaden the dependency graph:
 
-- `AngleSharp.Io` can add requesters, cookies, storage, `fetch`, and related web
-  platform services. Add it only with an explicit browserless-network contract,
-  including opt-in network access, URI policy, caller-provided HTTP configuration,
-  cancellation, size limits, and deterministic tests. Enabling it implicitly in
-  `HtmlScriptRunner` would also expose network-capable constructors such as
-  `WebSocket` to previously local DOM scripts.
 - `AngleSharp.XPath` overlaps with the established HtmlAgilityPack XPath cmdlets.
   Add it only as part of an intentional AngleSharp-native XPath surface rather
   than maintaining two interchangeable implementations.

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -1,6 +1,7 @@
 using HtmlTinkerX;
 using Microsoft.Playwright;
 using Moq;
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -62,6 +63,28 @@ public class HtmlBrowserSessionDisposeTests {
         playwright.Verify(p => p.Dispose(), Times.Once);
         browser.Verify(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>()), Times.Once);
         context.Verify(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RetriesCleanupAfterFailure() {
+        var playwright = new Mock<IPlaywright>();
+        playwright.Setup(p => p.Dispose()).Verifiable();
+        var browser = new Mock<IBrowser>();
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var context = new Mock<IBrowserContext>();
+        context.SetupSequence(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>()))
+            .ThrowsAsync(new InvalidOperationException("cleanup failed"))
+            .Returns(Task.CompletedTask);
+        var page = new Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => session.DisposeAsync().AsTask());
+        await session.DisposeAsync();
+
+        playwright.Verify(p => p.Dispose(), Times.Once);
+        browser.Verify(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>()), Times.Once);
+        context.Verify(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>()), Times.Exactly(2));
     }
 
     [Fact]

--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserSessionDisposeTests.cs
@@ -35,6 +35,36 @@ public class HtmlBrowserSessionDisposeTests {
     }
 
     [Fact]
+    public async Task DisposeAsync_ReusesCleanupAcrossRepeatedAndConcurrentCalls() {
+        var playwright = new Mock<IPlaywright>();
+        playwright.Setup(p => p.Dispose()).Verifiable();
+        var browser = new Mock<IBrowser>();
+        browser.Setup(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>())).Returns(Task.CompletedTask).Verifiable();
+        var contextCloseStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowContextClose = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new Mock<IBrowserContext>();
+        context.Setup(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>())).Returns(async () => {
+            contextCloseStarted.SetResult(true);
+            await allowContextClose.Task;
+        }).Verifiable();
+        var page = new Mock<IPage>();
+
+        HtmlBrowserSession session = new(playwright.Object, browser.Object, context.Object, page.Object);
+
+        Task firstDispose = session.DisposeAsync().AsTask();
+        await contextCloseStarted.Task;
+        Task concurrentDispose = session.DisposeAsync().AsTask();
+        Assert.Same(firstDispose, concurrentDispose);
+        allowContextClose.SetResult(true);
+        await Task.WhenAll(firstDispose, concurrentDispose);
+        await session.DisposeAsync();
+
+        playwright.Verify(p => p.Dispose(), Times.Once);
+        browser.Verify(b => b.CloseAsync(It.IsAny<BrowserCloseOptions?>()), Times.Once);
+        context.Verify(c => c.CloseAsync(It.IsAny<BrowserContextCloseOptions?>()), Times.Once);
+    }
+
+    [Fact]
     public async Task DisposeAsync_SavesAndCleansVideo() {
         string outFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString(), "video.webm");
         string tempVideo = System.IO.Path.GetTempFileName();

--- a/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlOptimizerTests.cs
@@ -66,7 +66,7 @@ public class HtmlOptimizerTests {
     }
 
     [Fact]
-    public void OptimizeHtml_ShortBooleanAttributesWhenRequested() {
+    public void OptimizeHtml_ShortensOnlyBooleanAttributesWhenRequested() {
         const string hxInput = "<a hx-boost=true></a>";
         string defaultResult = HtmlOptimizer.OptimizeHtml(hxInput, cssDecodeEscapes: false);
         string hxShortened = HtmlOptimizer.OptimizeHtml(
@@ -81,7 +81,7 @@ public class HtmlOptimizerTests {
             shortBooleanAttributes: true);
 
         Assert.Equal("<a hx-boost=true></a>", defaultResult);
-        Assert.Equal("<a hx-boost></a>", hxShortened);
+        Assert.Equal("<a hx-boost=true></a>", hxShortened);
         Assert.Equal("<input type=checkbox checked />", booleanShortened);
     }
 

--- a/Sources/HtmlTinkerX.Tests/HtmlScriptRunnerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlScriptRunnerTests.cs
@@ -1,5 +1,13 @@
+using AngleSharp;
+using AngleSharp.Io;
+using AngleSharp.Io.Network;
+using AngleSharp.Js;
 using HtmlTinkerX;
 using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -22,6 +30,25 @@ public class HtmlScriptRunnerTests {
     }
 
     [Fact]
+    public async Task RunAsync_WithExplicitIoConfiguration_InvokesConfiguredXmlHttpRequestTransport() {
+        using var handler = new StubHttpMessageHandler();
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+        var configuration = Configuration.Default
+            .With(new HttpClientRequester(httpClient))
+            .WithDefaultLoader()
+            .WithJs();
+        using var context = BrowsingContext.New(configuration);
+        const string script = "var request = new XMLHttpRequest(); request.open('GET', 'https://example.test/data', false); request.send(); typeof XMLHttpRequest;";
+
+        IRequester[] requesters = configuration.Services.OfType<IRequester>().ToArray();
+        string? result = await HtmlScriptRunner.RunAsync<string>("<html></html>", script, context);
+
+        Assert.Collection(requesters, requester => Assert.IsType<HttpClientRequester>(requester));
+        Assert.Equal(new Uri("https://example.test/data"), handler.LastRequestUri);
+        Assert.Equal("function", result);
+    }
+
+    [Fact]
     public async Task RunAsync_NullHtml_Throws() {
         await Assert.ThrowsAsync<ArgumentNullException>(() => HtmlScriptRunner.RunAsync<int>(null!, "1"));
     }
@@ -29,5 +56,25 @@ public class HtmlScriptRunnerTests {
     [Fact]
     public async Task RunAsync_NullScript_Throws() {
         await Assert.ThrowsAsync<ArgumentNullException>(() => HtmlScriptRunner.RunAsync<int>("<html></html>", null!));
+    }
+
+    [Fact]
+    public async Task RunAsync_ContextWithoutJavaScript_Throws() {
+        using var context = BrowsingContext.New(Configuration.Default);
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            HtmlScriptRunner.RunAsync<int>("<html></html>", "1", context));
+
+        Assert.Equal("context", exception.ParamName);
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            LastRequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("configured response")
+            });
+        }
     }
 }

--- a/Sources/HtmlTinkerX.Tests/HtmlScriptRunnerTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlScriptRunnerTests.cs
@@ -15,6 +15,13 @@ public class HtmlScriptRunnerTests {
     }
 
     [Fact]
+    public async Task RunAsync_PreservesNavigatorWithoutExposingNetworkCapableBrowserApis() {
+        const string script = "[typeof navigator, typeof XMLHttpRequest, typeof fetch, typeof WebSocket].join('|')";
+        string? result = await HtmlScriptRunner.RunAsync<string>("<html></html>", script);
+        Assert.Equal("object|undefined|undefined|undefined", result);
+    }
+
+    [Fact]
     public async Task RunAsync_NullHtml_Throws() {
         await Assert.ThrowsAsync<ArgumentNullException>(() => HtmlScriptRunner.RunAsync<int>(null!, "1"));
     }

--- a/Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj
+++ b/Sources/HtmlTinkerX.Tests/HtmlTinkerX.Tests.csproj
@@ -9,19 +9,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="10.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" Condition=" '$(TargetFramework)' != 'net472' " />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.3.9" Condition=" '$(TargetFramework)' == 'net472' " />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.9" Condition=" '$(TargetFramework)' == 'net472' " />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" Condition=" '$(TargetFramework)' == 'net8.0' " />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" Condition=" '$(TargetFramework)' == 'net10.0' " />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.3.11" Condition=" '$(TargetFramework)' == 'net472' " />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.11" Condition=" '$(TargetFramework)' == 'net472' " />
         <PackageReference Include="Moq" Version="4.20.72" />
     </ItemGroup>
 
@@ -31,7 +32,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Management.Automation" Version="7.4.15" Condition=" '$(TargetFramework)' != 'net472' " />
+        <PackageReference Include="System.Management.Automation" Version="7.4.15" Condition=" '$(TargetFramework)' == 'net8.0' " />
+        <PackageReference Include="System.Management.Automation" Version="7.6.4" Condition=" '$(TargetFramework)' == 'net10.0' " />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/HtmlTinkerX/HtmlScriptRunner.cs
+++ b/Sources/HtmlTinkerX/HtmlScriptRunner.cs
@@ -9,6 +9,10 @@ namespace HtmlTinkerX;
 /// <summary>
 /// Provides helpers for executing JavaScript against HTML using AngleSharp.Js.
 /// </summary>
+/// <remarks>
+/// The runner operates on the supplied markup only. It does not register document loaders,
+/// requesters, WebSockets, or other network-capable browser services.
+/// </remarks>
 public static class HtmlScriptRunner {
     /// <summary>
     /// Loads the provided HTML markup and executes JavaScript in its context.

--- a/Sources/HtmlTinkerX/HtmlScriptRunner.cs
+++ b/Sources/HtmlTinkerX/HtmlScriptRunner.cs
@@ -1,6 +1,7 @@
 using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Js;
+using AngleSharp.Scripting;
 using System;
 using System.Threading.Tasks;
 
@@ -10,8 +11,9 @@ namespace HtmlTinkerX;
 /// Provides helpers for executing JavaScript against HTML using AngleSharp.Js.
 /// </summary>
 /// <remarks>
-/// The runner operates on the supplied markup only. It does not register document loaders,
-/// requesters, WebSockets, or other network-capable browser services.
+/// The default overload operates on the supplied markup only. It does not register document
+/// loaders, requesters, WebSockets, or other network-capable browser services. Callers can use
+/// the browsing-context overload to opt into those capabilities explicitly.
 /// </remarks>
 public static class HtmlScriptRunner {
     /// <summary>
@@ -27,16 +29,37 @@ public static class HtmlScriptRunner {
     ///     "document.getElementById('a').textContent = '1'; return 1;");
     /// </code>
     /// </example>
-    public static async Task<T?> RunAsync<T>(string html, string script) {
+    public static Task<T?> RunAsync<T>(string html, string script) {
+        return RunAsync<T>(html, script, BrowsingContext.New(Configuration.Default.WithJs()));
+    }
+
+    /// <summary>
+    /// Loads the provided HTML markup and executes JavaScript using a caller-owned
+    /// AngleSharp browsing context.
+    /// </summary>
+    /// <typeparam name="T">Expected return type.</typeparam>
+    /// <param name="html">HTML markup to load.</param>
+    /// <param name="script">JavaScript code to execute.</param>
+    /// <param name="context">
+    /// Browsing context that controls available services and document lifetime. Its
+    /// configuration must include AngleSharp.Js. Registering loaders or AngleSharp.Io
+    /// requesters can allow scripts to perform I/O.
+    /// </param>
+    /// <returns>Value returned by the script.</returns>
+    public static async Task<T?> RunAsync<T>(string html, string script, IBrowsingContext context) {
         if (html == null) {
             throw new ArgumentNullException(nameof(html));
         }
         if (script == null) {
             throw new ArgumentNullException(nameof(script));
         }
+        if (context == null) {
+            throw new ArgumentNullException(nameof(context));
+        }
+        if (context.GetService<JsScriptingService>() == null) {
+            throw new ArgumentException("The browsing context must register AngleSharp.Js by calling WithJs() on its configuration.", nameof(context));
+        }
 
-        var config = Configuration.Default.WithJs();
-        var context = BrowsingContext.New(config);
         var document = await context
             .OpenAsync(req => req.Content(html))
             .WaitUntilAvailable()

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -26,6 +26,7 @@
         <PackageReference Include="AngleSharp" Version="1.7.1" />
         <PackageReference Include="AngleSharp.Css" Version="1.0.1" />
         <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
+        <PackageReference Include="AngleSharp.Io" Version="1.1.0" />
         <PackageReference Include="AngleSharp.Js" Version="1.0.1" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
         <PackageReference Include="Jint" Version="4.15.3" />

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -23,12 +23,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.5.2" />
-        <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.216" />
+        <PackageReference Include="AngleSharp" Version="1.7.1" />
+        <PackageReference Include="AngleSharp.Css" Version="1.0.1" />
         <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
-        <PackageReference Include="AngleSharp.Js" Version="1.0.0-beta.49" />
+        <PackageReference Include="AngleSharp.Js" Version="1.0.1" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-        <PackageReference Include="Jint" Version="4.8.0" />
+        <PackageReference Include="Jint" Version="4.15.3" />
         <PackageReference Include="NUglify" Version="1.21.17" />
         <PackageReference Include="PreMailer.Net" Version="2.7.2" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" Condition=" '$(TargetFramework)' == 'net472' " />

--- a/Sources/HtmlTinkerX/HtmlTinkerX.csproj
+++ b/Sources/HtmlTinkerX/HtmlTinkerX.csproj
@@ -18,8 +18,8 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OfficeImoVersion>3.0.2</OfficeImoVersion>
-        <ChartForgeXVersion>0.1.6</ChartForgeXVersion>
+        <OfficeImoVersion>3.2.0</OfficeImoVersion>
+        <ChartForgeXVersion>1.4.0</ChartForgeXVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -30,11 +30,11 @@
         <PackageReference Include="AngleSharp.Js" Version="1.0.1" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
         <PackageReference Include="Jint" Version="4.15.3" />
-        <PackageReference Include="NUglify" Version="1.21.17" />
-        <PackageReference Include="PreMailer.Net" Version="2.7.2" />
+        <PackageReference Include="NUglify" Version="1.22.3" />
+        <PackageReference Include="PreMailer.Net" Version="2.7.3" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" Condition=" '$(TargetFramework)' == 'net472' " />
         <PackageReference Include="System.Net.Http" Version="4.3.4" Condition=" '$(TargetFramework)' == 'net472' " />
-        <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
+        <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(ChartForgeXProjectPath)' != '' ">
@@ -49,7 +49,7 @@
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="System.Threading.Channels" Version="10.0.7" />
+        <PackageReference Include="System.Threading.Channels" Version="10.0.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -71,8 +71,11 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     private readonly ConcurrentDictionary<IRequest, IResponse> _responses = new();
     private ConcurrentQueue<IRequest>? _order;
     private object? _networkSync;
+    private Task? _disposeTask;
+    private object? _disposeSync;
     private ConcurrentQueue<IRequest> RequestOrder => LazyInitializer.EnsureInitialized(ref _order, () => new ConcurrentQueue<IRequest>())!;
     private object NetworkSync => LazyInitializer.EnsureInitialized(ref _networkSync, () => new object())!;
+    private object DisposeSync => LazyInitializer.EnsureInitialized(ref _disposeSync, () => new object())!;
     private readonly ConcurrentQueue<HtmlConsoleEntry> _console = new();
     private int? _networkLogLimit;
     /// <summary>
@@ -320,7 +323,13 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// <summary>
     /// Asynchronously disposes of the browser session, closing the page, context, and browser.
     /// </summary>
-    public async ValueTask DisposeAsync() {
+    public ValueTask DisposeAsync() {
+        lock (DisposeSync) {
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private async Task DisposeCoreAsync() {
         if (_closePageOnDispose && Page != null && !Page.IsClosed) {
             try {
                 await Page.CloseAsync().ConfigureAwait(false);

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserSession.cs
@@ -325,7 +325,10 @@ public sealed class HtmlBrowserSession : IAsyncDisposable {
     /// </summary>
     public ValueTask DisposeAsync() {
         lock (DisposeSync) {
-            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+            if (_disposeTask == null || _disposeTask.IsFaulted || _disposeTask.IsCanceled) {
+                _disposeTask = DisposeCoreAsync();
+            }
+            return new ValueTask(_disposeTask);
         }
     }
 

--- a/Sources/PSParseHTML.PowerShell/Communication/HttpClientHelper.cs
+++ b/Sources/PSParseHTML.PowerShell/Communication/HttpClientHelper.cs
@@ -17,7 +17,7 @@ internal static class HttpClientHelper {
     /// <param name="credential">Credentials for the proxy.</param>
     /// <returns>A configured <see cref="HttpClient"/> instance.</returns>
     internal static HttpClient Create(string? proxy, PSCredential? credential) {
-        ICredentials? creds = credential?.GetNetworkCredential();
+        System.Net.ICredentials? creds = credential?.GetNetworkCredential();
         return HtmlHttpClientFactory.Create(proxy, creds);
     }
 

--- a/Tests/Convert-HTMLToText.Tests.ps1
+++ b/Tests/Convert-HTMLToText.Tests.ps1
@@ -56,6 +56,6 @@
         $cmd.CommandType | Should -Be 'Cmdlet'
 
         $Output = Convert-HTMLToText -Content $HTMLContentFormatted
-        $Output.Trim() | Should -Be 'Name Id HandleCount WorkingSet   1Password 22268 1007 87146496  aesm_service 25340 189 3948544'
+        $Output.Trim() | Should -Be 'Name Id HandleCount WorkingSet 1Password 22268 1007 87146496 aesm_service 25340 189 3948544'
     }
 }

--- a/Tests/Optimize-HTML.Tests.ps1
+++ b/Tests/Optimize-HTML.Tests.ps1
@@ -110,7 +110,7 @@
         $content = '<a hx-boost=true><!--c--></a>'
         $result = Optimize-HTML -Content $content -HtmlSettings $settings
 
-        $result | Should -Be '<a hx-boost></a>'
+        $result | Should -Be '<a hx-boost=true></a>'
     }
 
     It 'Removes optional tags when requested' {


### PR DESCRIPTION
## Summary

- upgrade AngleSharp to 1.7.1 and move the CSS and JavaScript integrations to stable 1.0.1 releases
- add AngleSharp.Io 1.1.0 for explicitly configured browserless HTTP and align Jint with AngleSharp.Js
- update the remaining outdated product packages: ChartForgeX 1.4.0, OfficeIMO 3.2.0, Microsoft.Playwright 1.61.0, NUglify 1.22.3, PreMailer.Net 2.7.3, and System.Threading.Channels 10.0.10
- update test and coverage tooling while keeping ASP.NET Core and PowerShell test dependencies aligned with each target framework
- enable weekly Dependabot NuGet version updates for all three project directories

## Browserless I/O

AngleSharp.Js 1.0 moved `XMLHttpRequest` to AngleSharp.Io. The default `HtmlScriptRunner.RunAsync` overload remains local and network-isolated: `XMLHttpRequest`, `fetch`, and `WebSocket` are unavailable.

Callers that need browserless HTTP can supply a caller-owned browsing context configured with one policy-controlled `HttpClientRequester`, a document loader, and AngleSharp.Js. The documentation warns against `WithRequesters`, which would also enable FTP, file, data, and about requesters.

This supports HTTP/DOM scripting without presenting AngleSharp as a replacement for Playwright layout, rendering, authentication, downloads, or interaction automation.

## Compatibility notes

NUglify 1.22.3 now preserves value-bearing custom attributes such as `hx-boost=true` when boolean shortening is enabled, while still shortening real HTML boolean attributes such as `checked`.

Playwright 1.61 adds its own `ICredentials` type, so the PowerShell HTTP adapter now explicitly uses `System.Net.ICredentials`. It also exposed repeated session cleanup that could close an already-disposed Playwright connection; `HtmlBrowserSession.DisposeAsync` now shares one asynchronous cleanup operation across repeated and concurrent callers, caches successful cleanup, and permits retry after a failed attempt.

## Dependency automation

The repository had no `.github/dependabot.yml`, so Dependabot security updates could still be enabled in repository settings, but scheduled NuGet version updates were never configured. The new configuration scans `HtmlTinkerX`, its tests, and the PowerShell project every Monday.

## Validation

- full .NET 8 and .NET 10 suites pass with 879 tests per target
- the complete PowerShell suite passes with 562 tests and 3 environment-dependent skips
- the complete solution builds for .NET Framework 4.7.2, .NET 8, and .NET 10 with no warnings
- NuGet and PowerShell package builds complete, and the packed NuGet dependency groups contain the upgraded versions for every target
- direct and transitive NuGet vulnerability audits report no known advisories
- independent read-only review covered the dependency boundary and disposal concurrency; a targeted closure pass found no actionable issue in the retry-after-failure remediation

The .NET Framework test assembly was not executed locally because Mono is unavailable. GitHub Windows CI remains the authoritative runtime lane for that target.
