### PR TITLE
Expose browser PDF streams and tagged capture intent

### DIFF
--- a/Sources/HtmlTinkerX.Tests/HtmlBrowserPdfResultTests.cs
+++ b/Sources/HtmlTinkerX.Tests/HtmlBrowserPdfResultTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace HtmlTinkerX.Tests;
+
+public sealed class HtmlBrowserPdfResultTests {
+    [Fact]
+    public void OpenReadReturnsIndependentReadOnlyStreamsWithoutExposingTheBuffer() {
+        byte[] payload = { 1, 2, 3, 4 };
+        HtmlBrowserPdfResult result = new(payload, CreateDiagnostics(), tagged: false);
+
+        using Stream first = result.OpenRead();
+        using Stream second = result.OpenRead();
+
+        Assert.True(first.CanRead);
+        Assert.False(first.CanWrite);
+        Assert.Equal(1, first.ReadByte());
+        Assert.Equal(0, second.Position);
+        Assert.Equal(1, second.ReadByte());
+        Assert.Equal(payload.Length, result.Length);
+        Assert.Throws<NotSupportedException>(() => first.WriteByte(5));
+        Assert.Throws<UnauthorizedAccessException>(() => ((MemoryStream)first).GetBuffer());
+    }
+
+    [Fact]
+    public void PdfBytesRemainsADefensiveCopyAlongsideOpenRead() {
+        byte[] payload = { 1, 2, 3 };
+        HtmlBrowserPdfResult result = new(payload, CreateDiagnostics(), tagged: true);
+
+        byte[] copy = result.PdfBytes;
+        copy[0] = 9;
+
+        using Stream stream = result.OpenRead();
+        Assert.Equal(1, stream.ReadByte());
+        Assert.True(result.Tagged);
+    }
+
+    private static HtmlBrowserPdfDiagnostics CreateDiagnostics() => new(
+        HtmlBrowserPdfSourceKind.Html,
+        browserInstanceId: 1,
+        browserReused: false,
+        retriedAfterBrowserFailure: false,
+        finalUrl: "about:blank",
+        browserVersion: "test",
+        queueDuration: TimeSpan.Zero,
+        navigationDuration: TimeSpan.Zero,
+        readinessDuration: TimeSpan.Zero,
+        pdfDuration: TimeSpan.Zero,
+        totalDuration: TimeSpan.Zero,
+        blockedRequestCount: 0,
+        blockedRequests: Array.Empty<string>(),
+        warnings: Array.Empty<string>());
+}

--- a/Sources/HtmlTinkerX/Models/HtmlBrowserPdfResult.cs
+++ b/Sources/HtmlTinkerX/Models/HtmlBrowserPdfResult.cs
@@ -1,14 +1,16 @@
 namespace HtmlTinkerX;
 
 using System;
+using System.IO;
 
 /// <summary>Browser-generated PDF bytes and capture diagnostics.</summary>
 public sealed class HtmlBrowserPdfResult {
     private readonly byte[] _pdfBytes;
 
-    internal HtmlBrowserPdfResult(byte[] pdfBytes, HtmlBrowserPdfDiagnostics diagnostics) {
+    internal HtmlBrowserPdfResult(byte[] pdfBytes, HtmlBrowserPdfDiagnostics diagnostics, bool tagged) {
         _pdfBytes = pdfBytes ?? throw new ArgumentNullException(nameof(pdfBytes));
         Diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+        Tagged = tagged;
     }
 
     /// <summary>Gets a defensive copy of the generated PDF bytes.</summary>
@@ -17,7 +19,20 @@ public sealed class HtmlBrowserPdfResult {
     public int Length => _pdfBytes.Length;
     /// <summary>Gets diagnostics for the browser stage.</summary>
     public HtmlBrowserPdfDiagnostics Diagnostics { get; }
+    /// <summary>Gets whether Chromium was requested to generate a tagged PDF.</summary>
+    public bool Tagged { get; }
+
+    /// <summary>
+    /// Opens an independent, read-only stream over the generated PDF payload without cloning it.
+    /// Disposing the returned stream does not affect this result or other streams opened from it.
+    /// </summary>
+    public Stream OpenRead() => new MemoryStream(
+        _pdfBytes,
+        0,
+        _pdfBytes.Length,
+        writable: false,
+        publiclyVisible: false);
 
     internal HtmlBrowserPdfResult WithTotalDuration(TimeSpan totalDuration) =>
-        new(_pdfBytes, Diagnostics.WithTotalDuration(totalDuration));
+        new(_pdfBytes, Diagnostics.WithTotalDuration(totalDuration), Tagged);
 }

--- a/Sources/HtmlTinkerX/Playwright/HtmlBrowserPdfRenderer.Capture.cs
+++ b/Sources/HtmlTinkerX/Playwright/HtmlBrowserPdfRenderer.Capture.cs
@@ -340,7 +340,7 @@ public sealed partial class HtmlBrowserPdfRenderer {
                 Volatile.Read(ref blockedRequestCount),
                 blockedRequests.ToArray(),
                 warnings.ToArray());
-            return new HtmlBrowserPdfResult(bytes, diagnostics);
+            return new HtmlBrowserPdfResult(bytes, diagnostics, request.PdfOptions.Tagged);
         } finally {
             if (popupCoordinator != null) await popupCoordinator.DisposeAsync().ConfigureAwait(false);
             if (scopedHeaders != null) await scopedHeaders.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- expose an independent read-only stream over browser-generated PDF bytes without forcing another defensive copy
- preserve whether Chromium was asked to generate tagged output on HtmlBrowserPdfResult
- keep the existing defensive PdfBytes API unchanged

This gives document libraries a small, reusable handoff from HtmlTinkerX-owned browser capture into their own PDF model while leaving navigation, security policy, readiness, and capture lifecycle in HtmlTinkerX.

## Validation

- Release solution build
- focused result-contract tests on .NET Framework 4.7.2, .NET 8, and .NET 10
- full test suites on .NET 8 and .NET 10
- .NET Framework suite with one existing browser interception timing failure that passed on an immediate focused rerun